### PR TITLE
add server-managed _version counter to all entity CRUD paths

### DIFF
--- a/crates/mqdb-wasm/src/crud.rs
+++ b/crates/mqdb-wasm/src/crud.rs
@@ -46,6 +46,11 @@ impl WasmDatabase {
         self.validate_unique_async(&entity, &value, None).await?;
         self.validate_foreign_keys_async(&entity, &value).await?;
 
+        if let serde_json::Value::Object(ref mut obj) = value {
+            obj.remove("_version");
+            obj.insert("_version".to_string(), serde_json::Value::Number(1.into()));
+        }
+
         let key = format!("data/{entity}/{id}");
         let serialized = serde_json::to_vec(&value)
             .map_err(|e| JsValue::from_str(&format!("serialization error: {e}")))?;
@@ -204,6 +209,17 @@ impl WasmDatabase {
             }
         }
 
+        let existing_version = existing
+            .get("_version")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        if let serde_json::Value::Object(ref mut obj) = value {
+            obj.insert(
+                "_version".to_string(),
+                serde_json::Value::Number((existing_version + 1).into()),
+            );
+        }
+
         {
             let inner = self.borrow_inner()?;
             if let Some(schema) = inner.schemas.get(&entity) {
@@ -324,6 +340,11 @@ impl WasmDatabase {
         self.validate_unique_sync(&entity, &value, None)?;
         self.validate_foreign_keys_sync(&entity, &value)?;
 
+        if let serde_json::Value::Object(ref mut obj) = value {
+            obj.remove("_version");
+            obj.insert("_version".to_string(), serde_json::Value::Number(1.into()));
+        }
+
         let key = format!("data/{entity}/{id}");
         let serialized = serde_json::to_vec(&value)
             .map_err(|e| JsValue::from_str(&format!("serialization error: {e}")))?;
@@ -365,6 +386,17 @@ impl WasmDatabase {
             for (k, v) in new_fields {
                 existing_obj.insert(k, v);
             }
+        }
+
+        let existing_version = existing
+            .get("_version")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0);
+        if let serde_json::Value::Object(ref mut obj) = value {
+            obj.insert(
+                "_version".to_string(),
+                serde_json::Value::Number((existing_version + 1).into()),
+            );
         }
 
         {

--- a/src/cluster/db_handler/json_ops.rs
+++ b/src/cluster/db_handler/json_ops.rs
@@ -247,10 +247,15 @@ impl DbRequestHandler {
         sender: Option<&str>,
         client_id: Option<&str>,
     ) -> JsonOpResult {
-        let data: Value = match serde_json::from_slice(payload) {
+        let mut data: Value = match serde_json::from_slice(payload) {
             Ok(v) => v,
             Err(_) => return JsonOpResult::Response(Self::json_error(400, "invalid JSON payload")),
         };
+
+        if let Value::Object(ref mut obj) = data {
+            obj.remove("_version");
+            obj.insert("_version".to_string(), Value::Number(1.into()));
+        }
 
         if let Some(err) = Self::validate_against_schema(controller, entity, &data) {
             return JsonOpResult::Response(err);
@@ -735,6 +740,17 @@ impl DbRequestHandler {
             for (key, value) in update_obj {
                 existing_obj.insert(key, value);
             }
+        }
+
+        let existing_version = old_data
+            .get("_version")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        if let Value::Object(ref mut obj) = merged {
+            obj.insert(
+                "_version".to_string(),
+                Value::Number((existing_version + 1).into()),
+            );
         }
 
         Ok((old_data, merged))

--- a/src/cluster/node_controller/db_ops.rs
+++ b/src/cluster/node_controller/db_ops.rs
@@ -392,6 +392,18 @@ impl<T: ClusterTransport> NodeController<T> {
                     existing_obj.insert(key, value);
                 }
             }
+
+            let existing_version = old_data
+                .get("_version")
+                .and_then(Value::as_u64)
+                .unwrap_or(0);
+            if let Value::Object(ref mut obj) = merged {
+                obj.insert(
+                    "_version".to_string(),
+                    Value::Number((existing_version + 1).into()),
+                );
+            }
+
             (old_data, merged)
         } else {
             return (
@@ -547,6 +559,11 @@ impl<T: ClusterTransport> NodeController<T> {
         };
 
         Self::apply_ttl_expiry(&mut data);
+
+        if let serde_json::Value::Object(ref mut obj) = data {
+            obj.remove("_version");
+            obj.insert("_version".to_string(), serde_json::Value::Number(1.into()));
+        }
 
         let id = if let Some(client_id) = data.get("id").and_then(serde_json::Value::as_str) {
             client_id.to_string()

--- a/src/database/crud.rs
+++ b/src/database/crud.rs
@@ -46,6 +46,11 @@ impl Database {
             obj.remove("ttl_secs");
         }
 
+        if let Value::Object(ref mut obj) = data {
+            obj.remove("_version");
+            obj.insert("_version".to_string(), Value::Number(1.into()));
+        }
+
         let schema_registry = self.schema_registry.read().await;
         schema_registry.validate_entity(&entity_name, &data)?;
         drop(schema_registry);
@@ -141,6 +146,18 @@ impl Database {
             for (key, value) in updates {
                 existing.insert(key, value);
             }
+        }
+
+        let existing_version = existing_entity
+            .data
+            .get("_version")
+            .and_then(Value::as_u64)
+            .unwrap_or(0);
+        if let Value::Object(ref mut obj) = updated_data {
+            obj.insert(
+                "_version".to_string(),
+                Value::Number((existing_version + 1).into()),
+            );
         }
 
         let schema_registry = self.schema_registry.read().await;
@@ -258,6 +275,14 @@ impl Database {
 
                         if let Some(obj) = entity.data.as_object_mut() {
                             obj.insert(set_null_op.field.clone(), serde_json::Value::Null);
+                            let v = obj
+                                .get("_version")
+                                .and_then(serde_json::Value::as_u64)
+                                .unwrap_or(0);
+                            obj.insert(
+                                "_version".to_string(),
+                                serde_json::Value::Number((v + 1).into()),
+                            );
                         }
 
                         batch.insert(entity_key, entity.serialize()?);


### PR DESCRIPTION
## Summary
- Adds a monotonic `_version` field to all user entity data across 4 code paths (agent, cluster DbHandler, cluster NodeController, WASM)
- Create sets `_version: 1` (strips any client-provided value)
- Update sets `_version: existing + 1` (reads from pre-merge data, overrides client value)
- Delete SetNull cascade also increments `_version` on the modified entity
- Entities without `_version` are treated as version 0 (first update → `_version: 1`)

## Test plan
- [x] `cargo make dev` — 788 tests passed, 0 failures, clippy pedantic clean
- [x] Verify `_version: 1` appears in create response via E2E test
- [x] Verify `_version` increments on update
- [x] Verify client-provided `_version` is stripped on create, overwritten on update
- [x] Verify backward compatibility: entities without `_version` get `_version: 1` on first update