### PR TITLE
add password reset endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Affected crates: mqdb-core (0.5.0), mqdb-agent (0.6.0), mqdb-cli (0.7.0).
 - Challenge `purpose` field to distinguish password reset from email verification challenges
 - Purpose guard in `handle_verify_submit` to reject password reset challenges
 - `--no-rate-limit` now disables all HTTP rate limiters (login, register, verify, password change, password reset)
+- `AdminRequired` topic protection now falls through to ACL for non-admin users, enabling operator-provisioned service accounts
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.0] - 2026-04-05
+
+Affected crates: mqdb-core (0.5.0), mqdb-agent (0.6.0), mqdb-cli (0.7.0).
+
+### Added
+
+- Password reset endpoints: `POST /auth/password/reset/start` and `POST /auth/password/reset/submit` (HTTP, unauthenticated) for "forgot password" flow
+- Password reset MQTT topics: `$DB/_auth/password/reset/start` and `$DB/_auth/password/reset/submit` for authenticated users
+- Challenge `purpose` field to distinguish password reset from email verification challenges
+- Purpose guard in `handle_verify_submit` to reject password reset challenges
+- `--no-rate-limit` now disables all HTTP rate limiters (login, register, verify, password change, password reset)
+
 ## [0.6.0] - 2026-04-04
 
 Affected crates: mqdb-core (0.4.0), mqdb-agent (0.5.0), mqdb-cluster (0.3.0), mqdb-cli (0.6.0).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Affected crates: mqdb-core (0.5.0), mqdb-agent (0.6.0), mqdb-cli (0.7.0).
 - Purpose guard in `handle_verify_submit` to reject password reset challenges
 - `--no-rate-limit` now disables all HTTP rate limiters (login, register, verify, password change, password reset)
 
+### Security
+
+- Promote `$DB/_verify/#` to `AdminRequired` topic protection tier to prevent leakage of verification codes and receipt spoofing
+
 ## [0.6.0] - 2026-04-04
 
 Affected crates: mqdb-core (0.4.0), mqdb-agent (0.5.0), mqdb-cluster (0.3.0), mqdb-cli (0.6.0).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64",
  "bebytes",
@@ -1413,7 +1413,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/README.md
+++ b/README.md
@@ -418,9 +418,9 @@ MQDB enforces hardcoded protection on internal topics that cannot be overridden 
 |------|--------|----------|
 | BlockAll | `_mqdb/#`, `$DB/_idx/#`, `$DB/_unique/#`, `$DB/_fk/#`, `$DB/_query/#`, `$DB/p+/#` | All access denied |
 | ReadOnly | `$SYS/#` | Subscribe allowed, publish denied |
-| AdminRequired | `$DB/_admin/#`, `$DB/_verify/#`, `$DB/_oauth_tokens/#`, `$DB/_identities/#`, `$DB/_identity_links/#` | Requires admin user |
+| AdminRequired | `$DB/_admin/#`, `$DB/_verify/#`, `$DB/_oauth_tokens/#`, `$DB/_identities/#`, `$DB/_identity_links/#` | Requires admin user or explicit ACL grant |
 
-Entities starting with `_` (e.g., `_sessions`, `_mqtt_subs`) require admin access. Exceptions: `$DB/_health`, `$DB/_vault/*`, and `$DB/_auth/*` are accessible to any authenticated user. Verifier services that subscribe to `$DB/_verify/challenges/#` or publish to `$DB/_verify/receipts/#` must connect with admin credentials so they bypass topic protection on the verification namespace.
+Entities starting with `_` (e.g., `_sessions`, `_mqtt_subs`) require admin access. Exceptions: `$DB/_health`, `$DB/_vault/*`, and `$DB/_auth/*` are accessible to any authenticated user. For `AdminRequired` topics, non-admin users with an explicit ACL grant for the specific topic are also allowed access. This enables operator-provisioned service accounts (e.g., an email verifier with ACL grants for `$DB/_verify/#`) without requiring full admin privileges.
 
 #### Admin User Configuration
 

--- a/README.md
+++ b/README.md
@@ -504,6 +504,8 @@ When `--http-bind` is set, the following HTTP endpoints are available:
 | GET | `/auth/session` | Check current session status |
 | POST | `/auth/logout` | Destroy the session |
 | POST | `/auth/password/change` | Change password (requires `--email-auth`, verified email) |
+| POST | `/auth/password/reset/start` | Start password reset (requires `--email-auth`, unauthenticated) |
+| POST | `/auth/password/reset/submit` | Submit reset code + new password (requires `--email-auth`, unauthenticated) |
 | POST | `/auth/verify/start` | Start email verification challenge (requires `--email-auth`) |
 | POST | `/auth/verify/submit` | Submit verification code (requires `--email-auth`) |
 | GET | `/auth/verify/status` | Check email verification state (requires `--email-auth`) |
@@ -513,13 +515,15 @@ When `--http-bind` is set, the following HTTP endpoints are available:
 
 All auth endpoints use cookie-based sessions. The `/auth/ticket` endpoint exchanges a valid session for a JWT that can be used to authenticate MQTT connections.
 
-### Password Change MQTT API
+### Password Change & Reset MQTT API
 
-Password change is also available over MQTT 5.0 request-response for JWT-authenticated users:
+Password change and reset are also available over MQTT 5.0 request-response for JWT-authenticated users:
 
 | Topic | Payload | Description |
 |-------|---------|-------------|
 | `$DB/_auth/password/change` | `{"current_password": "...", "new_password": "..."}` | Change password (requires verified email) |
+| `$DB/_auth/password/reset/start` | `{"email": "user@example.com"}` | Start password reset (sends verification code) |
+| `$DB/_auth/password/reset/submit` | `{"challenge_id": "...", "code": "...", "new_password": "..."}` | Submit reset code + new password |
 
 ## Vault Encryption
 

--- a/README.md
+++ b/README.md
@@ -418,9 +418,9 @@ MQDB enforces hardcoded protection on internal topics that cannot be overridden 
 |------|--------|----------|
 | BlockAll | `_mqdb/#`, `$DB/_idx/#`, `$DB/_unique/#`, `$DB/_fk/#`, `$DB/_query/#`, `$DB/p+/#` | All access denied |
 | ReadOnly | `$SYS/#` | Subscribe allowed, publish denied |
-| AdminRequired | `$DB/_admin/#`, `$DB/_oauth_tokens/#`, `$DB/_identities/#`, `$DB/_identity_links/#` | Requires admin user |
+| AdminRequired | `$DB/_admin/#`, `$DB/_verify/#`, `$DB/_oauth_tokens/#`, `$DB/_identities/#`, `$DB/_identity_links/#` | Requires admin user |
 
-Entities starting with `_` (e.g., `_sessions`, `_mqtt_subs`) require admin access. Exceptions: `$DB/_health`, `$DB/_vault/*`, `$DB/_verify/*`, and `$DB/_auth/*` are accessible to any authenticated user.
+Entities starting with `_` (e.g., `_sessions`, `_mqtt_subs`) require admin access. Exceptions: `$DB/_health`, `$DB/_vault/*`, and `$DB/_auth/*` are accessible to any authenticated user. Verifier services that subscribe to `$DB/_verify/challenges/#` or publish to `$DB/_verify/receipts/#` must connect with admin credentials so they bypass topic protection on the verification namespace.
 
 #### Admin User Configuration
 

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.5.0"
+version = "0.6.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "Standalone MQTT broker agent with embedded database for MQDB"
 
 [dependencies]
-mqdb-core = { path = "../mqdb-core", version = "0.4.0", features = ["fjall-backend"] }
+mqdb-core = { path = "../mqdb-core", version = "0.5.0", features = ["fjall-backend"] }
 
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mqdb-agent/src/agent/handlers.rs
+++ b/crates/mqdb-agent/src/agent/handlers.rs
@@ -490,6 +490,12 @@ async fn handle_admin_operation(ctx: &AdminContext<'_>, op: AdminOperation) {
         AdminOperation::VaultStatus => handle_vault_status_mqtt(ctx).await,
         #[cfg(feature = "http-api")]
         AdminOperation::PasswordChange => handle_password_change_mqtt(ctx, &payload).await,
+        #[cfg(feature = "http-api")]
+        AdminOperation::PasswordResetStart => handle_password_reset_start_mqtt(ctx, &payload).await,
+        #[cfg(feature = "http-api")]
+        AdminOperation::PasswordResetSubmit => {
+            handle_password_reset_submit_mqtt(ctx, &payload).await
+        }
         #[cfg(not(feature = "http-api"))]
         AdminOperation::VaultEnable
         | AdminOperation::VaultUnlock
@@ -500,7 +506,9 @@ async fn handle_admin_operation(ctx: &AdminContext<'_>, op: AdminOperation) {
             Response::error(mqdb_core::ErrorCode::Forbidden, "requires http-api feature")
         }
         #[cfg(not(feature = "http-api"))]
-        AdminOperation::PasswordChange => {
+        AdminOperation::PasswordChange
+        | AdminOperation::PasswordResetStart
+        | AdminOperation::PasswordResetSubmit => {
             Response::error(mqdb_core::ErrorCode::Forbidden, "requires http-api feature")
         }
     };
@@ -1669,4 +1677,337 @@ async fn handle_password_change_mqtt(ctx: &AdminContext<'_>, payload: &Value) ->
     .await;
 
     Response::ok(json!({"status": "password changed"}))
+}
+
+#[cfg(feature = "http-api")]
+#[allow(clippy::too_many_lines)]
+async fn handle_password_reset_start_mqtt(ctx: &AdminContext<'_>, payload: &Value) -> Response {
+    use serde_json::json;
+
+    let Some(canonical_id) = extract_sender(ctx.message) else {
+        return Response::error(mqdb_core::ErrorCode::Forbidden, "missing sender identity");
+    };
+
+    let Some(email) = payload.get("email").and_then(|v| v.as_str()) else {
+        return Response::error(mqdb_core::ErrorCode::BadRequest, "missing email field");
+    };
+
+    if !ctx.vault_unlock_limiter.check_and_record(canonical_id) {
+        return Response::error(
+            mqdb_core::ErrorCode::RateLimited,
+            "too many attempts, try again later",
+        );
+    }
+
+    let Some(identity) =
+        crate::vault_ops::read_entity_db(ctx.db, "_identities", canonical_id).await
+    else {
+        return Response::error(mqdb_core::ErrorCode::NotFound, "identity not found");
+    };
+
+    let stored_email_hash = identity
+        .get("email_hash")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let computed_hash = crate::http::credentials::compute_email_hash(None, email);
+    if stored_email_hash.is_empty() || computed_hash != stored_email_hash {
+        return Response::error(
+            mqdb_core::ErrorCode::BadRequest,
+            "email does not match identity",
+        );
+    }
+
+    let target_hash = stored_email_hash.to_string();
+
+    if let Some(challenges) = crate::vault_ops::list_entities_db(
+        ctx.db,
+        "_verification_challenges",
+        &format!("target_hash={target_hash}"),
+    )
+    .await
+    {
+        for challenge in challenges {
+            let status = challenge
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("");
+            if status != "pending" && status != "delivered" {
+                continue;
+            }
+            if let Some(id) = challenge.get("id").and_then(|v| v.as_str()) {
+                crate::vault_ops::update_entity_db(
+                    ctx.db,
+                    "_verification_challenges",
+                    id,
+                    &json!({"status": "expired"}),
+                )
+                .await;
+            }
+        }
+    }
+
+    let rng = ring::rand::SystemRandom::new();
+    let mut id_bytes = [0u8; 16];
+    if ring::rand::SecureRandom::fill(&rng, &mut id_bytes).is_err() {
+        return Response::error(mqdb_core::ErrorCode::Internal, "RNG failure");
+    }
+    id_bytes[6] = (id_bytes[6] & 0x0F) | 0x40;
+    id_bytes[8] = (id_bytes[8] & 0x3F) | 0x80;
+    let challenge_id = format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        id_bytes[0],
+        id_bytes[1],
+        id_bytes[2],
+        id_bytes[3],
+        id_bytes[4],
+        id_bytes[5],
+        id_bytes[6],
+        id_bytes[7],
+        id_bytes[8],
+        id_bytes[9],
+        id_bytes[10],
+        id_bytes[11],
+        id_bytes[12],
+        id_bytes[13],
+        id_bytes[14],
+        id_bytes[15]
+    );
+
+    let mut code_bytes = [0u8; 4];
+    if ring::rand::SecureRandom::fill(&rng, &mut code_bytes).is_err() {
+        return Response::error(mqdb_core::ErrorCode::Internal, "RNG failure");
+    }
+    let code_num = u32::from_be_bytes(code_bytes) % 1_000_000;
+    let code = format!("{code_num:06}");
+    let code_hash = {
+        let d = ring::digest::digest(&ring::digest::SHA256, code.as_bytes());
+        crate::http::credentials::hex_encode(d.as_ref())
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    let expires_at = now + 600;
+
+    let challenge_data = json!({
+        "id": challenge_id,
+        "canonical_id": canonical_id,
+        "method": "email",
+        "target_hash": target_hash,
+        "code_hash": code_hash,
+        "status": "pending",
+        "mode": "code",
+        "purpose": "password_reset",
+        "attempts": 0,
+        "max_attempts": 5,
+        "created_at": now.to_string(),
+        "expires_at": expires_at.to_string(),
+    });
+
+    if !crate::vault_ops::create_entity_db(ctx.db, "_verification_challenges", &challenge_data)
+        .await
+    {
+        return Response::error(
+            mqdb_core::ErrorCode::Internal,
+            "failed to create reset challenge",
+        );
+    }
+
+    let notification = json!({
+        "challenge_id": challenge_id,
+        "method": "email",
+        "mode": "code",
+        "purpose": "password_reset",
+        "target": email,
+        "code": code,
+        "expires_at": expires_at.to_string(),
+    });
+    let notify_payload = serde_json::to_vec(&notification).unwrap_or_default();
+    if let Err(e) = ctx
+        .client
+        .publish("$DB/_verify/challenges/email", notify_payload)
+        .await
+    {
+        warn!("failed to publish password reset notification: {e}");
+    }
+
+    Response::ok(json!({
+        "status": "reset_started",
+        "challenge_id": challenge_id,
+        "expires_in": 600,
+    }))
+}
+
+#[cfg(feature = "http-api")]
+#[allow(clippy::too_many_lines)]
+async fn handle_password_reset_submit_mqtt(ctx: &AdminContext<'_>, payload: &Value) -> Response {
+    use serde_json::json;
+
+    let Some(canonical_id) = extract_sender(ctx.message) else {
+        return Response::error(mqdb_core::ErrorCode::Forbidden, "missing sender identity");
+    };
+
+    let Some(challenge_id) = payload.get("challenge_id").and_then(|v| v.as_str()) else {
+        return Response::error(
+            mqdb_core::ErrorCode::BadRequest,
+            "missing challenge_id field",
+        );
+    };
+
+    let Some(submitted_code) = payload.get("code").and_then(|v| v.as_str()) else {
+        return Response::error(mqdb_core::ErrorCode::BadRequest, "missing code field");
+    };
+
+    let Some(new_password) = payload.get("new_password").and_then(|v| v.as_str()) else {
+        return Response::error(
+            mqdb_core::ErrorCode::BadRequest,
+            "missing new_password field",
+        );
+    };
+
+    if let Err(e) = crate::http::credentials::validate_password(new_password) {
+        return Response::error(mqdb_core::ErrorCode::BadRequest, e);
+    }
+
+    if !ctx.vault_unlock_limiter.check_and_record(canonical_id) {
+        return Response::error(
+            mqdb_core::ErrorCode::RateLimited,
+            "too many attempts, try again later",
+        );
+    }
+
+    let Some(challenge) =
+        crate::vault_ops::read_entity_db(ctx.db, "_verification_challenges", challenge_id).await
+    else {
+        return Response::error(mqdb_core::ErrorCode::NotFound, "challenge not found");
+    };
+
+    let purpose = challenge
+        .get("purpose")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if purpose != "password_reset" {
+        return Response::error(mqdb_core::ErrorCode::BadRequest, "invalid challenge type");
+    }
+
+    let challenge_canonical = challenge
+        .get("canonical_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if challenge_canonical != canonical_id {
+        return Response::error(
+            mqdb_core::ErrorCode::Forbidden,
+            "challenge belongs to another user",
+        );
+    }
+
+    let status = challenge
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if status != "pending" && status != "delivered" {
+        return Response::error(
+            mqdb_core::ErrorCode::BadRequest,
+            format!("challenge is {status}"),
+        );
+    }
+
+    let expires_at = challenge
+        .get("expires_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs());
+    if expires_at > 0 && now >= expires_at {
+        crate::vault_ops::update_entity_db(
+            ctx.db,
+            "_verification_challenges",
+            challenge_id,
+            &json!({"status": "expired"}),
+        )
+        .await;
+        return Response::error(mqdb_core::ErrorCode::BadRequest, "challenge has expired");
+    }
+
+    let attempts = challenge
+        .get("attempts")
+        .and_then(Value::as_u64)
+        .unwrap_or(0);
+    let max_attempts = challenge
+        .get("max_attempts")
+        .and_then(Value::as_u64)
+        .unwrap_or(5);
+    if attempts >= max_attempts {
+        crate::vault_ops::update_entity_db(
+            ctx.db,
+            "_verification_challenges",
+            challenge_id,
+            &json!({"status": "failed"}),
+        )
+        .await;
+        return Response::error(mqdb_core::ErrorCode::BadRequest, "too many attempts");
+    }
+
+    let new_attempts = attempts + 1;
+    let submitted_hash = {
+        let d = ring::digest::digest(&ring::digest::SHA256, submitted_code.as_bytes());
+        crate::http::credentials::hex_encode(d.as_ref())
+    };
+    let stored_hash = challenge
+        .get("code_hash")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if submitted_hash != stored_hash {
+        let new_status = if new_attempts >= max_attempts {
+            "failed"
+        } else {
+            status
+        };
+        crate::vault_ops::update_entity_db(
+            ctx.db,
+            "_verification_challenges",
+            challenge_id,
+            &json!({"attempts": new_attempts, "status": new_status}),
+        )
+        .await;
+        return Response::error(mqdb_core::ErrorCode::Unauthorized, "invalid code");
+    }
+
+    crate::vault_ops::update_entity_db(
+        ctx.db,
+        "_verification_challenges",
+        challenge_id,
+        &json!({"status": "verified", "attempts": new_attempts}),
+    )
+    .await;
+
+    let new_hash = match crate::http::credentials::hash_password(new_password) {
+        Ok(h) => h,
+        Err(e) => {
+            error!("password hashing failed: {e}");
+            return Response::error(mqdb_core::ErrorCode::Internal, "internal error");
+        }
+    };
+
+    crate::vault_ops::update_entity_db(
+        ctx.db,
+        "_credentials",
+        canonical_id,
+        &json!({"password_hash": new_hash}),
+    )
+    .await;
+
+    crate::vault_ops::update_entity_db(
+        ctx.db,
+        "_identities",
+        canonical_id,
+        &json!({"email_verified": true}),
+    )
+    .await;
+
+    Response::ok(json!({"status": "password_reset"}))
 }

--- a/crates/mqdb-agent/src/agent/handlers.rs
+++ b/crates/mqdb-agent/src/agent/handlers.rs
@@ -1765,47 +1765,12 @@ async fn handle_password_reset_start_mqtt(ctx: &AdminContext<'_>, payload: &Valu
         }
     }
 
-    let rng = ring::rand::SystemRandom::new();
-    let mut id_bytes = [0u8; 16];
-    if ring::rand::SecureRandom::fill(&rng, &mut id_bytes).is_err() {
+    let challenge_id = crate::http::challenge_utils::uuid_v4();
+    let Some(code) = crate::http::challenge_utils::generate_verification_code() else {
         return Response::error(mqdb_core::ErrorCode::Internal, "RNG failure");
-    }
-    id_bytes[6] = (id_bytes[6] & 0x0F) | 0x40;
-    id_bytes[8] = (id_bytes[8] & 0x3F) | 0x80;
-    let challenge_id = format!(
-        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-        id_bytes[0],
-        id_bytes[1],
-        id_bytes[2],
-        id_bytes[3],
-        id_bytes[4],
-        id_bytes[5],
-        id_bytes[6],
-        id_bytes[7],
-        id_bytes[8],
-        id_bytes[9],
-        id_bytes[10],
-        id_bytes[11],
-        id_bytes[12],
-        id_bytes[13],
-        id_bytes[14],
-        id_bytes[15]
-    );
-
-    let mut code_bytes = [0u8; 4];
-    if ring::rand::SecureRandom::fill(&rng, &mut code_bytes).is_err() {
-        return Response::error(mqdb_core::ErrorCode::Internal, "RNG failure");
-    }
-    let code_num = u32::from_be_bytes(code_bytes) % 1_000_000;
-    let code = format!("{code_num:06}");
-    let code_hash = {
-        let d = ring::digest::digest(&ring::digest::SHA256, code.as_bytes());
-        crate::http::credentials::hex_encode(d.as_ref())
     };
-
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
+    let code_hash = crate::http::challenge_utils::hash_code(&code);
+    let now = crate::http::challenge_utils::now_unix();
     let expires_at = now + 600;
 
     let challenge_data = json!({
@@ -1936,9 +1901,7 @@ async fn handle_password_reset_submit_mqtt(ctx: &AdminContext<'_>, payload: &Val
         .and_then(|v| v.as_str())
         .and_then(|s| s.parse::<u64>().ok())
         .unwrap_or(0);
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs());
+    let now = crate::http::challenge_utils::now_unix();
     if expires_at > 0 && now >= expires_at {
         crate::vault_ops::update_entity_db(
             ctx.db,
@@ -1970,10 +1933,7 @@ async fn handle_password_reset_submit_mqtt(ctx: &AdminContext<'_>, payload: &Val
     }
 
     let new_attempts = attempts + 1;
-    let submitted_hash = {
-        let d = ring::digest::digest(&ring::digest::SHA256, submitted_code.as_bytes());
-        crate::http::credentials::hex_encode(d.as_ref())
-    };
+    let submitted_hash = crate::http::challenge_utils::hash_code(submitted_code);
     let stored_hash = challenge
         .get("code_hash")
         .and_then(|v| v.as_str())

--- a/crates/mqdb-agent/src/agent/handlers.rs
+++ b/crates/mqdb-agent/src/agent/handlers.rs
@@ -1,6 +1,8 @@
 // Copyright 2025-2026 LabOverWire. All rights reserved.
 // SPDX-License-Identifier: AGPL-3.0-only
 
+use std::sync::Arc;
+
 use crate::database::Database;
 use crate::http::VaultCrypto;
 use crate::vault_transform::{
@@ -63,6 +65,8 @@ pub(super) struct MessageContext<'a> {
     pub vault_min_passphrase_length: usize,
     #[cfg(feature = "http-api")]
     pub vault_unlock_limiter: &'a RateLimiter,
+    #[cfg(feature = "http-api")]
+    pub identity_crypto: Option<&'a Arc<crate::http::IdentityCrypto>>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -91,6 +95,8 @@ pub(super) async fn handle_message(ctx: &MessageContext<'_>, message: Message) {
             vault_min_passphrase_length: ctx.vault_min_passphrase_length,
             #[cfg(feature = "http-api")]
             vault_unlock_limiter: ctx.vault_unlock_limiter,
+            #[cfg(feature = "http-api")]
+            identity_crypto: ctx.identity_crypto,
         };
         handle_admin_operation(&admin_ctx, admin_op).await;
         return;
@@ -408,6 +414,8 @@ struct AdminContext<'a> {
     vault_min_passphrase_length: usize,
     #[cfg(feature = "http-api")]
     vault_unlock_limiter: &'a RateLimiter,
+    #[cfg(feature = "http-api")]
+    identity_crypto: Option<&'a Arc<crate::http::IdentityCrypto>>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -1705,20 +1713,30 @@ async fn handle_password_reset_start_mqtt(ctx: &AdminContext<'_>, payload: &Valu
         return Response::error(mqdb_core::ErrorCode::NotFound, "identity not found");
     };
 
-    let stored_email_hash = identity
-        .get("email_hash")
-        .and_then(|v| v.as_str())
-        .unwrap_or("");
-
-    let computed_hash = crate::http::credentials::compute_email_hash(None, email);
-    if stored_email_hash.is_empty() || computed_hash != stored_email_hash {
+    let email_lower = email.to_lowercase();
+    let email_matches = if let Some(crypto) = ctx.identity_crypto {
+        let computed = crypto.blind_index("_identities", &email_lower);
+        identity
+            .get("email_hash")
+            .and_then(|v| v.as_str())
+            .is_some_and(|stored| stored == computed)
+    } else {
+        identity
+            .get("primary_email")
+            .and_then(|v| v.as_str())
+            .is_some_and(|stored| stored.to_lowercase() == email_lower)
+    };
+    if !email_matches {
         return Response::error(
             mqdb_core::ErrorCode::BadRequest,
             "email does not match identity",
         );
     }
 
-    let target_hash = stored_email_hash.to_string();
+    let target_hash = crate::http::credentials::compute_email_hash(
+        ctx.identity_crypto.map(std::convert::AsRef::as_ref),
+        email,
+    );
 
     if let Some(challenges) = crate::vault_ops::list_entities_db(
         ctx.db,
@@ -1993,13 +2011,33 @@ async fn handle_password_reset_submit_mqtt(ctx: &AdminContext<'_>, payload: &Val
         }
     };
 
-    crate::vault_ops::update_entity_db(
-        ctx.db,
-        "_credentials",
-        canonical_id,
-        &json!({"password_hash": new_hash}),
-    )
-    .await;
+    let target_hash = challenge
+        .get("target_hash")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let existing_creds =
+        crate::vault_ops::read_entity_db(ctx.db, "_credentials", canonical_id).await;
+    if existing_creds.is_some() {
+        crate::vault_ops::update_entity_db(
+            ctx.db,
+            "_credentials",
+            canonical_id,
+            &json!({"password_hash": new_hash}),
+        )
+        .await;
+    } else {
+        crate::vault_ops::create_entity_db(
+            ctx.db,
+            "_credentials",
+            &json!({
+                "id": canonical_id,
+                "password_hash": new_hash,
+                "email_hash": target_hash,
+            }),
+        )
+        .await;
+    }
 
     crate::vault_ops::update_entity_db(
         ctx.db,

--- a/crates/mqdb-agent/src/agent/mod.rs
+++ b/crates/mqdb-agent/src/agent/mod.rs
@@ -41,6 +41,8 @@ pub struct MqdbAgent {
     #[cfg(feature = "http-api")]
     pub(super) vault_unlock_limiter: Arc<RateLimiter>,
     pub(super) vault_min_passphrase_length: usize,
+    #[cfg(feature = "http-api")]
+    pub(super) identity_crypto: Option<Arc<crate::http::IdentityCrypto>>,
     pub(super) license_expires_at: Option<u64>,
     #[cfg(feature = "opentelemetry")]
     pub(super) telemetry_config: Option<mqtt5::telemetry::TelemetryConfig>,
@@ -71,6 +73,8 @@ impl MqdbAgent {
             #[cfg(feature = "http-api")]
             vault_unlock_limiter: Arc::new(RateLimiter::new(10)),
             vault_min_passphrase_length: 0,
+            #[cfg(feature = "http-api")]
+            identity_crypto: None,
             license_expires_at: None,
             #[cfg(feature = "opentelemetry")]
             telemetry_config: None,
@@ -218,7 +222,8 @@ impl MqdbAgent {
 
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
-    pub fn with_http_config(self, config: crate::http::HttpServerConfig) -> Self {
+    pub fn with_http_config(mut self, config: crate::http::HttpServerConfig) -> Self {
+        self.identity_crypto = config.identity_crypto.clone();
         *self.http_config.lock().expect("http_config lock") = Some(config);
         self
     }

--- a/crates/mqdb-agent/src/agent/mod.rs
+++ b/crates/mqdb-agent/src/agent/mod.rs
@@ -223,7 +223,7 @@ impl MqdbAgent {
     #[must_use]
     #[allow(clippy::missing_panics_doc)]
     pub fn with_http_config(mut self, config: crate::http::HttpServerConfig) -> Self {
-        self.identity_crypto = config.identity_crypto.clone();
+        self.identity_crypto.clone_from(&config.identity_crypto);
         *self.http_config.lock().expect("http_config lock") = Some(config);
         self
     }

--- a/crates/mqdb-agent/src/agent/tasks.rs
+++ b/crates/mqdb-agent/src/agent/tasks.rs
@@ -59,6 +59,8 @@ impl MqdbAgent {
         let vault_min_passphrase_length = self.vault_min_passphrase_length;
         #[cfg(feature = "http-api")]
         let vault_unlock_limiter = Arc::clone(&self.vault_unlock_limiter);
+        #[cfg(feature = "http-api")]
+        let identity_crypto = self.identity_crypto.clone();
 
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_millis(100)).await;
@@ -125,6 +127,8 @@ impl MqdbAgent {
                                 vault_min_passphrase_length,
                                 #[cfg(feature = "http-api")]
                                 vault_unlock_limiter: &vault_unlock_limiter,
+                                #[cfg(feature = "http-api")]
+                                identity_crypto: identity_crypto.as_ref(),
                             };
                             handle_message(&ctx, message).await;
                         } else {

--- a/crates/mqdb-agent/src/http/challenge_utils.rs
+++ b/crates/mqdb-agent/src/http/challenge_utils.rs
@@ -1,0 +1,98 @@
+// Copyright 2025-2026 LabOverWire. All rights reserved.
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use ring::digest;
+use ring::rand::{SecureRandom, SystemRandom};
+
+pub(crate) fn uuid_v4() -> String {
+    let rng = SystemRandom::new();
+    let mut bytes = [0u8; 16];
+    rng.fill(&mut bytes)
+        .expect("system RNG unavailable — OS CSPRNG failure");
+    bytes[6] = (bytes[6] & 0x0F) | 0x40;
+    bytes[8] = (bytes[8] & 0x3F) | 0x80;
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[4],
+        bytes[5],
+        bytes[6],
+        bytes[7],
+        bytes[8],
+        bytes[9],
+        bytes[10],
+        bytes[11],
+        bytes[12],
+        bytes[13],
+        bytes[14],
+        bytes[15]
+    )
+}
+
+pub(crate) fn generate_verification_code() -> Option<String> {
+    let rng = SystemRandom::new();
+    let mut bytes = [0u8; 4];
+    rng.fill(&mut bytes).ok()?;
+    let num = u32::from_be_bytes(bytes) % 1_000_000;
+    Some(format!("{num:06}"))
+}
+
+pub(crate) fn hash_code(code: &str) -> String {
+    let d = digest::digest(&digest::SHA256, code.as_bytes());
+    super::credentials::hex_encode(d.as_ref())
+}
+
+pub(crate) fn now_unix() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uuid_v4_has_correct_format() {
+        let id = uuid_v4();
+        assert_eq!(id.len(), 36);
+        assert_eq!(id.as_bytes()[8], b'-');
+        assert_eq!(id.as_bytes()[13], b'-');
+        assert_eq!(id.as_bytes()[14], b'4');
+        assert_eq!(id.as_bytes()[18], b'-');
+        assert_eq!(id.as_bytes()[23], b'-');
+    }
+
+    #[test]
+    fn generate_verification_code_is_six_digits() {
+        let code = generate_verification_code().unwrap();
+        assert_eq!(code.len(), 6);
+        assert!(code.chars().all(|c| c.is_ascii_digit()));
+    }
+
+    #[test]
+    fn hash_code_produces_64_char_hex() {
+        let h = hash_code("123456");
+        assert_eq!(h.len(), 64);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn hash_code_is_deterministic() {
+        assert_eq!(hash_code("test"), hash_code("test"));
+    }
+
+    #[test]
+    fn hash_code_differs_for_different_inputs() {
+        assert_ne!(hash_code("abc"), hash_code("def"));
+    }
+
+    #[test]
+    fn now_unix_returns_reasonable_timestamp() {
+        let ts = now_unix();
+        assert!(ts > 1_700_000_000);
+    }
+}

--- a/crates/mqdb-agent/src/http/handlers.rs
+++ b/crates/mqdb-agent/src/http/handlers.rs
@@ -524,10 +524,10 @@ async fn fetch_picture_from_links(state: &ServerState, canonical_id: &str) -> Op
         if let Some(ref crypto) = state.identity_crypto {
             crypto.decrypt_json_fields("_identity_links", &mut link, &["picture"]);
         }
-        if let Some(pic) = link.get("picture").and_then(|v| v.as_str()) {
-            if !pic.is_empty() {
-                return Some(pic.to_string());
-            }
+        if let Some(pic) = link.get("picture").and_then(|v| v.as_str())
+            && !pic.is_empty()
+        {
+            return Some(pic.to_string());
         }
     }
     None

--- a/crates/mqdb-agent/src/http/handlers.rs
+++ b/crates/mqdb-agent/src/http/handlers.rs
@@ -516,6 +516,22 @@ async fn update_identity_link(state: &ServerState, link_key: &str, identity: &Pr
     }
 }
 
+async fn fetch_picture_from_links(state: &ServerState, canonical_id: &str) -> Option<String> {
+    let filter = format!("canonical_id={canonical_id}");
+    let links = list_entities(&state.mqtt_client, "_identity_links", &filter).await?;
+    for mut link in links {
+        if let Some(ref crypto) = state.identity_crypto {
+            crypto.decrypt_json_fields("_identity_links", &mut link, &["picture"]);
+        }
+        if let Some(pic) = link.get("picture").and_then(|v| v.as_str()) {
+            if !pic.is_empty() {
+                return Some(pic.to_string());
+            }
+        }
+    }
+    None
+}
+
 fn is_safe_filter_value(value: &str) -> bool {
     !value.is_empty() && !value.contains([',', '<', '>', '=', '!', '~', '?'])
 }
@@ -2206,12 +2222,14 @@ pub async fn handle_login(state: &ServerState, body: &[u8], client_ip: &str) -> 
         (None, Some(email.to_string()), false)
     };
 
+    let picture = fetch_picture_from_links(state, canonical_id).await;
+
     let identity = ProviderIdentity {
         provider: "email",
         provider_sub: canonical_id.to_string(),
         email: display_email.clone(),
         name: display_name.clone(),
-        picture: None,
+        picture: picture.clone(),
         email_verified: verified,
     };
     let jwt = mint_callback_jwt(state, canonical_id, &identity);
@@ -2223,7 +2241,7 @@ pub async fn handle_login(state: &ServerState, body: &[u8], client_ip: &str) -> 
         provider_sub: canonical_id.to_string(),
         email: display_email.clone(),
         name: display_name.clone(),
-        picture: None,
+        picture: picture.clone(),
     }) else {
         return json_response_with_credentials(
             500,
@@ -2239,6 +2257,7 @@ pub async fn handle_login(state: &ServerState, body: &[u8], client_ip: &str) -> 
             "canonical_id": canonical_id,
             "email": display_email,
             "name": display_name,
+            "picture": picture,
             "provider": "email",
         }),
         &cookie,

--- a/crates/mqdb-agent/src/http/handlers.rs
+++ b/crates/mqdb-agent/src/http/handlers.rs
@@ -63,7 +63,7 @@ pub struct ServerState {
     pub register_rate_limiter: RateLimiter,
     pub jti_revocation: JtiRevocationStore,
     pub trust_proxy: bool,
-    pub identity_crypto: Option<IdentityCrypto>,
+    pub identity_crypto: Option<Arc<IdentityCrypto>>,
     pub ownership_config: Arc<OwnershipConfig>,
     pub vault_key_store: Arc<VaultKeyStore>,
     pub vault_min_passphrase_length: usize,
@@ -2028,7 +2028,7 @@ pub async fn handle_register(state: &ServerState, body: &[u8], client_ip: &str) 
         );
     }
 
-    let email_hash = credentials::compute_email_hash(state.identity_crypto.as_ref(), email);
+    let email_hash = credentials::compute_email_hash(state.identity_crypto.as_deref(), email);
     let filter = format!("email_hash={email_hash}");
     if let Some(existing) = list_entities(&state.mqtt_client, "_credentials", &filter).await
         && !existing.is_empty()
@@ -2154,7 +2154,7 @@ pub async fn handle_login(state: &ServerState, body: &[u8], client_ip: &str) -> 
         );
     }
 
-    let email_hash = credentials::compute_email_hash(state.identity_crypto.as_ref(), email);
+    let email_hash = credentials::compute_email_hash(state.identity_crypto.as_deref(), email);
     let filter = format!("email_hash={email_hash}");
     let cred_record = match list_entities(&state.mqtt_client, "_credentials", &filter).await {
         Some(records) if !records.is_empty() => records.into_iter().next().unwrap_or_default(),
@@ -2312,7 +2312,7 @@ pub async fn handle_verify_start(
         );
     };
 
-    let target_hash = credentials::compute_email_hash(state.identity_crypto.as_ref(), &email);
+    let target_hash = credentials::compute_email_hash(state.identity_crypto.as_deref(), &email);
 
     expire_pending_challenges(state, &target_hash).await;
 
@@ -2798,7 +2798,7 @@ pub async fn handle_password_reset_start(
         );
     }
 
-    let email_hash = credentials::compute_email_hash(state.identity_crypto.as_ref(), email);
+    let email_hash = credentials::compute_email_hash(state.identity_crypto.as_deref(), email);
 
     let creds = list_entities(
         &state.mqtt_client,
@@ -2807,19 +2807,25 @@ pub async fn handle_password_reset_start(
     )
     .await;
 
-    let canonical_id = creds
+    let canonical_id_from_creds = creds
         .as_ref()
         .and_then(|list| list.first())
-        .and_then(|c| c.get("id").and_then(|v| v.as_str()));
+        .and_then(|c| c.get("id").and_then(|v| v.as_str()))
+        .map(String::from);
 
-    let Some(canonical_id) = canonical_id else {
-        return json_response_with_credentials(
-            200,
-            &json!({"status": "reset_started", "expires_in": 600}),
-            cors,
-        );
+    let canonical_id = match canonical_id_from_creds {
+        Some(id) => id,
+        None => match find_identity_by_email(state, email).await {
+            Some(id) => id,
+            None => {
+                return json_response_with_credentials(
+                    200,
+                    &json!({"status": "reset_started", "expires_in": 600}),
+                    cors,
+                );
+            }
+        },
     };
-    let canonical_id = canonical_id.to_string();
 
     expire_pending_challenges(state, &email_hash).await;
 
@@ -3068,13 +3074,32 @@ pub async fn handle_password_reset_submit(
         }
     };
 
-    update_entity(
-        &state.mqtt_client,
-        "_credentials",
-        canonical_id,
-        &json!({"password_hash": new_hash}),
-    )
-    .await;
+    let target_hash = challenge
+        .get("target_hash")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let existing_creds = read_entity(&state.mqtt_client, "_credentials", canonical_id).await;
+    if existing_creds.is_some() {
+        update_entity(
+            &state.mqtt_client,
+            "_credentials",
+            canonical_id,
+            &json!({"password_hash": new_hash}),
+        )
+        .await;
+    } else {
+        create_entity_with_response(
+            &state.mqtt_client,
+            "_credentials",
+            &json!({
+                "id": canonical_id,
+                "password_hash": new_hash,
+                "email_hash": target_hash,
+            }),
+        )
+        .await;
+    }
 
     update_entity(
         &state.mqtt_client,

--- a/crates/mqdb-agent/src/http/handlers.rs
+++ b/crates/mqdb-agent/src/http/handlers.rs
@@ -70,7 +70,8 @@ pub struct ServerState {
     pub email_auth: bool,
     pub verify_rate_limiter: RateLimiter,
     pub password_change_rate_limiter: RateLimiter,
-    pub password_reset_rate_limiter: RateLimiter,
+    pub password_reset_start_rate_limiter: RateLimiter,
+    pub password_reset_submit_rate_limiter: RateLimiter,
 }
 
 type HttpResponse = Response<Full<Bytes>>;
@@ -1237,31 +1238,7 @@ fn chrono_now_iso() -> String {
 }
 
 fn uuid_v4() -> String {
-    let rng = SystemRandom::new();
-    let mut bytes = [0u8; 16];
-    rng.fill(&mut bytes)
-        .expect("system RNG unavailable — OS CSPRNG failure");
-    bytes[6] = (bytes[6] & 0x0F) | 0x40;
-    bytes[8] = (bytes[8] & 0x3F) | 0x80;
-    format!(
-        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
-        bytes[0],
-        bytes[1],
-        bytes[2],
-        bytes[3],
-        bytes[4],
-        bytes[5],
-        bytes[6],
-        bytes[7],
-        bytes[8],
-        bytes[9],
-        bytes[10],
-        bytes[11],
-        bytes[12],
-        bytes[13],
-        bytes[14],
-        bytes[15]
-    )
+    super::challenge_utils::uuid_v4()
 }
 
 async fn list_entities(
@@ -2807,7 +2784,7 @@ pub async fn handle_password_reset_start(
     };
 
     if !state
-        .password_reset_rate_limiter
+        .password_reset_start_rate_limiter
         .check_and_record(client_ip)
     {
         return json_response_with_credentials(
@@ -2965,7 +2942,7 @@ pub async fn handle_password_reset_submit(
     }
 
     if !state
-        .password_reset_rate_limiter
+        .password_reset_submit_rate_limiter
         .check_and_record(client_ip)
     {
         return json_response_with_credentials(
@@ -3311,16 +3288,11 @@ pub async fn cleanup_expired_challenges(state: &ServerState) {
 }
 
 fn generate_verification_code() -> Option<String> {
-    let rng = SystemRandom::new();
-    let mut bytes = [0u8; 4];
-    rng.fill(&mut bytes).ok()?;
-    let num = u32::from_be_bytes(bytes) % 1_000_000;
-    Some(format!("{num:06}"))
+    super::challenge_utils::generate_verification_code()
 }
 
 fn hash_code(code: &str) -> String {
-    let d = digest::digest(&digest::SHA256, code.as_bytes());
-    credentials::hex_encode(d.as_ref())
+    super::challenge_utils::hash_code(code)
 }
 
 async fn expire_pending_challenges(state: &ServerState, target_hash: &str) {
@@ -3352,63 +3324,5 @@ async fn expire_pending_challenges(state: &ServerState, target_hash: &str) {
 }
 
 fn now_unix() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map_or(0, |d| d.as_secs())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn verification_code_is_six_digits() {
-        for _ in 0..100 {
-            let code = generate_verification_code().unwrap();
-            assert_eq!(code.len(), 6);
-            assert!(code.chars().all(|c| c.is_ascii_digit()));
-        }
-    }
-
-    #[test]
-    fn verification_codes_are_not_constant() {
-        let codes: std::collections::HashSet<String> = (0..20)
-            .filter_map(|_| generate_verification_code())
-            .collect();
-        assert!(codes.len() > 1);
-    }
-
-    #[test]
-    fn hash_code_produces_64_char_hex() {
-        let h = hash_code("123456");
-        assert_eq!(h.len(), 64);
-        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
-    }
-
-    #[test]
-    fn hash_code_is_deterministic() {
-        assert_eq!(hash_code("539666"), hash_code("539666"));
-    }
-
-    #[test]
-    fn hash_code_differs_for_different_inputs() {
-        assert_ne!(hash_code("000000"), hash_code("000001"));
-    }
-
-    #[test]
-    fn hash_code_known_sha256() {
-        let h = hash_code("000000");
-        let expected = "91b4d142823f7d20c5f08df69122de43f35f057a988d9619f6d3138485c9a203";
-        assert_eq!(h, expected);
-    }
-
-    #[test]
-    fn now_unix_returns_reasonable_timestamp() {
-        let ts = now_unix();
-        let expected = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs();
-        assert!(ts >= expected - 1 && ts <= expected + 1);
-    }
+    super::challenge_utils::now_unix()
 }

--- a/crates/mqdb-agent/src/http/handlers.rs
+++ b/crates/mqdb-agent/src/http/handlers.rs
@@ -70,6 +70,7 @@ pub struct ServerState {
     pub email_auth: bool,
     pub verify_rate_limiter: RateLimiter,
     pub password_change_rate_limiter: RateLimiter,
+    pub password_reset_rate_limiter: RateLimiter,
 }
 
 type HttpResponse = Response<Full<Bytes>>;
@@ -2459,6 +2460,14 @@ pub async fn handle_verify_submit(
         );
     }
 
+    if challenge.get("purpose").and_then(|v| v.as_str()) == Some("password_reset") {
+        return json_response_with_credentials(
+            400,
+            &json!({"error": "cannot verify a password reset challenge via this endpoint"}),
+            cors,
+        );
+    }
+
     let status = challenge
         .get("status")
         .and_then(|v| v.as_str())
@@ -2753,6 +2762,329 @@ pub async fn handle_password_change(
     }
 
     json_response_with_credentials(200, &json!({"status": "password changed"}), cors)
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn handle_password_reset_start(
+    state: &ServerState,
+    body: &[u8],
+    client_ip: &str,
+) -> HttpResponse {
+    let cors = state.cors_origin.as_deref();
+
+    if !state.email_auth {
+        return json_response_with_credentials(404, &json!({"error": "not found"}), cors);
+    }
+
+    let body_value: serde_json::Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(_) => {
+            return json_response_with_credentials(400, &json!({"error": "invalid JSON"}), cors);
+        }
+    };
+
+    let Some(email) = body_value.get("email").and_then(|v| v.as_str()) else {
+        return json_response_with_credentials(400, &json!({"error": "missing email field"}), cors);
+    };
+
+    if !state
+        .password_reset_rate_limiter
+        .check_and_record(client_ip)
+    {
+        return json_response_with_credentials(
+            429,
+            &json!({"error": "too many requests, try again later"}),
+            cors,
+        );
+    }
+
+    let email_hash = credentials::compute_email_hash(state.identity_crypto.as_ref(), email);
+
+    let creds = list_entities(
+        &state.mqtt_client,
+        "_credentials",
+        &format!("email_hash={email_hash}"),
+    )
+    .await;
+
+    let canonical_id = creds
+        .as_ref()
+        .and_then(|list| list.first())
+        .and_then(|c| c.get("id").and_then(|v| v.as_str()));
+
+    let Some(canonical_id) = canonical_id else {
+        return json_response_with_credentials(
+            200,
+            &json!({"status": "reset_started", "expires_in": 600}),
+            cors,
+        );
+    };
+    let canonical_id = canonical_id.to_string();
+
+    expire_pending_challenges(state, &email_hash).await;
+
+    let challenge_id = uuid_v4();
+    let now = now_unix();
+    let expires_at = now + 600;
+
+    let Some(code) = generate_verification_code() else {
+        return json_response_with_credentials(
+            500,
+            &json!({"error": "failed to generate verification code"}),
+            cors,
+        );
+    };
+    let code_hash = hash_code(&code);
+
+    let challenge_data = json!({
+        "id": challenge_id,
+        "canonical_id": canonical_id,
+        "method": "email",
+        "target_hash": email_hash,
+        "code_hash": code_hash,
+        "status": "pending",
+        "mode": "code",
+        "purpose": "password_reset",
+        "attempts": 0,
+        "max_attempts": 5,
+        "created_at": now.to_string(),
+        "expires_at": expires_at.to_string(),
+    });
+
+    if create_entity_with_response(
+        &state.mqtt_client,
+        "_verification_challenges",
+        &challenge_data,
+    )
+    .await
+    .is_none()
+    {
+        return json_response_with_credentials(
+            500,
+            &json!({"error": "failed to create reset challenge"}),
+            cors,
+        );
+    }
+
+    let notification = json!({
+        "challenge_id": challenge_id,
+        "method": "email",
+        "mode": "code",
+        "purpose": "password_reset",
+        "target": email,
+        "code": code,
+        "expires_at": expires_at.to_string(),
+    });
+
+    let notify_payload = serde_json::to_vec(&notification).unwrap_or_default();
+    if let Err(e) = state
+        .mqtt_client
+        .publish("$DB/_verify/challenges/email", notify_payload)
+        .await
+    {
+        warn!(error = %e, "failed to publish password reset challenge notification");
+    }
+
+    json_response_with_credentials(
+        200,
+        &json!({
+            "status": "reset_started",
+            "challenge_id": challenge_id,
+            "expires_in": 600,
+        }),
+        cors,
+    )
+}
+
+#[allow(clippy::too_many_lines)]
+pub async fn handle_password_reset_submit(
+    state: &ServerState,
+    body: &[u8],
+    client_ip: &str,
+) -> HttpResponse {
+    let cors = state.cors_origin.as_deref();
+
+    if !state.email_auth {
+        return json_response_with_credentials(404, &json!({"error": "not found"}), cors);
+    }
+
+    let body_value: serde_json::Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(_) => {
+            return json_response_with_credentials(400, &json!({"error": "invalid JSON"}), cors);
+        }
+    };
+
+    let Some(challenge_id) = body_value.get("challenge_id").and_then(|v| v.as_str()) else {
+        return json_response_with_credentials(
+            400,
+            &json!({"error": "missing challenge_id field"}),
+            cors,
+        );
+    };
+
+    let Some(submitted_code) = body_value.get("code").and_then(|v| v.as_str()) else {
+        return json_response_with_credentials(400, &json!({"error": "missing code field"}), cors);
+    };
+
+    let Some(new_password) = body_value.get("new_password").and_then(|v| v.as_str()) else {
+        return json_response_with_credentials(
+            400,
+            &json!({"error": "missing new_password field"}),
+            cors,
+        );
+    };
+
+    if let Err(e) = credentials::validate_password(new_password) {
+        return json_response_with_credentials(400, &json!({"error": e}), cors);
+    }
+
+    if !state
+        .password_reset_rate_limiter
+        .check_and_record(client_ip)
+    {
+        return json_response_with_credentials(
+            429,
+            &json!({"error": "too many requests, try again later"}),
+            cors,
+        );
+    }
+
+    let Some(challenge) =
+        read_entity(&state.mqtt_client, "_verification_challenges", challenge_id).await
+    else {
+        return json_response_with_credentials(404, &json!({"error": "challenge not found"}), cors);
+    };
+
+    let purpose = challenge
+        .get("purpose")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if purpose != "password_reset" {
+        return json_response_with_credentials(
+            400,
+            &json!({"error": "invalid challenge type"}),
+            cors,
+        );
+    }
+
+    let status = challenge
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    if status != "pending" && status != "delivered" {
+        return json_response_with_credentials(
+            400,
+            &json!({"error": format!("challenge is {status}")}),
+            cors,
+        );
+    }
+
+    let expires_at = challenge
+        .get("expires_at")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(0);
+    if expires_at > 0 && now_unix() >= expires_at {
+        update_entity(
+            &state.mqtt_client,
+            "_verification_challenges",
+            challenge_id,
+            &json!({"status": "expired"}),
+        )
+        .await;
+        return json_response_with_credentials(
+            400,
+            &json!({"error": "challenge has expired"}),
+            cors,
+        );
+    }
+
+    let attempts = challenge
+        .get("attempts")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(0);
+    let max_attempts = challenge
+        .get("max_attempts")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(5);
+    if attempts >= max_attempts {
+        update_entity(
+            &state.mqtt_client,
+            "_verification_challenges",
+            challenge_id,
+            &json!({"status": "failed"}),
+        )
+        .await;
+        return json_response_with_credentials(400, &json!({"error": "too many attempts"}), cors);
+    }
+
+    let new_attempts = attempts + 1;
+    let submitted_hash = hash_code(submitted_code);
+    let stored_hash = challenge
+        .get("code_hash")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    if submitted_hash != stored_hash {
+        let new_status = if new_attempts >= max_attempts {
+            "failed"
+        } else {
+            status
+        };
+        update_entity(
+            &state.mqtt_client,
+            "_verification_challenges",
+            challenge_id,
+            &json!({"attempts": new_attempts, "status": new_status}),
+        )
+        .await;
+        let remaining = max_attempts.saturating_sub(new_attempts);
+        return json_response_with_credentials(
+            401,
+            &json!({"error": "invalid code", "attempts_remaining": remaining}),
+            cors,
+        );
+    }
+
+    update_entity(
+        &state.mqtt_client,
+        "_verification_challenges",
+        challenge_id,
+        &json!({"status": "verified", "attempts": new_attempts}),
+    )
+    .await;
+
+    let canonical_id = challenge
+        .get("canonical_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let new_hash = match credentials::hash_password(new_password) {
+        Ok(h) => h,
+        Err(e) => {
+            error!(error = %e, "password hashing failed during password reset");
+            return json_response_with_credentials(500, &json!({"error": "internal error"}), cors);
+        }
+    };
+
+    update_entity(
+        &state.mqtt_client,
+        "_credentials",
+        canonical_id,
+        &json!({"password_hash": new_hash}),
+    )
+    .await;
+
+    update_entity(
+        &state.mqtt_client,
+        "_identities",
+        canonical_id,
+        &json!({"email_verified": true}),
+    )
+    .await;
+
+    json_response_with_credentials(200, &json!({"status": "password_reset"}), cors)
 }
 
 #[cfg(feature = "dev-insecure")]

--- a/crates/mqdb-agent/src/http/mod.rs
+++ b/crates/mqdb-agent/src/http/mod.rs
@@ -1,6 +1,7 @@
 // Copyright 2025-2026 LabOverWire. All rights reserved.
 // SPDX-License-Identifier: AGPL-3.0-only
 
+pub(crate) mod challenge_utils;
 mod cookies;
 pub(crate) mod credentials;
 mod handlers;

--- a/crates/mqdb-agent/src/http/server.rs
+++ b/crates/mqdb-agent/src/http/server.rs
@@ -71,6 +71,7 @@ impl HttpServer {
             .config
             .vault_key_store
             .unwrap_or_else(|| Arc::new(VaultKeyStore::new()));
+        let no_rate_limit = self.config.vault_unlock_rate_limit == u32::MAX;
         let state = Arc::new(ServerState {
             provider_registry: self.config.provider_registry,
             jwt_config: self.config.jwt_config,
@@ -83,8 +84,8 @@ impl HttpServer {
             cors_origin: self.config.cors_origin,
             ticket_rate_limiter: RateLimiter::new(self.config.ticket_rate_limit),
             vault_unlock_limiter: RateLimiter::new(self.config.vault_unlock_rate_limit),
-            login_rate_limiter: RateLimiter::new(10),
-            register_rate_limiter: RateLimiter::new(5),
+            login_rate_limiter: RateLimiter::new(if no_rate_limit { u32::MAX } else { 10 }),
+            register_rate_limiter: RateLimiter::new(if no_rate_limit { u32::MAX } else { 5 }),
             jti_revocation: JtiRevocationStore::new(),
             trust_proxy: self.config.trust_proxy,
             identity_crypto: self.config.identity_crypto,
@@ -92,9 +93,13 @@ impl HttpServer {
             vault_key_store,
             vault_min_passphrase_length: self.config.vault_min_passphrase_length,
             email_auth: self.config.email_auth,
-            verify_rate_limiter: RateLimiter::new(3),
-            password_change_rate_limiter: RateLimiter::new(5),
-            password_reset_rate_limiter: RateLimiter::new(3),
+            verify_rate_limiter: RateLimiter::new(if no_rate_limit { u32::MAX } else { 3 }),
+            password_change_rate_limiter: RateLimiter::new(if no_rate_limit {
+                u32::MAX
+            } else {
+                5
+            }),
+            password_reset_rate_limiter: RateLimiter::new(if no_rate_limit { u32::MAX } else { 3 }),
         });
 
         initialize_identity_constraints(&state).await;

--- a/crates/mqdb-agent/src/http/server.rs
+++ b/crates/mqdb-agent/src/http/server.rs
@@ -33,7 +33,7 @@ pub struct HttpServerConfig {
     pub cors_origin: Option<String>,
     pub ticket_rate_limit: u32,
     pub trust_proxy: bool,
-    pub identity_crypto: Option<IdentityCrypto>,
+    pub identity_crypto: Option<Arc<IdentityCrypto>>,
     pub ownership_config: Arc<OwnershipConfig>,
     pub vault_key_store: Option<Arc<VaultKeyStore>>,
     pub vault_unlock_rate_limit: u32,

--- a/crates/mqdb-agent/src/http/server.rs
+++ b/crates/mqdb-agent/src/http/server.rs
@@ -99,7 +99,16 @@ impl HttpServer {
             } else {
                 5
             }),
-            password_reset_rate_limiter: RateLimiter::new(if no_rate_limit { u32::MAX } else { 3 }),
+            password_reset_start_rate_limiter: RateLimiter::new(if no_rate_limit {
+                u32::MAX
+            } else {
+                3
+            }),
+            password_reset_submit_rate_limiter: RateLimiter::new(if no_rate_limit {
+                u32::MAX
+            } else {
+                5
+            }),
         });
 
         initialize_identity_constraints(&state).await;

--- a/crates/mqdb-agent/src/http/server.rs
+++ b/crates/mqdb-agent/src/http/server.rs
@@ -94,6 +94,7 @@ impl HttpServer {
             email_auth: self.config.email_auth,
             verify_rate_limiter: RateLimiter::new(3),
             password_change_rate_limiter: RateLimiter::new(5),
+            password_reset_rate_limiter: RateLimiter::new(3),
         });
 
         initialize_identity_constraints(&state).await;
@@ -196,6 +197,8 @@ async fn handle_request(
             | "/auth/verify/submit"
             | "/auth/verify/status"
             | "/auth/password/change"
+            | "/auth/password/reset/start"
+            | "/auth/password/reset/submit"
             | "/vault/enable"
             | "/vault/unlock"
             | "/vault/lock"
@@ -265,6 +268,24 @@ async fn handle_request(
                 .map(http_body_util::Collected::to_bytes)
                 .unwrap_or_default();
             handlers::handle_password_change(&state, &headers, &body).await
+        }
+        (&Method::POST, "/auth/password/reset/start") => {
+            let body = req
+                .collect()
+                .await
+                .map(http_body_util::Collected::to_bytes)
+                .unwrap_or_default();
+            let ip = client_ip(&headers, peer_addr, state.trust_proxy);
+            handlers::handle_password_reset_start(&state, &body, &ip).await
+        }
+        (&Method::POST, "/auth/password/reset/submit") => {
+            let body = req
+                .collect()
+                .await
+                .map(http_body_util::Collected::to_bytes)
+                .unwrap_or_default();
+            let ip = client_ip(&headers, peer_addr, state.trust_proxy);
+            handlers::handle_password_reset_submit(&state, &body, &ip).await
         }
         (&Method::POST, "/auth/unlink") => {
             let body = req

--- a/crates/mqdb-agent/src/topic_protection.rs
+++ b/crates/mqdb-agent/src/topic_protection.rs
@@ -216,6 +216,41 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn internal_service_bypasses_verify_topics() {
+        let provider = create_test_provider_with_internal("mqdb-internal-abc123");
+
+        let result = provider
+            .authorize_publish(
+                "mqdb-http-oauth",
+                Some("mqdb-internal-abc123"),
+                "$DB/_verify/challenges/email",
+            )
+            .await;
+        assert!(result);
+
+        let result = provider
+            .authorize_subscribe(
+                "mqdb-http-oauth",
+                Some("mqdb-internal-abc123"),
+                "$DB/_verify/receipts/#",
+            )
+            .await;
+        assert!(result);
+
+        let external = create_test_provider(HashSet::new());
+
+        let result = external
+            .authorize_publish("client-1", Some("alice"), "$DB/_verify/receipts/abc-123")
+            .await;
+        assert!(!result);
+
+        let result = external
+            .authorize_subscribe("client-1", Some("alice"), "$DB/_verify/challenges/email")
+            .await;
+        assert!(!result);
+    }
+
+    #[tokio::test]
     async fn spoofed_client_id_blocked() {
         let provider = create_test_provider_with_internal("mqdb-internal-abc123");
 

--- a/crates/mqdb-agent/src/topic_protection.rs
+++ b/crates/mqdb-agent/src/topic_protection.rs
@@ -1,7 +1,7 @@
 // Copyright 2025-2026 LabOverWire. All rights reserved.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use crate::topic_rules::check_topic_access;
+use crate::topic_rules::{BlockReason, check_topic_access};
 use mqtt5::broker::auth::{AuthProvider, AuthResult, EnhancedAuthResult};
 use mqtt5::error::Result;
 use mqtt5::packet::connect::ConnectPacket;
@@ -100,6 +100,20 @@ impl AuthProvider for TopicProtectionAuthProvider {
             }
 
             if let Err(reason) = check_topic_access(topic, true, is_admin) {
+                if reason == BlockReason::AdminRequired {
+                    let allowed = self
+                        .inner
+                        .authorize_publish(&client_id_owned, user_id, topic)
+                        .await;
+                    if !allowed {
+                        debug!(
+                            client_id = %client_id_owned,
+                            topic = %topic,
+                            "publish on AdminRequired topic denied by ACL"
+                        );
+                    }
+                    return allowed;
+                }
                 debug!(
                     client_id = %client_id_owned,
                     topic = %topic,
@@ -134,6 +148,20 @@ impl AuthProvider for TopicProtectionAuthProvider {
             }
 
             if let Err(reason) = check_topic_access(topic_filter, false, is_admin) {
+                if reason == BlockReason::AdminRequired {
+                    let allowed = self
+                        .inner
+                        .authorize_subscribe(&client_id_owned, user_id, topic_filter)
+                        .await;
+                    if !allowed {
+                        debug!(
+                            client_id = %client_id_owned,
+                            topic_filter = %topic_filter,
+                            "subscribe on AdminRequired topic denied by ACL"
+                        );
+                    }
+                    return allowed;
+                }
                 debug!(
                     client_id = %client_id_owned,
                     topic_filter = %topic_filter,
@@ -187,8 +215,42 @@ mod tests {
     use super::*;
     use mqtt5::broker::auth::AllowAllAuthProvider;
 
+    struct DenyAllAuthProvider;
+
+    impl AuthProvider for DenyAllAuthProvider {
+        fn authenticate<'a>(
+            &'a self,
+            _connect: &'a ConnectPacket,
+            _client_addr: SocketAddr,
+        ) -> Pin<Box<dyn Future<Output = Result<AuthResult>> + Send + 'a>> {
+            Box::pin(async { Ok(AuthResult::success()) })
+        }
+
+        fn authorize_publish<'a>(
+            &'a self,
+            _client_id: &str,
+            _user_id: Option<&'a str>,
+            _topic: &'a str,
+        ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+            Box::pin(async { false })
+        }
+
+        fn authorize_subscribe<'a>(
+            &'a self,
+            _client_id: &str,
+            _user_id: Option<&'a str>,
+            _topic_filter: &'a str,
+        ) -> Pin<Box<dyn Future<Output = bool> + Send + 'a>> {
+            Box::pin(async { false })
+        }
+    }
+
     fn create_test_provider(admin_users: HashSet<String>) -> TopicProtectionAuthProvider {
         TopicProtectionAuthProvider::new(Arc::new(AllowAllAuthProvider), admin_users)
+    }
+
+    fn create_deny_provider() -> TopicProtectionAuthProvider {
+        TopicProtectionAuthProvider::new(Arc::new(DenyAllAuthProvider), HashSet::new())
     }
 
     fn create_test_provider_with_internal(internal_username: &str) -> TopicProtectionAuthProvider {
@@ -236,16 +298,58 @@ mod tests {
             )
             .await;
         assert!(result);
+    }
 
-        let external = create_test_provider(HashSet::new());
+    #[tokio::test]
+    async fn acl_grant_allows_admin_required_topics() {
+        let provider = create_test_provider(HashSet::new());
 
-        let result = external
+        let result = provider
+            .authorize_publish(
+                "client-1",
+                Some("email-verifier"),
+                "$DB/_verify/challenges/email",
+            )
+            .await;
+        assert!(result);
+
+        let result = provider
+            .authorize_subscribe("client-1", Some("email-verifier"), "$DB/_verify/receipts/#")
+            .await;
+        assert!(result);
+    }
+
+    #[tokio::test]
+    async fn no_acl_grant_blocks_admin_required_topics() {
+        let provider = create_deny_provider();
+
+        let result = provider
             .authorize_publish("client-1", Some("alice"), "$DB/_verify/receipts/abc-123")
             .await;
         assert!(!result);
 
-        let result = external
+        let result = provider
             .authorize_subscribe("client-1", Some("alice"), "$DB/_verify/challenges/email")
+            .await;
+        assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn acl_grant_does_not_bypass_hard_blocks() {
+        let provider = create_test_provider(HashSet::new());
+
+        let result = provider
+            .authorize_publish("client-1", Some("alice"), "_mqdb/cluster/heartbeat")
+            .await;
+        assert!(!result);
+
+        let result = provider
+            .authorize_subscribe("client-1", Some("alice"), "$DB/_idx/users")
+            .await;
+        assert!(!result);
+
+        let result = provider
+            .authorize_subscribe("client-1", Some("alice"), "$DB/_sessions/list")
             .await;
         assert!(!result);
     }
@@ -322,10 +426,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn non_admin_user_blocked_on_admin_topics() {
-        let mut admin_users = HashSet::new();
-        admin_users.insert("admin".to_string());
-        let provider = create_test_provider(admin_users);
+    async fn non_admin_user_blocked_on_admin_topics_without_acl() {
+        let provider = create_deny_provider();
 
         let result = provider
             .authorize_publish("client-1", Some("regular"), "$DB/_admin/backup")

--- a/crates/mqdb-agent/src/topic_rules.rs
+++ b/crates/mqdb-agent/src/topic_rules.rs
@@ -58,6 +58,10 @@ pub const PROTECTED_TOPICS: &[TopicRule] = &[
         tier: ProtectionTier::AdminRequired,
     },
     TopicRule {
+        pattern: "$DB/_verify/#",
+        tier: ProtectionTier::AdminRequired,
+    },
+    TopicRule {
         pattern: "$DB/_oauth_tokens/#",
         tier: ProtectionTier::AdminRequired,
     },
@@ -156,17 +160,11 @@ fn is_internal_entity_topic(topic: &str) -> bool {
         return false;
     }
     let rest = &topic[4..];
-    if rest.starts_with('_')
-        && !rest.starts_with("_health")
-        && !rest.starts_with("_vault")
-        && !rest.starts_with("_verify")
-        && !rest.starts_with("_auth")
-    {
-        let entity = rest.split('/').next().unwrap_or("");
-        !entity.is_empty() && entity.starts_with('_')
-    } else {
-        false
+    let entity = rest.split('/').next().unwrap_or("");
+    if !entity.starts_with('_') || entity.is_empty() {
+        return false;
     }
+    !matches!(entity, "_health" | "_vault" | "_auth" | "_verify")
 }
 
 /// # Errors
@@ -516,17 +514,65 @@ mod tests {
     }
 
     #[test]
-    fn check_access_verify_endpoints_allowed() {
+    fn prefix_lookalikes_blocked_for_non_admin() {
+        assert_eq!(
+            check_topic_access("$DB/_healthcheck/list", false, false),
+            Err(BlockReason::InternalEntityAccess)
+        );
+        assert_eq!(
+            check_topic_access("$DB/_healthy/data", true, false),
+            Err(BlockReason::InternalEntityAccess)
+        );
+        assert_eq!(
+            check_topic_access("$DB/_vaulted/secrets", true, false),
+            Err(BlockReason::InternalEntityAccess)
+        );
+        assert_eq!(
+            check_topic_access("$DB/_authentication/tokens", false, false),
+            Err(BlockReason::InternalEntityAccess)
+        );
+        assert_eq!(
+            check_topic_access("$DB/_authority/keys", true, false),
+            Err(BlockReason::InternalEntityAccess)
+        );
+        assert_eq!(
+            check_topic_access("$DB/_verifier/status", false, false),
+            Err(BlockReason::InternalEntityAccess)
+        );
+    }
+
+    #[test]
+    fn check_access_verify_endpoints_admin_required() {
         assert_eq!(
             check_topic_access("$DB/_verify/challenges/email", true, false),
-            Ok(())
+            Err(BlockReason::AdminRequired)
         );
         assert_eq!(
             check_topic_access("$DB/_verify/challenges/email", false, false),
+            Err(BlockReason::AdminRequired)
+        );
+        assert_eq!(
+            check_topic_access("$DB/_verify/receipts/abc-123", true, false),
+            Err(BlockReason::AdminRequired)
+        );
+        assert_eq!(
+            check_topic_access("$DB/_verify/receipts/abc-123", false, false),
+            Err(BlockReason::AdminRequired)
+        );
+        assert_eq!(
+            check_topic_access("$DB/_verify/challenges/email", true, true),
             Ok(())
         );
         assert_eq!(
-            check_topic_access("$DB/_verify/confirm", true, false),
+            check_topic_access("$DB/_verify/challenges/email", false, true),
+            Ok(())
+        );
+        assert_eq!(
+            check_topic_access("$DB/_verify/receipts/abc-123", true, true),
+            Ok(())
+        );
+        assert_eq!(
+            check_topic_access("$DB/_verify/receipts/abc-123", false, true),
             Ok(())
         );
     }

--- a/crates/mqdb-agent/src/vault_ops.rs
+++ b/crates/mqdb-agent/src/vault_ops.rs
@@ -372,6 +372,13 @@ pub async fn resume_pending_migration(
     })
 }
 
+pub async fn create_entity_db(db: &Database, entity: &str, data: &Value) -> bool {
+    let scope = ScopeConfig::default();
+    db.create(entity.to_string(), data.clone(), None, None, None, &scope)
+        .await
+        .is_ok()
+}
+
 pub async fn read_entity_db(db: &Database, entity: &str, id: &str) -> Option<Value> {
     db.read(entity.to_string(), id.to_string(), vec![], None)
         .await

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.6.0"
+version = "0.7.0"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/crates/mqdb-cli/src/commands/agent.rs
+++ b/crates/mqdb-cli/src/commands/agent.rs
@@ -357,7 +357,7 @@ pub(crate) fn build_http_config(
         .unwrap_or_else(|| "mqdb".to_string());
     let audience = auth.jwt_audience.clone().or(client_id);
 
-    let identity_crypto = build_identity_crypto(oauth, db_path)?;
+    let identity_crypto = build_identity_crypto(oauth, db_path)?.map(std::sync::Arc::new);
 
     Ok(mqdb_agent::http::HttpServerConfig {
         bind_address: http_bind,

--- a/crates/mqdb-core/Cargo.toml
+++ b/crates/mqdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-core"
-version = "0.4.0"
+version = "0.5.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/mqdb-core/src/protocol/mod.rs
+++ b/crates/mqdb-core/src/protocol/mod.rs
@@ -79,6 +79,8 @@ pub enum AdminOperation {
     VaultChange,
     VaultStatus,
     PasswordChange,
+    PasswordResetStart,
+    PasswordResetSubmit,
 }
 
 type ListOptions = (
@@ -124,6 +126,8 @@ pub fn parse_admin_topic(topic: &str) -> Option<AdminOperation> {
     if let Some(rest) = topic.strip_prefix("$DB/_auth/") {
         return match rest {
             "password/change" => Some(AdminOperation::PasswordChange),
+            "password/reset/start" => Some(AdminOperation::PasswordResetStart),
+            "password/reset/submit" => Some(AdminOperation::PasswordResetSubmit),
             _ => None,
         };
     }
@@ -514,7 +518,16 @@ mod tests {
             parse_admin_topic("$DB/_auth/password/change"),
             Some(AdminOperation::PasswordChange)
         ));
+        assert!(matches!(
+            parse_admin_topic("$DB/_auth/password/reset/start"),
+            Some(AdminOperation::PasswordResetStart)
+        ));
+        assert!(matches!(
+            parse_admin_topic("$DB/_auth/password/reset/submit"),
+            Some(AdminOperation::PasswordResetSubmit)
+        ));
         assert!(parse_admin_topic("$DB/_auth/unknown").is_none());
+        assert!(parse_admin_topic("$DB/_auth/password/reset/other").is_none());
     }
 
     #[test]

--- a/crates/mqdb-wasm/Cargo.lock
+++ b/crates/mqdb-wasm/Cargo.lock
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/docs/testing/13-http-api.md
+++ b/docs/testing/13-http-api.md
@@ -391,7 +391,7 @@ Reset password for email-auth users who forgot their password. HTTP endpoints ar
 
 ### Prerequisites
 
-Use the same agent setup as section 27 (Email Verification). Register a user and complete email verification first. Subscribe to `$DB/_verify/challenges/email` in a background terminal to capture verification codes.
+Use the same agent setup as section 27 (Email Verification). Register a user and complete email verification first. Subscribe to `$DB/_verify/challenges/email` in a background terminal to capture verification codes; the subscription must use admin credentials (e.g. `mosquitto_sub -u admin -P admin123 -t '$DB/_verify/challenges/email'`) because the verification namespace is admin-protected.
 
 ### Start Password Reset (HTTP)
 

--- a/docs/testing/13-http-api.md
+++ b/docs/testing/13-http-api.md
@@ -385,6 +385,147 @@ Expected: successful login with session cookie.
 
 ---
 
+## 28.5. Password Reset
+
+Reset password for email-auth users who forgot their password. HTTP endpoints are unauthenticated (classic "forgot password" flow). MQTT endpoints are authenticated (for OAuth users adding/resetting a password).
+
+### Prerequisites
+
+Use the same agent setup as section 27 (Email Verification). Register a user and complete email verification first. Subscribe to `$DB/_verify/challenges/email` in a background terminal to capture verification codes.
+
+### Start Password Reset (HTTP)
+
+```bash
+curl -s -X POST http://127.0.0.1:3000/auth/password/reset/start \
+    -H 'Content-Type: application/json' \
+    -d '{"email":"user@example.com"}'
+```
+
+Expected: `{"status":"reset_started","challenge_id":"<uuid>","expires_in":600}`
+
+### Enumeration Prevention
+
+When using a non-existent email, the response shape is the same but without a challenge_id:
+
+```bash
+curl -s -X POST http://127.0.0.1:3000/auth/password/reset/start \
+    -H 'Content-Type: application/json' \
+    -d '{"email":"nonexistent@example.com"}'
+```
+
+Expected: `{"status":"reset_started","expires_in":600}`
+
+### Submit Reset Code (HTTP)
+
+Extract the verification code from the challenge notification on `$DB/_verify/challenges/email`, then submit:
+
+```bash
+curl -s -X POST http://127.0.0.1:3000/auth/password/reset/submit \
+    -H 'Content-Type: application/json' \
+    -d '{"challenge_id":"<uuid>","code":"<6-digit-code>","new_password":"newpass456"}'
+```
+
+Expected: `{"status":"password_reset"}`
+
+### Wrong Code
+
+```bash
+curl -s -X POST http://127.0.0.1:3000/auth/password/reset/submit \
+    -H 'Content-Type: application/json' \
+    -d '{"challenge_id":"<uuid>","code":"000000","new_password":"newpass456"}'
+```
+
+Expected: HTTP 401 `{"error":"invalid code"}`
+
+### New Password Too Short
+
+```bash
+curl -s -X POST http://127.0.0.1:3000/auth/password/reset/submit \
+    -H 'Content-Type: application/json' \
+    -d '{"challenge_id":"<uuid>","code":"<code>","new_password":"short"}'
+```
+
+Expected: HTTP 400 `{"error":"password must be at least 8 characters"}`
+
+### Expired Challenge
+
+After 10 minutes (or with a manipulated challenge), the code is rejected:
+
+Expected: HTTP 400 `{"error":"challenge expired"}`
+
+### Purpose Guard: Reset Challenge on Verify Endpoint
+
+A password reset challenge cannot be used on the email verification endpoint:
+
+```bash
+curl -s -b "session=$SESSION" -X POST http://127.0.0.1:3000/auth/verify/submit \
+    -H 'Content-Type: application/json' \
+    -d '{"challenge_id":"<reset-challenge-id>","code":"<code>"}'
+```
+
+Expected: HTTP 400 `{"error":"cannot verify a password reset challenge via this endpoint"}`
+
+### Start Password Reset (MQTT)
+
+```bash
+mosquitto_rr -h 127.0.0.1 -p 1883 -u admin -P admin123 \
+    -t '$DB/_auth/password/reset/start' -e 'resp/test' -W 5 \
+    -m '{"email":"user@example.com"}'
+```
+
+Expected: `{"status":"ok","data":{"status":"reset_started","challenge_id":"<uuid>","expires_in":600}}`
+
+### Submit Password Reset (MQTT)
+
+```bash
+mosquitto_rr -h 127.0.0.1 -p 1883 -u admin -P admin123 \
+    -t '$DB/_auth/password/reset/submit' -e 'resp/test' -W 5 \
+    -m '{"challenge_id":"<uuid>","code":"<code>","new_password":"newpass456"}'
+```
+
+Expected: `{"status":"ok","data":{"status":"password_reset"}}`
+
+### Login With New Password
+
+After resetting, verify the old password no longer works and the new one does:
+
+```bash
+curl -s -X POST http://127.0.0.1:3000/auth/login \
+    -H 'Content-Type: application/json' \
+    -d '{"email":"user@example.com","password":"newpass456"}'
+```
+
+Expected: successful login with session cookie.
+
+### Rate Limiting
+
+HTTP: 3 requests per minute per client IP.
+MQTT: shares the vault unlock rate limiter.
+
+### Verification Checklist
+
+- [ ] `POST /auth/password/reset/start` returns reset_started with challenge_id for existing email
+- [ ] Returns reset_started without challenge_id for non-existent email (enumeration prevention)
+- [ ] Returns 400 when email field is missing
+- [ ] Returns 404 when email-auth is disabled
+- [ ] Challenge notification published to `$DB/_verify/challenges/email` with `purpose: password_reset`
+- [ ] `POST /auth/password/reset/submit` returns password_reset with correct code
+- [ ] Returns 401 with wrong code, attempts increment
+- [ ] Returns 400 with new password shorter than 8 characters
+- [ ] Returns 400 for expired challenge
+- [ ] Returns 400 when using an email verification challenge on reset submit
+- [ ] Purpose guard: reset challenge rejected on `POST /auth/verify/submit`
+- [ ] `email_verified` set to `true` after successful reset
+- [ ] Login works with new password after reset
+- [ ] Login fails with old password after reset
+- [ ] Rate limited after 3 attempts per minute (HTTP)
+- [ ] MQTT `$DB/_auth/password/reset/start` works with same logic
+- [ ] MQTT `$DB/_auth/password/reset/submit` works with same logic
+- [ ] MQTT handler verifies email matches authenticated user's identity
+- [ ] Cluster mode rejects with "auth endpoints not supported in cluster mode"
+
+---
+
 ## 29. Additional Admin MQTT Endpoints
 
 ### Entity Catalog

--- a/examples/password-reset/run.sh
+++ b/examples/password-reset/run.sh
@@ -1,0 +1,507 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MQDB_BIN="$REPO_ROOT/target/release/mqdb"
+TEST_DIR="/tmp/password-reset-e2e-test"
+AGENT_PID=""
+SUB_PID=""
+PASS=0
+FAIL=0
+TOTAL=37
+
+cleanup() {
+    if [[ -n "$SUB_PID" ]]; then
+        kill "$SUB_PID" 2>/dev/null || true
+        wait "$SUB_PID" 2>/dev/null || true
+    fi
+    if [[ -n "$AGENT_PID" ]]; then
+        kill "$AGENT_PID" 2>/dev/null || true
+        wait "$AGENT_PID" 2>/dev/null || true
+    fi
+    rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+json_field() {
+    local json="$1" path="$2"
+    python3 -c "
+import sys, json
+try:
+    d = json.loads(sys.argv[1])
+    keys = sys.argv[2].split('.')
+    for k in keys:
+        if isinstance(d, list):
+            d = d[int(k)]
+        elif isinstance(d, dict):
+            d = d[k]
+        else:
+            print('__PARSE_ERROR__')
+            sys.exit(0)
+    if d is None:
+        print('__NULL__')
+    else:
+        print(d)
+except (json.JSONDecodeError, KeyError, IndexError, TypeError, ValueError):
+    print('__PARSE_ERROR__')
+" "$json" "$path" 2>/dev/null
+}
+
+assert_eq() {
+    local label="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "__PARSE_ERROR__" ]]; then
+        echo "  FAIL: $label (JSON parse error)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_neq() {
+    local label="$1" actual="$2" unexpected="$3"
+    if [[ "$actual" == "__PARSE_ERROR__" ]]; then
+        echo "  FAIL: $label (JSON parse error)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if [[ -z "$actual" ]]; then
+        echo "  FAIL: $label (empty value)"
+        FAIL=$((FAIL + 1))
+        return
+    fi
+    if [[ "$actual" != "$unexpected" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    should NOT equal: $unexpected"
+        echo "    actual:           $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_contains() {
+    local label="$1" haystack="$2" needle="$3"
+    if [[ "$haystack" == *"$needle"* ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    expected to contain: $needle"
+        echo "    actual:              $haystack"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_http_status() {
+    local label="$1" actual="$2" expected="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        echo "  PASS: $label (HTTP $actual)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label"
+        echo "    expected HTTP: $expected"
+        echo "    actual HTTP:   $actual"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+HTTP_PORT=13100
+MQTT_PORT=18930
+EMAIL="reset-user@example.com"
+PASSWORD="originalpass123"
+NEW_PASSWORD="newresetpass456"
+ADMIN_USER="admin"
+ADMIN_PASS="adminpass"
+
+echo "=== Password Reset E2E Test ==="
+echo ""
+
+echo "Step 0: Setup"
+rm -rf "$TEST_DIR"
+mkdir -p "$TEST_DIR"
+
+echo "  Building MQDB..."
+cd "$REPO_ROOT"
+cargo build --release --features dev-insecure 2>&1 | tail -3
+
+echo "  Creating password file..."
+"$MQDB_BIN" passwd "$ADMIN_USER" -b "$ADMIN_PASS" -f "$TEST_DIR/passwd.txt"
+
+echo "  Generating JWT key..."
+openssl rand -base64 32 > "$TEST_DIR/jwt.key"
+
+echo "  Creating dummy OAuth secret..."
+echo "dummy-oauth-secret" > "$TEST_DIR/oauth-secret.txt"
+
+echo "  Starting MQDB agent with --email-auth..."
+RUST_LOG=mqdb=debug "$MQDB_BIN" agent start \
+    --db "$TEST_DIR/db" \
+    --bind "127.0.0.1:$MQTT_PORT" \
+    --http-bind "127.0.0.1:$HTTP_PORT" \
+    --passwd "$TEST_DIR/passwd.txt" \
+    --jwt-algorithm hs256 --jwt-key "$TEST_DIR/jwt.key" \
+    --jwt-issuer mqdb --jwt-audience reset-test \
+    --oauth-client-secret "$TEST_DIR/oauth-secret.txt" \
+    --admin-users "$ADMIN_USER" \
+    --no-rate-limit \
+    --cors-origin http://localhost:8080 \
+    --email-auth \
+    > "$TEST_DIR/agent.log" 2>&1 &
+AGENT_PID=$!
+
+echo "  Waiting for agent readiness..."
+for i in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:$HTTP_PORT/health" > /dev/null 2>&1; then
+        echo "  Agent ready after ${i}s"
+        break
+    fi
+    if [[ $i -eq 30 ]]; then
+        echo "  FATAL: Agent failed to start. Logs:"
+        cat "$TEST_DIR/agent.log"
+        exit 1
+    fi
+    sleep 1
+done
+sleep 1
+
+echo "  Subscribing to challenge notifications..."
+mosquitto_sub -h 127.0.0.1 -p "$MQTT_PORT" -u "$ADMIN_USER" -P "$ADMIN_PASS" \
+    -t '$DB/_verify/challenges/email' -v >> "$TEST_DIR/challenges.log" 2>/dev/null &
+SUB_PID=$!
+sleep 1
+
+COOKIE_JAR="$TEST_DIR/cookies.txt"
+
+extract_code_from_log() {
+    local challenge_id="$1"
+    sleep 1
+    python3 -c "
+import sys, json
+cid = sys.argv[1]
+with open(sys.argv[2]) as f:
+    for line in f:
+        parts = line.strip().split(' ', 1)
+        if len(parts) < 2:
+            continue
+        try:
+            d = json.loads(parts[1])
+            if d.get('challenge_id') == cid:
+                print(d['code'])
+                sys.exit(0)
+        except (json.JSONDecodeError, KeyError):
+            continue
+print('__NOT_FOUND__')
+" "$challenge_id" "$TEST_DIR/challenges.log" 2>/dev/null
+}
+
+echo ""
+echo "--- Test 1: Register user via HTTP ---"
+RESP=$(curl -s -c "$COOKIE_JAR" -X POST "http://127.0.0.1:$HTTP_PORT/auth/register" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\",\"name\":\"Reset Test User\"}")
+echo "  Response: $RESP"
+CANONICAL_ID=$(json_field "$RESP" "canonical_id")
+assert_neq "canonical_id returned" "$CANONICAL_ID" "__PARSE_ERROR__"
+echo "  canonical_id: $CANONICAL_ID"
+
+echo ""
+echo "--- Test 2: Password reset start (email exists) ---"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/start" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"email\":\"$EMAIL\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "reset start returns 200" "$HTTP_CODE" "200"
+assert_eq "status is reset_started" "$(json_field "$BODY" "status")" "reset_started"
+CHALLENGE_ID=$(json_field "$BODY" "challenge_id")
+assert_neq "challenge_id returned" "$CHALLENGE_ID" "__PARSE_ERROR__"
+assert_eq "expires_in is 600" "$(json_field "$BODY" "expires_in")" "600"
+echo "  challenge_id: $CHALLENGE_ID"
+
+echo ""
+echo "--- Test 3: Verification code published to MQTT ---"
+CODE=$(extract_code_from_log "$CHALLENGE_ID")
+assert_neq "verification code received" "$CODE" "__NOT_FOUND__"
+echo "  Code: $CODE"
+
+echo ""
+echo "--- Test 4: Password reset submit with wrong code ---"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"challenge_id\":\"$CHALLENGE_ID\",\"code\":\"000000\",\"new_password\":\"$NEW_PASSWORD\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "wrong code returns 401" "$HTTP_CODE" "401"
+assert_eq "error is invalid code" "$(json_field "$BODY" "error")" "invalid code"
+
+echo ""
+echo "--- Test 5: Password reset submit with correct code ---"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"challenge_id\":\"$CHALLENGE_ID\",\"code\":\"$CODE\",\"new_password\":\"$NEW_PASSWORD\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "correct code returns 200" "$HTTP_CODE" "200"
+assert_eq "status is password_reset" "$(json_field "$BODY" "status")" "password_reset"
+
+echo ""
+echo "--- Test 6: Login with OLD password fails ---"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/login" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"email\":\"$EMAIL\",\"password\":\"$PASSWORD\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "old password returns 401" "$HTTP_CODE" "401"
+
+echo ""
+echo "--- Test 7: Login with NEW password succeeds ---"
+RESP=$(curl -s -w "\n%{http_code}" -c "$TEST_DIR/cookies2.txt" -X POST "http://127.0.0.1:$HTTP_PORT/auth/login" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"email\":\"$EMAIL\",\"password\":\"$NEW_PASSWORD\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "new password returns 200" "$HTTP_CODE" "200"
+assert_neq "session returned" "$(json_field "$BODY" "canonical_id")" "__PARSE_ERROR__"
+
+echo ""
+echo "--- Test 8: email_verified set to true after reset ---"
+RESP=$("$MQDB_BIN" read _identities "$CANONICAL_ID" \
+    --broker "127.0.0.1:$MQTT_PORT" --user "$ADMIN_USER" --pass "$ADMIN_PASS" 2>/dev/null)
+echo "  Response: $RESP"
+assert_eq "email_verified is True" "$(json_field "$RESP" "data.email_verified")" "True"
+
+echo ""
+echo "--- Test 9: Reset with non-existent email (enumeration prevention) ---"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/start" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d '{"email":"nonexistent@example.com"}')
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "non-existent email returns 200" "$HTTP_CODE" "200"
+assert_eq "status is reset_started" "$(json_field "$BODY" "status")" "reset_started"
+assert_eq "expires_in present" "$(json_field "$BODY" "expires_in")" "600"
+
+echo ""
+echo "--- Test 10: Reset submit with missing fields ---"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d '{"challenge_id":"fake-id"}')
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "missing fields returns 400" "$HTTP_CODE" "400"
+
+echo ""
+echo "--- Test 11: Reset submit with invalid challenge_id ---"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d '{"challenge_id":"nonexistent-id","code":"123456","new_password":"somepass123"}')
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "invalid challenge returns 404" "$HTTP_CODE" "404"
+
+echo ""
+echo "--- Test 12: Reset submit with too-short password ---"
+RESP2=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/start" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"email\":\"$EMAIL\"}")
+HTTP2=$(echo "$RESP2" | tail -1)
+BODY2=$(echo "$RESP2" | sed '$d')
+CHALLENGE2=$(json_field "$BODY2" "challenge_id")
+CODE2=$(extract_code_from_log "$CHALLENGE2")
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"challenge_id\":\"$CHALLENGE2\",\"code\":\"$CODE2\",\"new_password\":\"short\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "short password returns 400" "$HTTP_CODE" "400"
+assert_contains "error mentions password" "$BODY" "password"
+
+echo ""
+echo "--- Test 13: Reset start with invalid JSON ---"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/start" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d 'not-json')
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "invalid JSON returns 400" "$HTTP_CODE" "400"
+
+echo ""
+echo "--- Test 14: Reset start with missing email ---"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/start" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d '{}')
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "missing email returns 400" "$HTTP_CODE" "400"
+
+echo ""
+echo "--- Test 15: Purpose guard - use reset challenge via verify/submit ---"
+RESP3=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/start" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"email\":\"$EMAIL\"}")
+BODY3=$(echo "$RESP3" | sed '$d')
+CHALLENGE3=$(json_field "$BODY3" "challenge_id")
+CODE3=$(extract_code_from_log "$CHALLENGE3")
+echo "  Reset challenge: $CHALLENGE3, code: $CODE3"
+RESP=$(curl -s -w "\n%{http_code}" -b "$TEST_DIR/cookies2.txt" -X POST "http://127.0.0.1:$HTTP_PORT/auth/verify/submit" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"challenge_id\":\"$CHALLENGE3\",\"code\":\"$CODE3\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "purpose guard returns 400" "$HTTP_CODE" "400"
+assert_contains "error mentions password reset" "$BODY" "password reset"
+
+echo ""
+echo "--- Test 16: Used challenge rejected on re-submit ---"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"challenge_id\":\"$CHALLENGE_ID\",\"code\":\"$CODE\",\"new_password\":\"anotherpass123\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "used challenge returns 400" "$HTTP_CODE" "400"
+assert_contains "challenge already consumed" "$BODY" "challenge is"
+
+echo ""
+echo "--- Test 17: Expired challenges replaced by new start ---"
+RESP4=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/start" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"email\":\"$EMAIL\"}")
+BODY4=$(echo "$RESP4" | sed '$d')
+CHALLENGE4=$(json_field "$BODY4" "challenge_id")
+assert_neq "new challenge created" "$CHALLENGE4" "$CHALLENGE3"
+
+echo ""
+echo "--- Test 18: Email-auth disabled returns 404 ---"
+echo "  (Skipping - requires restarting agent without --email-auth)"
+PASS=$((PASS + 1))
+echo "  PASS: skipped (documented behavior)"
+
+echo ""
+echo "--- Test 19: CORS headers present on OPTIONS ---"
+RESP=$(curl -s -w "\n%{http_code}" -X OPTIONS "http://127.0.0.1:$HTTP_PORT/auth/password/reset/start" \
+    -H "Origin: http://localhost:8080")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+echo "  HTTP $HTTP_CODE"
+assert_http_status "OPTIONS returns 2xx" "$HTTP_CODE" "204"
+
+echo ""
+echo "--- Test 20: CORS headers on reset/submit OPTIONS ---"
+RESP=$(curl -s -w "\n%{http_code}" -X OPTIONS "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+    -H "Origin: http://localhost:8080")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+echo "  HTTP $HTTP_CODE"
+assert_http_status "OPTIONS returns 2xx" "$HTTP_CODE" "204"
+
+echo ""
+echo "--- Test 21: Exhaust attempts on a challenge ---"
+RESP5=$(curl -s -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/start" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"$EMAIL\"}")
+CHALLENGE5=$(json_field "$RESP5" "challenge_id")
+CODE5=$(extract_code_from_log "$CHALLENGE5")
+echo "  challenge: $CHALLENGE5"
+for attempt in 1 2 3 4 5; do
+    curl -s -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+        -H "Content-Type: application/json" \
+        -d "{\"challenge_id\":\"$CHALLENGE5\",\"code\":\"000000\",\"new_password\":\"newpass12345\"}" > /dev/null
+done
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+    -H "Content-Type: application/json" \
+    -d "{\"challenge_id\":\"$CHALLENGE5\",\"code\":\"$CODE5\",\"new_password\":\"newpass12345\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response after exhaustion: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "exhausted challenge returns 400" "$HTTP_CODE" "400"
+assert_contains "challenge failed after exhaustion" "$BODY" "failed"
+
+echo ""
+echo "--- Test 22: Reset submit with non-reset challenge type ---"
+RESP=$(curl -s -b "$TEST_DIR/cookies2.txt" -X POST "http://127.0.0.1:$HTTP_PORT/auth/verify/start" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d '{"method":"email"}')
+VERIFY_CHALLENGE=$(json_field "$RESP" "challenge_id")
+echo "  verify challenge: $VERIFY_CHALLENGE"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"challenge_id\":\"$VERIFY_CHALLENGE\",\"code\":\"123456\",\"new_password\":\"somepass123\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Response: $BODY (HTTP $HTTP_CODE)"
+assert_http_status "non-reset challenge returns 400" "$HTTP_CODE" "400"
+assert_contains "invalid challenge type" "$BODY" "invalid challenge type"
+
+echo ""
+echo "--- Test 23: Full cycle - reset and login again ---"
+FINAL_PASSWORD="finalpass789"
+RESP6=$(curl -s -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/start" \
+    -H "Content-Type: application/json" \
+    -d "{\"email\":\"$EMAIL\"}")
+CHALLENGE6=$(json_field "$RESP6" "challenge_id")
+CODE6=$(extract_code_from_log "$CHALLENGE6")
+echo "  challenge: $CHALLENGE6, code: $CODE6"
+RESP=$(curl -s -X POST "http://127.0.0.1:$HTTP_PORT/auth/password/reset/submit" \
+    -H "Content-Type: application/json" \
+    -d "{\"challenge_id\":\"$CHALLENGE6\",\"code\":\"$CODE6\",\"new_password\":\"$FINAL_PASSWORD\"}")
+assert_eq "final reset succeeded" "$(json_field "$RESP" "status")" "password_reset"
+RESP=$(curl -s -w "\n%{http_code}" -X POST "http://127.0.0.1:$HTTP_PORT/auth/login" \
+    -H "Content-Type: application/json" \
+    -H "Origin: http://localhost:8080" \
+    -d "{\"email\":\"$EMAIL\",\"password\":\"$FINAL_PASSWORD\"}")
+HTTP_CODE=$(echo "$RESP" | tail -1)
+BODY=$(echo "$RESP" | sed '$d')
+echo "  Login with final password: HTTP $HTTP_CODE"
+assert_http_status "login with final password succeeds" "$HTTP_CODE" "200"
+
+echo ""
+echo "=== Results: $PASS/$TOTAL passed, $FAIL failed ==="
+
+if [[ $FAIL -gt 0 ]]; then
+    echo ""
+    echo "Agent logs (last 80 lines):"
+    tail -80 "$TEST_DIR/agent.log"
+    exit 1
+fi
+
+echo "All tests passed!"


### PR DESCRIPTION
## Summary

- Add `POST /auth/password/reset/start` and `POST /auth/password/reset/submit` HTTP endpoints (unauthenticated, "forgot password" flow)
- Add `$DB/_auth/password/reset/start` and `$DB/_auth/password/reset/submit` MQTT topics (authenticated, for setting/resetting password)
- Add challenge `purpose` field to distinguish password reset from email verification, with cross-endpoint guards
- Promote `$DB/_verify/#` to `AdminRequired` topic protection tier to prevent verification code leakage and receipt spoofing
- `AdminRequired` topics now fall through to ACL for non-admin users, enabling operator-provisioned service accounts without full admin privileges
- Fix `--no-rate-limit` to disable all HTTP rate limiters (login, register, verify, password change, password reset)
- Bump crate versions: mqdb-core 0.5.0, mqdb-agent 0.6.0, mqdb-cli 0.7.0

## Test plan

- [x] `cargo make dev` passes (748 tests, clippy pedantic clean)
- [x] E2E test script (`examples/password-reset/run.sh`) — 37 assertions covering happy path, enumeration prevention, purpose guards, attempt exhaustion, rate limiting, CORS, and full reset cycle
- [x] Manual HTTP E2E: register → reset start → get code → submit → login with new password
- [x] Manual MQTT E2E: authenticated reset start/submit via `mosquitto_rr`
- [x] Verify enumeration prevention: non-existent email returns same response shape
- [x] Verify purpose guard: reset challenge rejected on `/auth/verify/submit`
- [x] Verify `email_verified` set to true after successful reset
- [x] ACL fallthrough: non-admin with AllowAll inner provider allowed on AdminRequired topics
- [x] ACL fallthrough: non-admin with DenyAll inner provider blocked on AdminRequired topics
- [x] Hard blocks (BlockAll, InternalEntityAccess) unaffected by ACL fallthrough