### PR TITLE
increase partition count from 64 to 256

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 
 MQDB is a message-oriented reactive database built in Rust that combines:
 - **Native MQTT integration** with embedded broker and topic-based API
-- **Distributed clustering** with 64-partition sharding, Raft consensus, and automatic rebalancing
+- **Distributed clustering** with 256-partition sharding, Raft consensus, and automatic rebalancing
 - **Point-to-point delivery** with consumer groups and partition-based routing
 - **Reactive subscriptions** with MQTT-style pub/sub patterns
 - **Schema-less JSON** entities with optional schema validation
@@ -1179,7 +1179,7 @@ MQDB supports two deployment modes:
 Both modes share the same database API, but cluster mode adds:
 - Raft consensus for partition management
 - MQTT bridges or direct QUIC for inter-node transport
-- 64 fixed partitions with replication factor 2
+- 256 fixed partitions with replication factor 2
 - Automatic rebalancing and failover
 
 ### 9.2 Storage Layer in Cluster Mode
@@ -1202,9 +1202,9 @@ In cluster mode, the `StorageBackend` trait is used by multiple subsystems:
 Cluster mode introduces two classes of entities:
 
 **Partitioned Entities** (hash-based distribution):
-- Sessions: `hash(client_id) % 64`
-- Database records: `hash(entity/id) % 64`
-- Retained messages: `hash(topic) % 64`
+- Sessions: `hash(client_id) % 256`
+- Database records: `hash(entity/id) % 256`
+- Retained messages: `hash(topic) % 256`
 
 **Broadcast Entities** (replicated to all nodes):
 - `_topic_index`: Topic → subscriber mappings
@@ -1766,7 +1766,7 @@ This layered approach ensures that even if an ACL grants broad access like `user
 ### Key Strengths:
 
 1. **Native MQTT Integration:** Embedded broker with topic-based database API
-2. **Distributed Clustering:** 64-partition sharding with Raft consensus and automatic rebalancing
+2. **Distributed Clustering:** 256-partition sharding with Raft consensus and automatic rebalancing
 3. **Point-to-Point Delivery:** Consumer groups with LoadBalanced and Ordered modes
 4. **ACID Transactions:** Full transactional guarantees with outbox pattern
 5. **Reactive Subscriptions:** MQTT-style patterns for real-time change notifications

--- a/CLI_TESTING_GUIDE.md
+++ b/CLI_TESTING_GUIDE.md
@@ -847,7 +847,7 @@ Raft leader initializing partition assignments
 
 The node should:
 - Become Raft leader immediately (single-node quorum)
-- Assign all 64 partitions to itself
+- Assign all 256 partitions to itself
 
 ### Starting a Multi-Node Cluster
 
@@ -944,7 +944,7 @@ mqdb cluster status --broker 127.0.0.1:1883
     {"id": 2, "name": "node-2", "status": "alive"},
     {"id": 3, "name": "node-3", "status": "alive"}
   ],
-  "partitions": 64
+  "partitions": 256
 }
 ```
 
@@ -1179,7 +1179,7 @@ Verify that JSON creates on non-local partitions are forwarded to the correct pr
 mqdb dev start-cluster --nodes 3 --clean
 sleep 5
 
-# Create entities on each node (with 64 partitions across 3 nodes,
+# Create entities on each node (with 256 partitions across 3 nodes,
 # ~2/3 of creates will hit non-local partitions and require forwarding)
 mqdb create testfw -d '{"name":"from-node1"}' --broker 127.0.0.1:1883
 mqdb create testfw -d '{"name":"from-node2"}' --broker 127.0.0.1:1884
@@ -1429,7 +1429,7 @@ mosquitto_pub -h 127.0.0.1 -p 1883 -t '$DB/_health' -m ''
     "node_name": "node-1",
     "raft_leader": 1,
     "alive_nodes": [1, 2, 3],
-    "partition_count": 64,
+    "partition_count": 256,
     "primary_partitions": 22,
     "replica_partitions": 21
   }
@@ -1950,7 +1950,7 @@ Run through this checklist to verify MQDB works completely:
 - [ ] Single-node cluster start
 - [ ] Multi-node cluster formation
 - [ ] Raft leader election
-- [ ] Partition assignment (64 partitions distributed)
+- [ ] Partition assignment (256 partitions distributed)
 - [ ] Cross-node data routing
 - [ ] Cluster status command
 - [ ] Cluster CRUD (create, read, update, delete, list)

--- a/DISTRIBUTED_DESIGN.md
+++ b/DISTRIBUTED_DESIGN.md
@@ -12,7 +12,7 @@ MQDB is a distributed MQTT broker with embedded database capabilities. The clust
 - **BeBytes crate** for all protocol encoding/decoding (custom, modifiable as needed)
 - **QUIC preferred** for inter-node transport (UDP port mirrors TCP port 1883)
 - **Direct QUIC transport**: Default transport that bypasses MQTT broker for cluster traffic (MQTT bridges deprecated)
-- **64 fixed partitions** (never changes)
+- **256 fixed partitions** (never changes)
 - **Replication Factor = 2** (primary + one replica)
 
 ---
@@ -33,7 +33,7 @@ Every mutation in MQDB—whether from an MQTT client subscribing or a database i
 
 - **What changed**: Entity type, identifier, serialized data
 - **How it changed**: Insert, Update, or Delete operation
-- **Where it lives**: Partition ID (0-63) for routing
+- **Where it lives**: Partition ID (0-255) for routing
 - **When it changed**: Epoch and sequence for ordering
 
 The entity type string (e.g., `_sessions`, `_db_data`, `_topic_index`) determines which store processes the write on each node.
@@ -41,9 +41,9 @@ The entity type string (e.g., `_sessions`, `_db_data`, `_topic_index`) determine
 ### A1.3 Two Classes of Entities
 
 **Partitioned Entities** follow standard hash-based distribution:
-- Sessions, subscriptions, QoS state → partitioned by `hash(client_id) % 64`
-- Retained messages → partitioned by `hash(topic) % 64`
-- Database records → partitioned by `hash(entity/id) % 64`
+- Sessions, subscriptions, QoS state → partitioned by `hash(client_id) % 256`
+- Retained messages → partitioned by `hash(topic) % 256`
+- Database records → partitioned by `hash(entity/id) % 256`
 
 **Broadcast Entities** must exist completely on every node:
 - TopicIndex (`_topic_index`) → maps topics to subscribers
@@ -55,7 +55,7 @@ The entity type string (e.g., `_sessions`, `_db_data`, `_topic_index`) determine
 Broadcast entities exist because publish routing requires local lookups. When a message arrives on Node A, it must immediately determine which clients (potentially on Node B) subscribe to that topic—without cross-node queries.
 
 There are two distinct mechanisms for handling broadcast entities:
-1.  **Fan-out to all partitions**: Used for `_topic_index`, `_wildcards`, and `_db_schema`. This involves creating 64 `ReplicationWrite`s, one for each partition.
+1.  **Fan-out to all partitions**: Used for `_topic_index`, `_wildcards`, and `_db_schema`. This involves creating 256 `ReplicationWrite`s, one for each partition.
 2.  **Gossip-style broadcast to all nodes**: Used for `_client_loc` and `_db_constraint`. This involves creating a single `ReplicationWrite` (often for Partition 0) and then having the `write_or_forward` logic send it to all other alive nodes.
 
 ---
@@ -113,15 +113,15 @@ A single MQTT subscription demonstrates how broadcast entities create write ampl
 The subscription itself is stored in `_mqtt_subs`, partitioned by client_id:
 ```
 add_subscription_replicated(client_id, topic, qos)
-→ 1 ReplicationWrite to partition hash(client_id) % 64
+→ 1 ReplicationWrite to partition hash(client_id) % 256
 ```
 
 **Step 2: TopicIndex Broadcast** (`event_handler.rs:334-342`)
 
-Every node needs the complete topic→subscriber mapping for publish routing. The TopicIndex is a broadcast entity, so it writes to all 64 partitions:
+Every node needs the complete topic→subscriber mapping for publish routing. The TopicIndex is a broadcast entity, so it writes to all 256 partitions:
 ```
 subscribe_topic_replicated(topic, client_id, partition, qos)
-→ 64 ReplicationWrites, one per partition (store_manager.rs:868-880)
+→ 256 ReplicationWrites, one per partition (store_manager.rs:868-880)
 ```
 
 **Step 3: Wildcard Broadcast** (`event_handler.rs:299-317`, only if pattern contains `+` or `#`)
@@ -129,15 +129,15 @@ subscribe_topic_replicated(topic, client_id, partition, qos)
 Wildcard patterns also need cluster-wide visibility:
 ```
 subscribe_wildcard_replicated() + WildcardBroadcast
-→ 64 ReplicationWrites to _wildcards entity
+→ 256 ReplicationWrites to _wildcards entity
 ```
 
 **Total writes per subscription:**
 
 | Pattern Type | Writes Generated | Breakdown |
 |--------------|------------------|-----------|
-| Exact topic (e.g., `sensor/temp`) | 65 | 1 subscription + 64 topic index |
-| Wildcard topic (e.g., `sensor/+/temp`) | 65 | 1 subscription + 64 wildcards (TopicIndex is NOT updated for wildcards) |
+| Exact topic (e.g., `sensor/temp`) | 257 | 1 subscription + 256 topic index |
+| Wildcard topic (e.g., `sensor/+/temp`) | 257 | 1 subscription + 256 wildcards (TopicIndex is NOT updated for wildcards) |
 
 This amplification is fundamental to the design—without broadcast entities, publish routing would require cross-node queries for every message, destroying throughput.
 
@@ -314,7 +314,7 @@ Single-ID queries can skip scatter-gather:
 
 - Query for specific `entity/id` → hash to single partition
 - Filter with `id=VALUE` → extract value, hash to single partition
-- Otherwise → query all 64 partitions
+- Otherwise → query all 256 partitions
 
 ### A5.3 Pagination via ScatterCursor
 
@@ -329,8 +329,8 @@ Each partition maintains independent pagination state, allowing efficient resump
 
 Retained Message Queries:
 
-- Exact topic: `hash(topic) % 64` → single partition
-- Wildcard pattern (`+`, `#`): query all 64 partitions, filter locally.
+- Exact topic: `hash(topic) % 256` → single partition
+- Wildcard pattern (`+`, `#`): query all 256 partitions, filter locally.
   However, the `on_client_subscribe` event handler currently *does not* initiate retained message queries for wildcard subscriptions. Only non-wildcard subscriptions trigger these queries.
 
 **Key Files**: `query_coordinator.rs:1-470`, `cursor.rs:1-140`, `protocol.rs:661-909` (QueryRequest/Response)
@@ -757,7 +757,7 @@ The cluster agent (`cluster_agent.rs`) handles admin requests via `$SYS/mqdb/clu
 **Status Response** includes:
 - `node_id`, `node_name`, `is_raft_leader`, `raft_term`
 - `alive_nodes` - list of other alive node IDs
-- `partitions` - all 64 partitions with primary, replicas, epoch
+- `partitions` - all 256 partitions with primary, replicas, epoch
 
 **CLI Commands**:
 ```bash
@@ -815,9 +815,9 @@ mqdb cluster rebalance --broker 127.0.0.1:1883
 
 | Type | Definition | Range | File:Line |
 |------|------------|-------|-----------|
-| `NUM_PARTITIONS` | `64` (u16 const) | Fixed, never changes | `partition.rs:3` |
+| `NUM_PARTITIONS` | `256` (u16 const) | Fixed, never changes | `partition.rs:3` |
 | `NodeId` | Newtype(u16) | 1-65535, 0=INVALID | `node.rs:4-72` |
-| `PartitionId` | Newtype(u16) | 0-63 | `partition.rs:5-94` |
+| `PartitionId` | Newtype(u16) | 0-255 | `partition.rs:5-94` |
 | `Epoch` | Newtype(u64) | 0-MAX, saturating add | `epoch.rs:4-95` |
 
 **NodeId** (`src/cluster/node.rs:4-72`):
@@ -839,7 +839,7 @@ impl NodeId {
 
 **PartitionId** (`src/cluster/partition.rs:5-94`):
 ```rust
-pub const NUM_PARTITIONS: u16 = 64;
+pub const NUM_PARTITIONS: u16 = 256;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PartitionId(u16);
@@ -895,9 +895,9 @@ All cluster-managed data types (`src/cluster/entity.rs`):
 
 ### 1.4 Partitioning Scheme
 
-- **64 fixed partitions** (0-63) - count NEVER changes
+- **256 fixed partitions** (0-255) - count NEVER changes
 - **Replication Factor (RF) = 2** - primary + 1 replica
-- Partition ID = `crc32fast::hash(key.as_bytes()) % 64`
+- Partition ID = `crc32fast::hash(key.as_bytes()) % 256`
 - Partition map managed by Raft consensus
 
 ### 1.5 Node Roles Per Partition
@@ -976,19 +976,19 @@ All cluster messages follow this format (`src/cluster/mqtt_transport.rs:318-389`
 | 84 | `UniqueReleaseRequest` | Release reserved unique value |
 | 85 | `UniqueReleaseResponse` | Unique release response |
 
-### 2.3 Heartbeat Message (27 bytes)
+### 2.3 Heartbeat Message (75 bytes)
 
 `src/cluster/protocol.rs` - BeBytes serialization:
 
 ```rust
 struct Heartbeat {
-    version: u8,           // 1 byte, = 1
-    node_id: u16,          // 2 bytes, sender BE
-    timestamp_ms: u64,     // 8 bytes, current time BE
-    primary_bitmap: u64,   // 8 bytes, bit N = primary for partition N
-    replica_bitmap: u64,   // 8 bytes, bit N = replica for partition N
+    version: u8,              // 1 byte, = 1
+    node_id: u16,             // 2 bytes, sender BE
+    timestamp_ms: u64,        // 8 bytes, current time BE
+    primary_bitmap: [u64; 4], // 32 bytes, bit N = primary for partition N (256 bits)
+    replica_bitmap: [u64; 4], // 32 bytes, bit N = replica for partition N (256 bits)
 }
-// Total: 1 + 2 + 8 + 8 + 8 = 27 bytes
+// Total: 1 + 2 + 8 + 32 + 32 = 75 bytes
 ```
 
 ### 2.4 ReplicationWrite Message (variable)
@@ -1143,11 +1143,11 @@ struct SnapshotComplete {
 
 ```rust
 struct Heartbeat {
-    version: u8,           // Protocol version
-    node_id: u16,          // Sender node ID
-    timestamp_ms: u64,     // Sender timestamp
-    primary_bitmap: u64,   // Bit N = this node is primary for partition N
-    replica_bitmap: u64,   // Bit N = this node is replica for partition N
+    version: u8,              // Protocol version
+    node_id: u16,             // Sender node ID
+    timestamp_ms: u64,        // Sender timestamp
+    primary_bitmap: [u64; 4], // 256 bits, bit N = this node is primary for partition N
+    replica_bitmap: [u64; 4], // 256 bits, bit N = this node is replica for partition N
 }
 ```
 
@@ -1365,7 +1365,7 @@ struct PartitionUpdate {
 
 When first node starts:
 1. Becomes Raft leader (single-node cluster)
-2. Proposes UpdatePartition for all 64 partitions
+2. Proposes UpdatePartition for all 256 partitions
 3. Assigns itself as primary for all partitions
 4. Waits for other nodes to join
 
@@ -1489,13 +1489,13 @@ BridgeConfig::new(format!("bridge-to-node-{}", peer_id), remote_addr)
 
 **Symptom**: 2-node and 3-node clusters experienced repeated death/revival cycles. Nodes marked each other as dead every 15-30 seconds despite being healthy.
 
-**Root Cause**: Synchronous disk I/O in Raft storage. When a follower received `AppendEntries` with 64 partition updates, each log entry was persisted with a separate `flush()` call. 64 flushes took 20+ seconds, blocking the async event loop and causing heartbeat timeouts.
+**Root Cause**: Synchronous disk I/O in Raft storage. When a follower received `AppendEntries` with 256 partition updates, each log entry was persisted with a separate `flush()` call. 256 flushes took 20+ seconds, blocking the async event loop and causing heartbeat timeouts.
 
 **Code path**:
 1. `RaftNode::handle_append_entries()` loops over entries calling `persist_log_entry()`
 2. `persist_log_entry()` calls `RaftStorage::append_log_entry()`
 3. `append_log_entry()` does `backend.insert()` + `backend.flush()` per entry
-4. 64 entries × 1 flush each = event loop blocked for 20+ seconds
+4. 256 entries × 1 flush each = event loop blocked for 20+ seconds
 
 **Fix Applied**:
 1. Added `RaftStorage::append_log_entries_batch()` that uses batch writes with single flush (`storage.rs:76-88`)
@@ -1548,7 +1548,7 @@ BridgeConfig::new(format!("bridge-to-node-{}", peer_id), remote_addr)
 
 **Status**: FIXED
 
-**Symptom**: When Node 3 joined a cluster, it sometimes received zero partitions even though auto-rebalancing should assign ~21 partitions (64/3).
+**Symptom**: When Node 3 joined a cluster, it sometimes received zero partitions even though auto-rebalancing should assign ~85 partitions (256/3).
 
 **Root Cause**: Race condition in `handle_node_alive()`. When a new node joined, `trigger_rebalance()` was called which proposed multiple `AssignPartition` commands via Raft. However, `compute_balanced_assignments()` was called based on pre-rebalance state, and if multiple nodes joined quickly, the partition counts became inconsistent.
 
@@ -2179,7 +2179,7 @@ Bridge settings:
 When Raft leader and partitions not initialized:
 1. Calculate primary for each partition: `partition % node_count`
 2. Calculate replica: `(primary_idx + 1) % node_count`
-3. Propose `RaftCommand::update_partition()` for all 64 partitions
+3. Propose `RaftCommand::update_partition()` for all 256 partitions
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -475,7 +475,7 @@ mqdb agent start --bind 0.0.0.0:1883 --db ./data/mydb \
 
 ## Distributed Clustering
 
-MQDB supports distributed clustering with automatic failover and partition rebalancing. The cluster distributes data across 64 fixed partitions with a configurable replication factor (RF=2 by default). Raft consensus manages cluster topology and partition ownership. All inter-node communication flows over QUIC streams, providing multiplexed, TLS-encrypted, low-overhead transport.
+MQDB supports distributed clustering with automatic failover and partition rebalancing. The cluster distributes data across 256 fixed partitions with a configurable replication factor (RF=2 by default). Raft consensus manages cluster topology and partition ownership. All inter-node communication flows over QUIC streams, providing multiplexed, TLS-encrypted, low-overhead transport.
 
 ### Starting a Cluster
 
@@ -725,7 +725,7 @@ cargo run --example parking_lot
 | Reactive query language | Subscribe to expressions, not just topics |
 | Metrics and tracing | Persistence-layer observability |
 | TTL optimization | Expiration index to avoid full scans |
-| Horizontal scaling | Partition counts beyond the current 64 |
+| Horizontal scaling | Partition counts beyond the current 256 |
 
 ## Contributing
 

--- a/src/bin/mqdb/commands/bench/db_async.rs
+++ b/src/bin/mqdb/commands/bench/db_async.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use mqtt5::QoS;
 use mqtt5::client::MqttClient;
-use mqtt5::types::{PublishOptions, PublishProperties};
+use mqtt5::types::{ConnectOptions, PublishOptions, PublishProperties};
 use serde_json::{Value, json};
 
 use super::common::{BenchDbArgs, DbOp, generate_record};
@@ -55,7 +55,13 @@ pub(super) async fn cmd_bench_db_async(
     if args.conn.insecure {
         client.set_insecure_tls(true).await;
     }
-    client.connect(&args.conn.broker).await?;
+    if let (Some(user), Some(pass)) = (&args.conn.user, &args.conn.pass) {
+        let opts =
+            ConnectOptions::new(&client_id).with_credentials(user.clone(), pass.clone());
+        Box::pin(client.connect_with_options(&args.conn.broker, opts)).await?;
+    } else {
+        client.connect(&args.conn.broker).await?;
+    }
 
     let seeded_ids: Arc<Vec<String>> = if matches!(op, DbOp::Get | DbOp::Update | DbOp::Delete) {
         let seed_count = args.seed.max(1000);

--- a/src/cluster/db_handler/tests.rs
+++ b/src/cluster/db_handler/tests.rs
@@ -5,7 +5,7 @@ use super::super::db::data_partition;
 use super::super::db_protocol::{DbReadRequest, DbResponse, DbStatus, DbWriteRequest};
 use super::super::node_controller::NodeController;
 use super::super::transport::{ClusterMessage, ClusterTransport, InboundMessage, TransportConfig};
-use super::super::{Epoch, NodeId, PartitionId, PartitionMap};
+use super::super::{Epoch, NUM_PARTITIONS, NodeId, PartitionId, PartitionMap};
 use super::DbRequestHandler;
 use crate::types::OwnershipConfig;
 use bebytes::BeBytes;
@@ -124,7 +124,7 @@ fn setup_controller_all_partitions() -> NodeController<MockTransport> {
     let mut ctrl = create_test_controller(node1, transport);
 
     let mut map = PartitionMap::default();
-    for i in 0..64_u16 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         ctrl.become_primary(partition, Epoch::new(1));
         map.set(

--- a/src/cluster/db_topic.rs
+++ b/src/cluster/db_topic.rs
@@ -357,20 +357,20 @@ mod tests {
     fn parse_invalid_topics() {
         assert!(ParsedDbTopic::parse("not/a/db/topic").is_none());
         assert!(ParsedDbTopic::parse("$DB/").is_none());
-        assert!(ParsedDbTopic::parse("$DB/p99/users").is_none());
-        assert!(ParsedDbTopic::parse("$DB/p64/users/create").is_none());
+        assert!(ParsedDbTopic::parse("$DB/p999/users").is_none());
+        assert!(ParsedDbTopic::parse("$DB/p256/users/create").is_none());
         assert!(ParsedDbTopic::parse("$DB/_unknown/p5/op").is_none());
     }
 
     #[test]
-    fn partition_63_is_valid() {
-        let parsed = ParsedDbTopic::parse("$DB/p63/test/create").unwrap();
-        assert_eq!(parsed.partition, PartitionId::new(63));
+    fn partition_255_is_valid() {
+        let parsed = ParsedDbTopic::parse("$DB/p255/test/create").unwrap();
+        assert_eq!(parsed.partition, PartitionId::new(255));
     }
 
     #[test]
-    fn partition_64_is_invalid() {
-        assert!(ParsedDbTopic::parse("$DB/p64/test/create").is_none());
+    fn partition_256_is_invalid() {
+        assert!(ParsedDbTopic::parse("$DB/p256/test/create").is_none());
     }
 
     #[test]

--- a/src/cluster/node_controller/mod.rs
+++ b/src/cluster/node_controller/mod.rs
@@ -317,7 +317,7 @@ impl<T: ClusterTransport> NodeController<T> {
     /// Pick a local partition for creating new entities (round-robin).
     ///
     /// # Panics
-    /// Panics if no valid partition can be created (should never happen with 64 partitions).
+    /// Panics if no valid partition can be created.
     #[must_use]
     pub fn pick_partition_for_create(&self) -> PartitionId {
         use std::sync::atomic::{AtomicU16, Ordering};

--- a/src/cluster/node_controller/tests.rs
+++ b/src/cluster/node_controller/tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 use super::*;
+use crate::cluster::NUM_PARTITIONS;
 use crate::cluster::protocol::{Heartbeat, Operation};
 use crate::cluster::quorum::QuorumResult;
 use crate::cluster::session_partition;
@@ -272,11 +273,11 @@ fn subscribe_wildcard_broadcast_creates_64_writes() {
         .subscribe_wildcard_broadcast("sensors/+/temp", "client1", partition, 1)
         .unwrap();
 
-    assert_eq!(writes.len(), 64);
+    assert_eq!(writes.len(), NUM_PARTITIONS as usize);
 
     let mut partitions_covered: Vec<u16> = writes.iter().map(|w| w.partition.get()).collect();
     partitions_covered.sort_unstable();
-    let expected: Vec<u16> = (0..64).collect();
+    let expected: Vec<u16> = (0..NUM_PARTITIONS).collect();
     assert_eq!(partitions_covered, expected);
 }
 
@@ -765,7 +766,7 @@ async fn schema_is_valid_for_write_checks_active_state() {
 
 fn setup_all_partitions_primary(ctrl: &mut NodeController<MockTransport>, node: NodeId) {
     let mut map = PartitionMap::new();
-    for partition_id in 0..64 {
+    for partition_id in 0..NUM_PARTITIONS {
         if let Some(p) = PartitionId::new(partition_id) {
             ctrl.become_primary(p, Epoch::new(1));
             map.set(

--- a/src/cluster/partition_storage.rs
+++ b/src/cluster/partition_storage.rs
@@ -4,8 +4,8 @@
 use crate::error::Result;
 use crate::storage::StorageBackend;
 
-use super::PartitionId;
 use super::protocol::{Operation, ReplicationWrite};
+use super::{NUM_PARTITIONS, PartitionId};
 
 use std::sync::Arc;
 
@@ -66,7 +66,7 @@ impl PartitionStorage {
     /// Returns an error if the storage backend fails to scan.
     pub fn scan_entity(&self, entity: &str) -> Result<Vec<(PartitionId, String, Vec<u8>)>> {
         let mut results = Vec::new();
-        for p in 0..64u16 {
+        for p in 0..NUM_PARTITIONS {
             let prefix = format!("{p:02x}/{entity}/");
             let entries = self.backend.prefix_scan(prefix.as_bytes())?;
             for (key, value) in entries {
@@ -244,7 +244,7 @@ mod tests {
     fn batch_write_all_partitions() {
         let storage = storage();
 
-        let writes: Vec<_> = (0..64u16)
+        let writes: Vec<_> = (0..NUM_PARTITIONS)
             .map(|p| {
                 ReplicationWrite::new(
                     partition(p),
@@ -261,7 +261,7 @@ mod tests {
         storage.write_batch(&writes).unwrap();
 
         let entries = storage.scan_entity("_topic_index").unwrap();
-        assert_eq!(entries.len(), 64);
+        assert_eq!(entries.len(), NUM_PARTITIONS as usize);
     }
 
     #[test]

--- a/src/cluster/protocol/heartbeat.rs
+++ b/src/cluster/protocol/heartbeat.rs
@@ -1,20 +1,24 @@
 // Copyright 2027 LabOverWire. All rights reserved.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::cluster::{NodeId, PartitionId};
-use bebytes::BeBytes;
+use crate::cluster::{NUM_PARTITIONS, NodeId, PartitionId};
 
-#[derive(Debug, Clone, BeBytes)]
+const BITMAP_WORDS: usize = (NUM_PARTITIONS as usize).div_ceil(64);
+
+#[derive(Debug, Clone)]
 pub struct Heartbeat {
     version: u8,
     node_id: u16,
     timestamp_ms: u64,
-    primary_bitmap: u64,
-    replica_bitmap: u64,
+    primary_bitmap: [u64; BITMAP_WORDS],
+    replica_bitmap: [u64; BITMAP_WORDS],
 }
 
 impl Heartbeat {
-    pub const VERSION: u8 = 1;
+    pub const VERSION: u8 = 2;
+
+    const FIXED_HEADER_SIZE: usize = 1 + 2 + 8;
+    const TOTAL_SIZE: usize = Self::FIXED_HEADER_SIZE + BITMAP_WORDS * 8 * 2;
 
     #[must_use]
     pub fn create(node_id: NodeId, timestamp_ms: u64) -> Self {
@@ -22,27 +26,35 @@ impl Heartbeat {
             version: Self::VERSION,
             node_id: node_id.get(),
             timestamp_ms,
-            primary_bitmap: 0,
-            replica_bitmap: 0,
+            primary_bitmap: [0; BITMAP_WORDS],
+            replica_bitmap: [0; BITMAP_WORDS],
         }
     }
 
     pub fn set_primary(&mut self, partition: PartitionId) {
-        self.primary_bitmap |= 1u64 << partition.get();
+        let idx = partition.get() as usize / 64;
+        let bit = partition.get() as usize % 64;
+        self.primary_bitmap[idx] |= 1u64 << bit;
     }
 
     pub fn set_replica(&mut self, partition: PartitionId) {
-        self.replica_bitmap |= 1u64 << partition.get();
+        let idx = partition.get() as usize / 64;
+        let bit = partition.get() as usize % 64;
+        self.replica_bitmap[idx] |= 1u64 << bit;
     }
 
     #[must_use]
     pub fn is_primary(&self, partition: PartitionId) -> bool {
-        (self.primary_bitmap >> partition.get()) & 1 == 1
+        let idx = partition.get() as usize / 64;
+        let bit = partition.get() as usize % 64;
+        (self.primary_bitmap[idx] >> bit) & 1 == 1
     }
 
     #[must_use]
     pub fn is_replica(&self, partition: PartitionId) -> bool {
-        (self.replica_bitmap >> partition.get()) & 1 == 1
+        let idx = partition.get() as usize / 64;
+        let bit = partition.get() as usize % 64;
+        (self.replica_bitmap[idx] >> bit) & 1 == 1
     }
 
     #[must_use]
@@ -53,5 +65,61 @@ impl Heartbeat {
     #[must_use]
     pub fn timestamp_ms(&self) -> u64 {
         self.timestamp_ms
+    }
+
+    #[must_use]
+    pub fn to_be_bytes(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(Self::TOTAL_SIZE);
+        buf.push(self.version);
+        buf.extend_from_slice(&self.node_id.to_be_bytes());
+        buf.extend_from_slice(&self.timestamp_ms.to_be_bytes());
+        for word in &self.primary_bitmap {
+            buf.extend_from_slice(&word.to_be_bytes());
+        }
+        for word in &self.replica_bitmap {
+            buf.extend_from_slice(&word.to_be_bytes());
+        }
+        buf
+    }
+
+    #[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
+    pub fn try_from_be_bytes(data: &[u8]) -> std::result::Result<(Self, usize), String> {
+        if data.len() < Self::TOTAL_SIZE {
+            return Err(format!(
+                "heartbeat too short: {} < {}",
+                data.len(),
+                Self::TOTAL_SIZE
+            ));
+        }
+
+        let version = data[0];
+        let node_id = u16::from_be_bytes([data[1], data[2]]);
+        let timestamp_ms = u64::from_be_bytes(data[3..11].try_into().unwrap());
+
+        let mut primary_bitmap = [0u64; BITMAP_WORDS];
+        let mut replica_bitmap = [0u64; BITMAP_WORDS];
+
+        let bitmap_start = Self::FIXED_HEADER_SIZE;
+        for (i, word) in primary_bitmap.iter_mut().enumerate() {
+            let offset = bitmap_start + i * 8;
+            *word = u64::from_be_bytes(data[offset..offset + 8].try_into().unwrap());
+        }
+
+        let replica_start = bitmap_start + BITMAP_WORDS * 8;
+        for (i, word) in replica_bitmap.iter_mut().enumerate() {
+            let offset = replica_start + i * 8;
+            *word = u64::from_be_bytes(data[offset..offset + 8].try_into().unwrap());
+        }
+
+        Ok((
+            Self {
+                version,
+                node_id,
+                timestamp_ms,
+                primary_bitmap,
+                replica_bitmap,
+            },
+            Self::TOTAL_SIZE,
+        ))
     }
 }

--- a/src/cluster/query_coordinator.rs
+++ b/src/cluster/query_coordinator.rs
@@ -385,9 +385,9 @@ mod tests {
     }
 
     #[test]
-    fn all_partitions_returns_64() {
+    fn all_partitions_returns_expected_count() {
         let partitions = QueryCoordinator::all_partitions();
-        assert_eq!(partitions.len(), 64);
+        assert_eq!(partitions.len(), NUM_PARTITIONS as usize);
     }
 
     #[test]

--- a/src/cluster/rebalancer.rs
+++ b/src/cluster/rebalancer.rs
@@ -454,8 +454,10 @@ mod tests {
             assert!(!replicas.contains(&primary));
         }
 
+        let expected_min = NUM_PARTITIONS as usize / 3;
+        let expected_max = expected_min + 1;
         for count in counts {
-            assert!((20..=23).contains(&count));
+            assert!((expected_min..=expected_max).contains(&count));
         }
     }
 
@@ -502,15 +504,16 @@ mod tests {
         let config = RebalanceConfig::default();
         let map = compute_balanced_assignments(&initial_nodes, &config, Epoch::ZERO);
 
-        assert_eq!(map.primary_count(node(1)), 32);
-        assert_eq!(map.primary_count(node(2)), 32);
+        assert_eq!(map.primary_count(node(1)), NUM_PARTITIONS as usize / 2);
+        assert_eq!(map.primary_count(node(2)), NUM_PARTITIONS as usize / 2);
         assert_eq!(map.primary_count(node(3)), 0);
 
         let all_nodes = vec![node(1), node(2), node(3)];
         let reassignments = compute_incremental_assignments(&map, &all_nodes, &config);
 
+        let expected_per_node = NUM_PARTITIONS as usize / 3;
         assert!(!reassignments.is_empty());
-        assert!(reassignments.len() >= 20);
+        assert!(reassignments.len() >= expected_per_node);
 
         let mut new_node3_count = 0;
         for r in &reassignments {
@@ -518,7 +521,7 @@ mod tests {
                 new_node3_count += 1;
             }
         }
-        assert!(new_node3_count >= 20);
+        assert!(new_node3_count >= expected_per_node);
     }
 
     #[test]
@@ -534,20 +537,20 @@ mod tests {
             );
         }
 
-        assert_eq!(map.primary_count(node(1)), 64);
+        assert_eq!(map.primary_count(node(1)), NUM_PARTITIONS as usize);
         assert_eq!(map.replica_count(node(1)), 0);
 
         let all_nodes = vec![node(1), node(2)];
         let reassignments = compute_incremental_assignments(&map, &all_nodes, &config);
 
         assert!(!reassignments.is_empty());
-        assert_eq!(reassignments.len(), 64);
+        assert_eq!(reassignments.len(), NUM_PARTITIONS as usize);
 
         let primary_moves: Vec<_> = reassignments
             .iter()
             .filter(|r| r.new_primary != r.old_primary.unwrap())
             .collect();
-        assert_eq!(primary_moves.len(), 32);
+        assert_eq!(primary_moves.len(), NUM_PARTITIONS as usize / 2);
 
         let replica_adds: Vec<_> = reassignments
             .iter()
@@ -555,7 +558,7 @@ mod tests {
                 r.new_primary == r.old_primary.unwrap() && r.new_replicas.contains(&node(2))
             })
             .collect();
-        assert_eq!(replica_adds.len(), 32);
+        assert_eq!(replica_adds.len(), NUM_PARTITIONS as usize / 2);
 
         for r in &reassignments {
             let has_node2 = r.new_primary == node(2) || r.new_replicas.contains(&node(2));
@@ -573,10 +576,11 @@ mod tests {
         let config = RebalanceConfig::default();
         let map = compute_balanced_assignments(&initial_nodes, &config, Epoch::ZERO);
 
-        assert_eq!(map.primary_count(node(1)), 32);
-        assert_eq!(map.primary_count(node(2)), 32);
-        assert_eq!(map.replica_count(node(1)), 32);
-        assert_eq!(map.replica_count(node(2)), 32);
+        let half = NUM_PARTITIONS as usize / 2;
+        assert_eq!(map.primary_count(node(1)), half);
+        assert_eq!(map.primary_count(node(2)), half);
+        assert_eq!(map.replica_count(node(1)), half);
+        assert_eq!(map.replica_count(node(2)), half);
         assert_eq!(map.replica_count(node(3)), 0);
 
         let all_nodes = vec![node(1), node(2), node(3)];
@@ -597,13 +601,14 @@ mod tests {
             }
         }
 
+        let expected_per_node = NUM_PARTITIONS as usize / 3;
         assert!(
-            node3_primaries >= 20,
-            "expected ~21 primaries, got {node3_primaries}"
+            node3_primaries >= expected_per_node,
+            "expected ~{expected_per_node} primaries, got {node3_primaries}"
         );
         assert!(
-            node3_replicas >= 20,
-            "expected ~21 replicas, got {node3_replicas}"
+            node3_replicas >= expected_per_node,
+            "expected ~{expected_per_node} replicas, got {node3_replicas}"
         );
     }
 }

--- a/src/cluster/types.rs
+++ b/src/cluster/types.rs
@@ -90,7 +90,7 @@ impl From<u64> for Epoch {
     }
 }
 
-pub const NUM_PARTITIONS: u16 = 64;
+pub const NUM_PARTITIONS: u16 = 256;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PartitionId(u16);
@@ -236,9 +236,9 @@ mod tests {
     #[test]
     fn partition_new_validates_bounds() {
         assert!(PartitionId::new(0).is_some());
-        assert!(PartitionId::new(63).is_some());
-        assert!(PartitionId::new(64).is_none());
-        assert!(PartitionId::new(100).is_none());
+        assert!(PartitionId::new(NUM_PARTITIONS - 1).is_some());
+        assert!(PartitionId::new(NUM_PARTITIONS).is_none());
+        assert!(PartitionId::new(NUM_PARTITIONS + 100).is_none());
     }
 
     #[test]
@@ -246,6 +246,9 @@ mod tests {
         let partitions: Vec<_> = PartitionId::all().collect();
         assert_eq!(partitions.len(), NUM_PARTITIONS as usize);
         assert_eq!(partitions[0].get(), 0);
-        assert_eq!(partitions[63].get(), 63);
+        assert_eq!(
+            partitions[NUM_PARTITIONS as usize - 1].get(),
+            NUM_PARTITIONS - 1
+        );
     }
 }

--- a/src/cluster_agent/event_loop.rs
+++ b/src/cluster_agent/event_loop.rs
@@ -53,14 +53,14 @@ impl ClusteredAgent {
 
         self.setup_and_spawn_raft().await?;
 
-        self.run_event_loop(
+        Box::pin(self.run_event_loop(
             synced_retained_topics,
             broker_handle,
             admin_client,
             admin_rx,
             service_username.as_ref(),
             service_password.as_ref(),
-        )
+        ))
         .await
     }
 
@@ -105,7 +105,7 @@ impl ClusteredAgent {
                 biased;
 
                 _ = tick_interval.tick() => {
-                    self.handle_tick(&tx_tick).await;
+                    Box::pin(self.handle_tick(&tx_tick)).await;
                 }
                 Ok(batch) = rx_batch.recv_async() => {
                     self.handle_processing_batch(batch).await;

--- a/src/cluster_agent/init.rs
+++ b/src/cluster_agent/init.rs
@@ -107,7 +107,7 @@ impl ClusteredAgent {
         }
         let executor = DedicatedExecutor::new("msg-processor", 2);
         executor.handle().spawn(async move {
-            processor.run(channels.tx_batch).await;
+            Box::pin(processor.run(channels.tx_batch)).await;
         });
         info!("started message processor on dedicated executor");
         executor
@@ -267,7 +267,7 @@ impl ClusteredAgent {
             all_nodes,
         );
         tokio::spawn(async move {
-            raft_task.run().await;
+            Box::pin(raft_task.run()).await;
         });
         info!("spawned Raft task");
 

--- a/tests/cluster_integration_test.rs
+++ b/tests/cluster_integration_test.rs
@@ -5,10 +5,10 @@ mod simulation;
 
 use mqdb::cluster::raft::{RaftConfig, RaftNode, RaftOutput, RaftRole};
 use mqdb::cluster::{
-    ClusterTransport, Epoch, NodeController, NodeId, NodeStatus, Operation, PartitionAssignment,
-    PartitionId, PartitionMap, PublishRouter, Qos2Store, RaftEvent, RaftMessage, ReplicationWrite,
-    RetainedStore, SessionStore, SubscriptionCache, TopicIndex, TransportConfig, WildcardStore,
-    session_partition, topic_partition,
+    ClusterTransport, Epoch, NUM_PARTITIONS, NodeController, NodeId, NodeStatus, Operation,
+    PartitionAssignment, PartitionId, PartitionMap, PublishRouter, Qos2Store, RaftEvent,
+    RaftMessage, ReplicationWrite, RetainedStore, SessionStore, SubscriptionCache, TopicIndex,
+    TransportConfig, WildcardStore, session_partition, topic_partition,
 };
 use simulation::framework::runtime::SimulatedRuntime;
 use simulation::transport::SimulatedTransport;
@@ -112,7 +112,7 @@ impl TestCluster {
         }
 
         let mut partition_map = PartitionMap::new();
-        for i in 0..64 {
+        for i in 0..NUM_PARTITIONS {
             let partition = PartitionId::new(i).unwrap();
             let primary_idx = i as usize % node_count;
             let replica_idx = (i as usize + 1) % node_count;
@@ -139,7 +139,7 @@ impl TestCluster {
     }
 
     async fn setup_all_primaries(&mut self) {
-        for i in 0..64 {
+        for i in 0..NUM_PARTITIONS {
             let partition = PartitionId::new(i).unwrap();
             self.nodes[0]
                 .controller
@@ -257,7 +257,7 @@ impl TestCluster {
         let new_rx_messages = rx_raft_messages;
         let all_node_ids: Vec<NodeId> = self.nodes.iter().map(|n| n.id).collect();
         let mut partition_map = PartitionMap::new();
-        for i in 0..64 {
+        for i in 0..NUM_PARTITIONS {
             let partition = PartitionId::new(i).unwrap();
             let primary_idx = i as usize % node_count;
             let replica_idx = (i as usize + 1) % node_count;
@@ -2777,7 +2777,7 @@ async fn db_crud_replication_to_replicas() {
 async fn db_list_returns_entities_by_type() {
     let mut cluster = TestCluster::new(3);
 
-    for i in 0..64 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         cluster.nodes[0]
             .controller
@@ -2835,7 +2835,7 @@ async fn schema_broadcast_to_all_nodes() {
     let n2 = cluster.nodes[1].id;
     let n3 = cluster.nodes[2].id;
 
-    for i in 0..64 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         cluster.nodes[0]
             .controller
@@ -2868,7 +2868,11 @@ async fn schema_broadcast_to_all_nodes() {
 
     assert_eq!(schema.entity_str(), "users");
     assert_eq!(schema.schema_version, 1);
-    assert_eq!(writes.len(), 64, "Should broadcast to all 64 partitions");
+    assert_eq!(
+        writes.len(),
+        NUM_PARTITIONS as usize,
+        "Should broadcast to all partitions"
+    );
 
     for write in writes {
         cluster.nodes[0]
@@ -2931,7 +2935,7 @@ async fn schema_update_increments_version() {
     let n2 = cluster.nodes[1].id;
     let n3 = cluster.nodes[2].id;
 
-    for i in 0..64 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         cluster.nodes[0]
             .controller
@@ -3005,7 +3009,7 @@ async fn index_add_and_lookup() {
     let n2 = cluster.nodes[1].id;
     let n3 = cluster.nodes[2].id;
 
-    for i in 0..64 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         cluster.nodes[0]
             .controller
@@ -3073,7 +3077,7 @@ async fn index_multiple_records_same_value() {
     let n2 = cluster.nodes[1].id;
     let n3 = cluster.nodes[2].id;
 
-    for i in 0..64 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         cluster.nodes[0]
             .controller
@@ -3251,7 +3255,7 @@ async fn unique_constraint_expires_after_ttl() {
 
     let mut cluster = TestCluster::new(3);
 
-    for i in 0..64 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         cluster.nodes[0]
             .controller
@@ -3311,7 +3315,7 @@ async fn fk_validation_request_lifecycle() {
     let n2 = cluster.nodes[1].id;
     let n3 = cluster.nodes[2].id;
 
-    for i in 0..64 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         cluster.nodes[0]
             .controller
@@ -3432,7 +3436,7 @@ async fn fk_validation_cleanup_expired() {
 
     let mut cluster = TestCluster::new(3);
 
-    for i in 0..64 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         cluster.nodes[0]
             .controller
@@ -3831,7 +3835,7 @@ async fn unique_constraint_cross_node_message_flow() {
     let mut cluster = TestCluster::new(2);
     cluster.runtime.network().set_base_latency_ms(0);
 
-    for i in 0..64 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         cluster.nodes[0]
             .controller

--- a/tests/cluster_test.rs
+++ b/tests/cluster_test.rs
@@ -5,8 +5,8 @@ mod simulation;
 
 use mqdb::cluster::raft::RaftConfig;
 use mqdb::cluster::{
-    Epoch, NodeController, NodeId, Operation, PartitionAssignment, PartitionId, PartitionMap,
-    PartitionRole, ReplicationWrite, TransportConfig,
+    Epoch, NUM_PARTITIONS, NodeController, NodeId, Operation, PartitionAssignment, PartitionId,
+    PartitionMap, PartitionRole, ReplicationWrite, TransportConfig,
 };
 use simulation::transport::SimulatedTransport;
 
@@ -52,7 +52,11 @@ async fn partition_id_always_in_valid_range() {
         let entity = format!("entity_{i}");
         let id = format!("id_{}", i * 7);
         let partition = PartitionId::from_entity_id(&entity, &id);
-        assert!(partition.get() < 64, "partition {} >= 64", partition.get());
+        assert!(
+            partition.get() < NUM_PARTITIONS,
+            "partition {} >= {NUM_PARTITIONS}",
+            partition.get()
+        );
     }
 }
 
@@ -245,7 +249,7 @@ async fn heartbeat_detection() {
     ctrl2.register_peer(node1_id);
 
     let mut partition_map = PartitionMap::new();
-    for i in 0..64 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         let primary = if i % 2 == 0 { node1_id } else { node2_id };
         let replica = if i % 2 == 0 { node2_id } else { node1_id };
@@ -839,7 +843,7 @@ async fn rebalancer_assigns_partitions_to_node_with_zero_primaries() {
     let node3 = NodeId::validated(3).unwrap();
 
     let mut map = PartitionMap::new();
-    for i in 0..64u16 {
+    for i in 0..NUM_PARTITIONS {
         let partition = PartitionId::new(i).unwrap();
         let primary = if i % 2 == 0 { node1 } else { node2 };
         let replica = if i % 2 == 0 { node2 } else { node1 };
@@ -849,8 +853,8 @@ async fn rebalancer_assigns_partitions_to_node_with_zero_primaries() {
         );
     }
 
-    assert_eq!(map.primary_count(node1), 32);
-    assert_eq!(map.primary_count(node2), 32);
+    assert_eq!(map.primary_count(node1), NUM_PARTITIONS as usize / 2);
+    assert_eq!(map.primary_count(node2), NUM_PARTITIONS as usize / 2);
     assert_eq!(map.primary_count(node3), 0);
 
     let all_nodes = vec![node1, node2, node3];
@@ -862,13 +866,14 @@ async fn rebalancer_assigns_partitions_to_node_with_zero_primaries() {
         "rebalancer must propose changes when node has zero partitions"
     );
 
+    let expected_per_node = NUM_PARTITIONS as usize / 3;
     let node3_primaries = reassignments
         .iter()
         .filter(|r| r.new_primary == node3)
         .count();
     assert!(
-        node3_primaries >= 20,
-        "node3 should receive at least 20 primaries (got {node3_primaries})"
+        node3_primaries >= expected_per_node,
+        "node3 should receive at least {expected_per_node} primaries (got {node3_primaries})"
     );
 }
 
@@ -888,22 +893,24 @@ async fn rebalancer_distributes_partitions_fairly() {
     let n2_count = map.primary_count(nodes[1]);
     let n3_count = map.primary_count(nodes[2]);
 
+    let per_node_min = NUM_PARTITIONS as usize / 3;
+    let per_node_max = per_node_min + 1;
     assert!(
-        (21..=22).contains(&n1_count),
-        "node1 should have ~21-22 primaries"
+        (per_node_min..=per_node_max).contains(&n1_count),
+        "node1 should have ~{per_node_min}-{per_node_max} primaries, got {n1_count}"
     );
     assert!(
-        (21..=22).contains(&n2_count),
-        "node2 should have ~21-22 primaries"
+        (per_node_min..=per_node_max).contains(&n2_count),
+        "node2 should have ~{per_node_min}-{per_node_max} primaries, got {n2_count}"
     );
     assert!(
-        (21..=22).contains(&n3_count),
-        "node3 should have ~21-22 primaries"
+        (per_node_min..=per_node_max).contains(&n3_count),
+        "node3 should have ~{per_node_min}-{per_node_max} primaries, got {n3_count}"
     );
     assert_eq!(
         n1_count + n2_count + n3_count,
-        64,
-        "total should be 64 partitions"
+        NUM_PARTITIONS as usize,
+        "total should be {NUM_PARTITIONS} partitions"
     );
 
     for partition in PartitionId::all() {

--- a/tests/simulation/transport.rs
+++ b/tests/simulation/transport.rs
@@ -8,10 +8,11 @@ use mqdb::cluster::raft::{
 use mqdb::cluster::{
     BatchReadRequest, BatchReadResponse, CatchupRequest, CatchupResponse, ClusterMessage,
     ClusterTransport, Epoch, ForwardedPublish, Heartbeat, InboundMessage, JsonDbRequest,
-    JsonDbResponse, NodeId, PartitionId, QueryRequest, QueryResponse, ReplicationAck,
-    ReplicationWrite, SnapshotChunk, SnapshotComplete, SnapshotRequest, TopicSubscriptionBroadcast,
-    TransportError, UniqueCommitRequest, UniqueCommitResponse, UniqueReleaseRequest,
-    UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse, WildcardBroadcast,
+    JsonDbResponse, NUM_PARTITIONS, NodeId, PartitionId, QueryRequest, QueryResponse,
+    ReplicationAck, ReplicationWrite, SnapshotChunk, SnapshotComplete, SnapshotRequest,
+    TopicSubscriptionBroadcast, TransportError, UniqueCommitRequest, UniqueCommitResponse,
+    UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse,
+    WildcardBroadcast,
 };
 
 use super::framework::{VirtualClock, VirtualNetwork};
@@ -41,7 +42,7 @@ impl SimulatedTransport {
             clock,
             state: Arc::new(Mutex::new(TransportState {
                 registered_nodes: vec![node_id.get()],
-                partition_primaries: vec![None; 64],
+                partition_primaries: vec![None; NUM_PARTITIONS as usize],
             })),
         }
     }


### PR DESCRIPTION
## Summary
- Increase `NUM_PARTITIONS` from 64 to 256 for better data distribution across cluster nodes
- Rewrite heartbeat bitmap from `u64` to `[u64; 4]` with manual serialization (wire format v1 → v2)
- Fix async bench client not passing `--user`/`--pass` credentials

## Test plan
- [x] `cargo make dev` passes (format + pedantic clippy + all tests)
- [x] 3-node full mesh cluster: all 19 dev integration tests pass
- [x] Async insert benchmark: no regression vs 64 partitions (measured same session, same hardware)
- [x] Pub/sub benchmark: no regression vs 64 partitions