### PR TITLE
harden temp file permissions and deduplicate env secret helpers

### DIFF
--- a/crates/mqdb-cli/src/cli_types/agent.rs
+++ b/crates/mqdb-cli/src/cli_types/agent.rs
@@ -79,9 +79,9 @@ pub(crate) struct AgentStartFields {
     pub(crate) license: Option<PathBuf>,
     #[arg(long = "", env = "MQDB_LICENSE", hide = true)]
     pub(crate) license_data: Option<String>,
-    #[arg(long, env = "MQDB_QUIC_CERT", hide = true)]
+    #[arg(long = "", env = "MQDB_QUIC_CERT", hide = true)]
     pub(crate) quic_cert_data: Option<String>,
-    #[arg(long, env = "MQDB_QUIC_KEY", hide = true)]
+    #[arg(long = "", env = "MQDB_QUIC_KEY", hide = true)]
     pub(crate) quic_key_data: Option<String>,
     #[arg(
         long,
@@ -233,11 +233,11 @@ pub(crate) struct ClusterStartFields {
     pub(crate) license: Option<PathBuf>,
     #[arg(long = "", env = "MQDB_LICENSE", hide = true)]
     pub(crate) license_data: Option<String>,
-    #[arg(long, env = "MQDB_QUIC_CERT", hide = true)]
+    #[arg(long = "", env = "MQDB_QUIC_CERT", hide = true)]
     pub(crate) quic_cert_data: Option<String>,
-    #[arg(long, env = "MQDB_QUIC_KEY", hide = true)]
+    #[arg(long = "", env = "MQDB_QUIC_KEY", hide = true)]
     pub(crate) quic_key_data: Option<String>,
-    #[arg(long, env = "MQDB_QUIC_CA", hide = true)]
+    #[arg(long = "", env = "MQDB_QUIC_CA", hide = true)]
     pub(crate) quic_ca_data: Option<String>,
 }
 

--- a/crates/mqdb-cli/src/commands/agent.rs
+++ b/crates/mqdb-cli/src/commands/agent.rs
@@ -8,6 +8,9 @@ use std::sync::Arc;
 use mqdb_agent::{Database, MqdbAgent};
 
 use crate::cli_types::{AuthArgs, ConnectionArgs, DurabilityArg, JwtAlgorithmArg, OAuthArgs};
+use crate::commands::env_secret::{
+    resolve_federated_jwt_content, resolve_passphrase, resolve_path_or_data,
+};
 use crate::common::connect_client;
 
 pub(crate) struct AgentStartArgs {
@@ -31,45 +34,6 @@ pub(crate) struct AgentStartArgs {
     pub(crate) otlp_endpoint: Option<String>,
     pub(crate) otel_service_name: String,
     pub(crate) otel_sampling_ratio: f64,
-}
-
-fn write_temp_file(name: &str, content: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let dir = std::env::temp_dir().join("mqdb-env-secrets");
-    std::fs::create_dir_all(&dir)?;
-    let path = dir.join(name);
-    let normalized = if content.ends_with('\n') {
-        content.to_string()
-    } else {
-        format!("{content}\n")
-    };
-    std::fs::write(&path, normalized)?;
-    Ok(path)
-}
-
-fn resolve_path_or_data(
-    file: Option<PathBuf>,
-    data: Option<&str>,
-    temp_name: &str,
-) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
-    if let Some(content) = data {
-        return Ok(Some(write_temp_file(temp_name, content)?));
-    }
-    Ok(file)
-}
-
-fn resolve_passphrase(
-    file: Option<&PathBuf>,
-    data: Option<&str>,
-) -> Result<Option<String>, Box<dyn std::error::Error>> {
-    if let Some(content) = data {
-        return Ok(Some(content.trim().to_string()));
-    }
-    if let Some(pf) = file {
-        let passphrase = std::fs::read_to_string(pf)
-            .map_err(|e| format!("failed to read passphrase file: {e}"))?;
-        return Ok(Some(passphrase.trim().to_string()));
-    }
-    Ok(None)
 }
 
 #[allow(clippy::too_many_lines)]
@@ -112,7 +76,11 @@ pub(crate) async fn cmd_agent_start(
     crate::license::enforce_license(license_info.as_ref(), needs_vault, false)
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
 
-    let auth_setup = build_auth_setup_config(&args.auth)?;
+    let federated_content = resolve_federated_jwt_content(
+        args.auth.federated_jwt_config_data.as_deref(),
+        args.auth.federated_jwt_config.as_ref(),
+    );
+    let auth_setup = build_auth_setup_config(&args.auth, federated_content.as_deref())?;
     let mut agent = MqdbAgent::new(db)
         .with_bind_address(args.bind)
         .with_auth_setup(auth_setup);
@@ -172,6 +140,7 @@ pub(crate) async fn cmd_agent_start(
             http_bind,
             &args.auth,
             &args.oauth,
+            federated_content.as_deref(),
             ownership_for_http,
             &args.db_path,
         )?;
@@ -201,6 +170,7 @@ pub(crate) async fn cmd_agent_status(
 #[allow(clippy::too_many_lines)]
 pub(crate) fn build_auth_setup_config(
     auth: &AuthArgs,
+    federated_content: Option<&str>,
 ) -> Result<mqdb_agent::auth_config::AuthSetupConfig, Box<dyn std::error::Error>> {
     use mqtt5::broker::config::{JwtAlgorithm, JwtConfig, RateLimitConfig};
 
@@ -220,16 +190,6 @@ pub(crate) fn build_auth_setup_config(
         auth.jwt_key_data.as_deref(),
         "jwt_key",
     )?;
-
-    let federated_content = auth
-        .federated_jwt_config_data
-        .as_deref()
-        .map(String::from)
-        .or_else(|| {
-            auth.federated_jwt_config
-                .as_ref()
-                .and_then(|p| std::fs::read_to_string(p).ok())
-        });
 
     let jwt_config = if let Some(alg) = auth.jwt_algorithm {
         let key_path = jwt_key_path
@@ -264,7 +224,7 @@ pub(crate) fn build_auth_setup_config(
         None
     };
 
-    let federated_jwt_config = if let Some(ref content) = federated_content {
+    let federated_jwt_config = if let Some(content) = federated_content {
         let config: mqtt5::broker::config::FederatedJwtConfig = serde_json::from_str(content)?;
         Some(config)
     } else {
@@ -317,6 +277,7 @@ pub(crate) fn build_http_config(
     http_bind: SocketAddr,
     auth: &AuthArgs,
     oauth: &OAuthArgs,
+    federated_content: Option<&str>,
     ownership_config: std::sync::Arc<mqdb_core::types::OwnershipConfig>,
     db_path: &Path,
 ) -> Result<mqdb_agent::http::HttpServerConfig, Box<dyn std::error::Error>> {
@@ -337,17 +298,7 @@ pub(crate) fn build_http_config(
         .into());
     }
 
-    let federated_content = auth
-        .federated_jwt_config_data
-        .as_deref()
-        .map(String::from)
-        .or_else(|| {
-            auth.federated_jwt_config
-                .as_ref()
-                .and_then(|p| std::fs::read_to_string(p).ok())
-        });
-
-    let client_id = if let Some(ref content) = federated_content {
+    let client_id = if let Some(content) = federated_content {
         let config: serde_json::Value = serde_json::from_str(content)?;
         config
             .get("providers")

--- a/crates/mqdb-cli/src/commands/cluster.rs
+++ b/crates/mqdb-cli/src/commands/cluster.rs
@@ -10,6 +10,9 @@ use serde_json::json;
 
 use super::agent::{build_auth_setup_config, build_http_config};
 use crate::cli_types::{AuthArgs, ConnectionArgs, DurabilityArg, OAuthArgs, OutputFormat};
+use crate::commands::env_secret::{
+    resolve_federated_jwt_content, resolve_passphrase, resolve_path_or_data,
+};
 use crate::common::{execute_request, output_response};
 
 #[allow(clippy::struct_excessive_bools)]
@@ -44,30 +47,6 @@ pub(crate) struct ClusterStartArgs {
     pub(crate) license_data: Option<String>,
 }
 
-fn write_temp_file(name: &str, content: &str) -> Result<PathBuf, Box<dyn std::error::Error>> {
-    let dir = std::env::temp_dir().join("mqdb-env-secrets");
-    std::fs::create_dir_all(&dir)?;
-    let path = dir.join(name);
-    let normalized = if content.ends_with('\n') {
-        content.to_string()
-    } else {
-        format!("{content}\n")
-    };
-    std::fs::write(&path, normalized)?;
-    Ok(path)
-}
-
-fn resolve_path_or_data(
-    file: Option<PathBuf>,
-    data: Option<&str>,
-    temp_name: &str,
-) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
-    if let Some(content) = data {
-        return Ok(Some(write_temp_file(temp_name, content)?));
-    }
-    Ok(file)
-}
-
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn cmd_cluster_start(
     args: ClusterStartArgs,
@@ -99,15 +78,10 @@ pub(crate) async fn cmd_cluster_start(
         None
     };
 
-    let passphrase = if let Some(ref data) = args.passphrase_data {
-        Some(data.trim().to_string())
-    } else if let Some(ref pf) = args.passphrase_file {
-        let content = std::fs::read_to_string(pf)
-            .map_err(|e| format!("failed to read passphrase file: {e}"))?;
-        Some(content.trim().to_string())
-    } else {
-        None
-    };
+    let passphrase = resolve_passphrase(
+        args.passphrase_file.as_ref(),
+        args.passphrase_data.as_deref(),
+    )?;
 
     let needs_vault = passphrase.is_some();
     crate::license::enforce_license(license_info.as_ref(), needs_vault, true)
@@ -131,7 +105,11 @@ pub(crate) async fn cmd_cluster_start(
         args.auth.acl_data.as_deref(),
         "cluster_acl",
     )?;
-    let auth_setup = build_auth_setup_config(&args.auth)?;
+    let federated_content = resolve_federated_jwt_content(
+        args.auth.federated_jwt_config_data.as_deref(),
+        args.auth.federated_jwt_config.as_ref(),
+    );
+    let auth_setup = build_auth_setup_config(&args.auth, federated_content.as_deref())?;
 
     let db_path = args.db_path;
     let mut config = ClusterConfig::new(args.node_id, db_path.clone(), peer_configs);
@@ -202,6 +180,7 @@ pub(crate) async fn cmd_cluster_start(
             http_bind,
             &args.auth,
             &args.oauth,
+            federated_content.as_deref(),
             ownership_arc.clone(),
             &db_path,
         )?;

--- a/crates/mqdb-cli/src/commands/env_secret.rs
+++ b/crates/mqdb-cli/src/commands/env_secret.rs
@@ -1,0 +1,85 @@
+// Copyright 2025-2026 LabOverWire. All rights reserved.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use std::io::Write;
+use std::path::PathBuf;
+
+#[cfg(unix)]
+use std::os::unix::fs::{DirBuilderExt, OpenOptionsExt};
+
+fn secret_dir() -> PathBuf {
+    std::env::temp_dir().join(format!("mqdb-env-secrets-{}", std::process::id()))
+}
+
+pub(crate) fn write_temp_file(
+    name: &str,
+    content: &str,
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let dir = secret_dir();
+
+    #[cfg(unix)]
+    std::fs::DirBuilder::new()
+        .recursive(true)
+        .mode(0o700)
+        .create(&dir)?;
+
+    #[cfg(not(unix))]
+    std::fs::create_dir_all(&dir)?;
+
+    let path = dir.join(name);
+    let normalized = if content.ends_with('\n') {
+        content.to_string()
+    } else {
+        format!("{content}\n")
+    };
+
+    #[cfg(unix)]
+    {
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(&path)?;
+        file.write_all(normalized.as_bytes())?;
+    }
+
+    #[cfg(not(unix))]
+    std::fs::write(&path, normalized)?;
+
+    Ok(path)
+}
+
+pub(crate) fn resolve_path_or_data(
+    file: Option<PathBuf>,
+    data: Option<&str>,
+    temp_name: &str,
+) -> Result<Option<PathBuf>, Box<dyn std::error::Error>> {
+    if let Some(content) = data {
+        return Ok(Some(write_temp_file(temp_name, content)?));
+    }
+    Ok(file)
+}
+
+pub(crate) fn resolve_passphrase(
+    file: Option<&PathBuf>,
+    data: Option<&str>,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    if let Some(content) = data {
+        return Ok(Some(content.trim().to_string()));
+    }
+    if let Some(pf) = file {
+        let passphrase = std::fs::read_to_string(pf)
+            .map_err(|e| format!("failed to read passphrase file: {e}"))?;
+        return Ok(Some(passphrase.trim().to_string()));
+    }
+    Ok(None)
+}
+
+pub(crate) fn resolve_federated_jwt_content(
+    data: Option<&str>,
+    file: Option<&PathBuf>,
+) -> Option<String> {
+    data.map(String::from)
+        .or_else(|| file.as_ref().and_then(|p| std::fs::read_to_string(p).ok()))
+}

--- a/crates/mqdb-cli/src/commands/mod.rs
+++ b/crates/mqdb-cli/src/commands/mod.rs
@@ -13,3 +13,4 @@ pub(crate) mod crud;
 pub(crate) mod dev;
 #[cfg(feature = "cluster")]
 pub(crate) mod dev_bench;
+pub(crate) mod env_secret;


### PR DESCRIPTION
## Summary
- Extract shared `env_secret` module with hardened temp file creation (0o700 dirs, 0o600 files, PID-scoped isolation)
- Remove duplicate `write_temp_file` and `resolve_path_or_data` from `agent.rs` and `cluster.rs`
- Fix federated JWT config being read twice (once in `build_auth_setup_config`, once in `build_http_config`) — now resolved once and passed through
- Fix 5 QUIC `_data` fields using `long` instead of `long = ""` (exposed hidden CLI flags)

## Test plan
- [x] `cargo make clippy` — zero warnings
- [x] `cargo make dev` — all tests pass

This was commit `9d44fc8` on the `docker-env-config` branch that didn't make it into the squash merge of #31.