### PR TITLE
centralize ownership check logic into OwnershipDecision enum

### DIFF
--- a/crates/mqdb-agent/src/agent/handlers.rs
+++ b/crates/mqdb-agent/src/agent/handlers.rs
@@ -11,7 +11,7 @@ use mqdb_core::VaultKeyStore;
 use mqdb_core::constraint::Constraint;
 use mqdb_core::protocol::{AdminOperation, DbOp, build_request, parse_admin_topic, parse_db_topic};
 use mqdb_core::transport::{Request, Response};
-use mqdb_core::types::{OwnershipConfig, ScopeConfig};
+use mqdb_core::types::{OwnershipConfig, OwnershipDecision, ScopeConfig};
 use mqtt5::broker::auth::ComprehensiveAuthProvider;
 use mqtt5::broker::{AclRule, Permission};
 use mqtt5::client::MqttClient;
@@ -251,9 +251,10 @@ async fn vault_pre_update(
     id: &str,
     delta: Value,
 ) -> Result<(Request, Option<(Value, Value)>), Response> {
-    if let Some(uid) = params.sender_uid
-        && !params.ownership.is_admin(uid)
-        && let Some(owner_field) = params.ownership.entity_owner_fields.get(entity)
+    if let OwnershipDecision::Check {
+        owner_field,
+        sender: uid,
+    } = params.ownership.evaluate(entity, params.sender_uid)
         && let Err(e) = db.check_ownership(entity, id, owner_field, uid)
     {
         return Err(e.into());

--- a/crates/mqdb-agent/src/transport_execute.rs
+++ b/crates/mqdb-agent/src/transport_execute.rs
@@ -3,7 +3,7 @@
 
 use crate::database::{CallerContext, Database};
 use mqdb_core::transport::{Request, Response, VaultConstraintData};
-use mqdb_core::types::{OwnershipConfig, ScopeConfig};
+use mqdb_core::types::{OwnershipConfig, OwnershipDecision, ScopeConfig};
 use serde_json::Value;
 
 fn value_from_unit(_: ()) -> Value {
@@ -68,9 +68,10 @@ impl Database {
                 includes,
                 projection,
             } => {
-                if let Some(uid) = sender
-                    && !ownership.is_admin(uid)
-                    && let Some(owner_field) = ownership.owner_field(&entity)
+                if let OwnershipDecision::Check {
+                    owner_field,
+                    sender: uid,
+                } = ownership.evaluate(&entity, sender)
                     && let Err(e) = self.check_ownership(&entity, &id, owner_field, uid)
                 {
                     return e.into();
@@ -85,9 +86,10 @@ impl Database {
                 id,
                 mut fields,
             } => {
-                if let Some(uid) = sender
-                    && !ownership.is_admin(uid)
-                    && let Some(owner_field) = ownership.owner_field(&entity)
+                if let OwnershipDecision::Check {
+                    owner_field,
+                    sender: uid,
+                } = ownership.evaluate(&entity, sender)
                 {
                     if let Err(e) = self.check_ownership(&entity, &id, owner_field, uid) {
                         return e.into();
@@ -116,9 +118,10 @@ impl Database {
                 }
             }
             Request::Delete { entity, id } => {
-                if let Some(uid) = sender
-                    && !ownership.is_admin(uid)
-                    && let Some(owner_field) = ownership.owner_field(&entity)
+                if let OwnershipDecision::Check {
+                    owner_field,
+                    sender: uid,
+                } = ownership.evaluate(&entity, sender)
                     && let Err(e) = self.check_ownership(&entity, &id, owner_field, uid)
                 {
                     return e.into();
@@ -149,9 +152,10 @@ impl Database {
                 {
                     return e.into();
                 }
-                if let Some(uid) = sender
-                    && !ownership.is_admin(uid)
-                    && let Some(owner_field) = ownership.owner_field(&entity)
+                if let OwnershipDecision::Check {
+                    owner_field,
+                    sender: uid,
+                } = ownership.evaluate(&entity, sender)
                 {
                     filters.push(mqdb_core::Filter::new(
                         owner_field.to_string(),

--- a/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
@@ -13,7 +13,7 @@ use super::super::transport::ClusterTransport;
 use super::DbRequestHandler;
 use super::helpers::{self, parse_projection};
 use mqdb_core::events::ChangeEvent;
-use mqdb_core::types::{MAX_FILTERS, MAX_LIST_RESULTS, MAX_SORT_FIELDS};
+use mqdb_core::types::{MAX_FILTERS, MAX_LIST_RESULTS, MAX_SORT_FIELDS, OwnershipDecision};
 use serde_json::{Value, json};
 
 pub(super) enum JsonOpResult {
@@ -118,9 +118,10 @@ impl DbRequestHandler {
                 }
             }
             DbTopicOperation::JsonRead { entity, id } => {
-                if let Some(uid) = sender
-                    && !self.ownership.is_admin(uid)
-                    && let Some(owner_field) = self.ownership.owner_field(entity)
+                if let OwnershipDecision::Check {
+                    owner_field,
+                    sender: uid,
+                } = self.ownership.evaluate(entity, sender)
                     && let Some(err) =
                         self.check_cluster_ownership(controller, entity, id, owner_field, uid)
                 {
@@ -131,9 +132,10 @@ impl DbRequestHandler {
             }
             DbTopicOperation::JsonUpdate { entity, id } => {
                 let stripped_payload;
-                let effective_payload = if let Some(uid) = sender
-                    && !self.ownership.is_admin(uid)
-                    && let Some(owner_field) = self.ownership.owner_field(entity)
+                let effective_payload = if let OwnershipDecision::Check {
+                    owner_field,
+                    sender: uid,
+                } = self.ownership.evaluate(entity, sender)
                 {
                     if let Some(err) =
                         self.check_cluster_ownership(controller, entity, id, owner_field, uid)
@@ -181,9 +183,10 @@ impl DbRequestHandler {
                 }
             }
             DbTopicOperation::JsonDelete { entity, id } => {
-                if let Some(uid) = sender
-                    && !self.ownership.is_admin(uid)
-                    && let Some(owner_field) = self.ownership.owner_field(entity)
+                if let OwnershipDecision::Check {
+                    owner_field,
+                    sender: uid,
+                } = self.ownership.evaluate(entity, sender)
                     && let Some(err) =
                         self.check_cluster_ownership(controller, entity, id, owner_field, uid)
                 {
@@ -1093,20 +1096,20 @@ impl DbRequestHandler {
             return Some(err);
         }
 
-        if let Some(uid) = sender
-            && !self.ownership.is_admin(uid)
-            && let Some(owner_field) = self.ownership.owner_field(entity)
+        let ownership_check = self.ownership.evaluate(entity, sender);
+        if let OwnershipDecision::Check {
+            owner_field,
+            sender: uid,
+        } = &ownership_check
         {
             filters.push(mqdb_core::Filter::new(
-                owner_field.to_string(),
+                (*owner_field).to_string(),
                 mqdb_core::FilterOp::Eq,
-                Value::String(uid.to_string()),
+                Value::String((*uid).to_string()),
             ));
         }
 
-        let sender_needs_filter = sender.is_some_and(|uid| !self.ownership.is_admin(uid))
-            && self.ownership.owner_field(entity).is_some();
-        let scatter_payload = if sender_needs_filter {
+        let scatter_payload = if matches!(ownership_check, OwnershipDecision::Check { .. }) {
             let mut data: Value = if payload.is_empty() {
                 json!({})
             } else {

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -9,7 +9,7 @@ use super::{
 };
 use crate::cluster::store_manager::outbox::{CascadeOutboxPayload, CascadeRemoteOp, OutboxPayload};
 use mqdb_core::events::ChangeEvent;
-use mqdb_core::types::MAX_LIST_RESULTS;
+use mqdb_core::types::{MAX_LIST_RESULTS, OwnershipDecision};
 use serde_json::Value;
 use tokio::sync::oneshot;
 
@@ -516,11 +516,15 @@ impl<T: ClusterTransport> NodeController<T> {
     }
 
     fn check_forwarded_ownership(&self, request: &JsonDbRequest) -> Option<Vec<u8>> {
-        let sender = request.sender.as_deref()?;
-        if self.ownership.is_admin(sender) {
+        let OwnershipDecision::Check {
+            owner_field,
+            sender: uid,
+        } = self
+            .ownership
+            .evaluate(&request.entity, request.sender.as_deref())
+        else {
             return None;
-        }
-        let owner_field = self.ownership.owner_field(&request.entity)?;
+        };
         let id = request.id.as_deref()?;
         if !matches!(
             request.op,
@@ -533,7 +537,7 @@ impl<T: ClusterTransport> NodeController<T> {
             return Some(Self::json_error(403, "permission denied"));
         };
         let owner_value = data.get(owner_field).and_then(serde_json::Value::as_str);
-        if owner_value != Some(sender) {
+        if owner_value != Some(uid) {
             return Some(Self::json_error(403, "permission denied"));
         }
         None

--- a/crates/mqdb-core/src/types.rs
+++ b/crates/mqdb-core/src/types.rs
@@ -134,6 +134,35 @@ impl OwnershipConfig {
     pub fn is_empty(&self) -> bool {
         self.entity_owner_fields.is_empty()
     }
+
+    #[must_use]
+    pub fn evaluate<'a, 'b>(
+        &'a self,
+        entity: &str,
+        sender: Option<&'b str>,
+    ) -> OwnershipDecision<'a, 'b> {
+        let Some(uid) = sender else {
+            return OwnershipDecision::Allowed;
+        };
+        if self.is_admin(uid) {
+            return OwnershipDecision::Allowed;
+        }
+        match self.owner_field(entity) {
+            Some(field) => OwnershipDecision::Check {
+                owner_field: field,
+                sender: uid,
+            },
+            None => OwnershipDecision::Allowed,
+        }
+    }
+}
+
+pub enum OwnershipDecision<'a, 'b> {
+    Allowed,
+    Check {
+        owner_field: &'a str,
+        sender: &'b str,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Add `OwnershipDecision` enum and `evaluate()` method to `OwnershipConfig` that centralizes the 3-condition ownership check (sender exists, not admin, entity has owner field)
- Replace inline guard patterns across all three code paths (agent, cluster DbRequestHandler, cluster NodeController) with `evaluate()` calls
- Include `sender` in the `Check` variant to eliminate `unwrap()` calls at all call sites

## Test plan
- [x] `cargo make clippy` — zero warnings
- [x] `cargo make test` — all tests pass (914 total, 0 failures)
- [x] Pure refactor — no behavioral changes, no new dependencies, no API changes