### PR TITLE
harden input validation, rate limiting, and credential hashing

### DIFF
--- a/crates/mqdb-agent/src/agent/handlers.rs
+++ b/crates/mqdb-agent/src/agent/handlers.rs
@@ -1205,6 +1205,13 @@ async fn handle_vault_enable_mqtt(ctx: &AdminContext<'_>, payload: &Value) -> Re
         );
     }
 
+    if !ctx.vault_unlock_limiter.check_and_record(canonical_id) {
+        return Response::error(
+            mqdb_core::ErrorCode::RateLimited,
+            "too many unlock attempts, try again later",
+        );
+    }
+
     let Some(identity) =
         crate::vault_ops::read_entity_db(ctx.db, "_identities", canonical_id).await
     else {
@@ -1476,6 +1483,13 @@ async fn handle_vault_change_mqtt(ctx: &AdminContext<'_>, payload: &Value) -> Re
         return Response::error(
             mqdb_core::ErrorCode::BadRequest,
             format!("passphrase must be at least {min_len} characters"),
+        );
+    }
+
+    if !ctx.vault_unlock_limiter.check_and_record(canonical_id) {
+        return Response::error(
+            mqdb_core::ErrorCode::RateLimited,
+            "too many unlock attempts, try again later",
         );
     }
 
@@ -1892,7 +1906,7 @@ async fn handle_password_reset_submit_mqtt(ctx: &AdminContext<'_>, payload: &Val
     if status != "pending" && status != "delivered" {
         return Response::error(
             mqdb_core::ErrorCode::BadRequest,
-            format!("challenge is {status}"),
+            "invalid or expired challenge",
         );
     }
 

--- a/crates/mqdb-agent/src/http/credentials.rs
+++ b/crates/mqdb-agent/src/http/credentials.rs
@@ -3,7 +3,7 @@
 
 use argon2::password_hash::{PasswordHash, PasswordHasher, PasswordVerifier, SaltString};
 use argon2::{Algorithm, Argon2, Params, Version};
-use ring::digest;
+use ring::hmac;
 use ring::rand::{SecureRandom, SystemRandom};
 
 use super::identity_crypto::IdentityCrypto;
@@ -24,6 +24,7 @@ impl std::fmt::Display for CredentialError {
 impl std::error::Error for CredentialError {}
 
 const MIN_PASSWORD_LENGTH: usize = 8;
+const MAX_PASSWORD_LENGTH: usize = 256;
 const ARGON2_M_COST: u32 = 19456;
 const ARGON2_T_COST: u32 = 2;
 const ARGON2_P_COST: u32 = 1;
@@ -61,8 +62,9 @@ pub fn compute_email_hash(crypto: Option<&IdentityCrypto>, email: &str) -> Strin
     if let Some(c) = crypto {
         c.blind_index("_credentials", &lower)
     } else {
-        let d = digest::digest(&digest::SHA256, lower.as_bytes());
-        hex_encode(d.as_ref())
+        let key = hmac::Key::new(hmac::HMAC_SHA256, b"mqdb-credential-email-index-v1");
+        let tag = hmac::sign(&key, lower.as_bytes());
+        hex_encode(tag.as_ref())
     }
 }
 
@@ -79,6 +81,9 @@ pub fn validate_email(email: &str) -> bool {
 pub fn validate_password(password: &str) -> Result<(), &'static str> {
     if password.len() < MIN_PASSWORD_LENGTH {
         return Err("password must be at least 8 characters");
+    }
+    if password.len() > MAX_PASSWORD_LENGTH {
+        return Err("password must be at most 256 characters");
     }
     Ok(())
 }
@@ -120,6 +125,8 @@ mod tests {
         assert!(validate_password("12345678").is_ok());
         assert!(validate_password("1234567").is_err());
         assert!(validate_password("").is_err());
+        assert!(validate_password(&"a".repeat(256)).is_ok());
+        assert!(validate_password(&"a".repeat(257)).is_err());
     }
 
     #[test]

--- a/crates/mqdb-agent/src/http/handlers.rs
+++ b/crates/mqdb-agent/src/http/handlers.rs
@@ -72,6 +72,7 @@ pub struct ServerState {
     pub password_change_rate_limiter: RateLimiter,
     pub password_reset_start_rate_limiter: RateLimiter,
     pub password_reset_submit_rate_limiter: RateLimiter,
+    pub refresh_rate_limiter: RateLimiter,
 }
 
 type HttpResponse = Response<Full<Bytes>>;
@@ -652,6 +653,14 @@ pub async fn handle_refresh(state: &ServerState, body: &[u8]) -> HttpResponse {
             Ok(result) => result,
             Err(resp) => return resp,
         };
+
+    if !state.refresh_rate_limiter.check_and_record(&canonical_id) {
+        return json_response_with_credentials(
+            429,
+            &json!({"error": "too many requests, try again later"}),
+            cors,
+        );
+    }
 
     let Some(stored_refresh_token) = stored_data
         .get("refresh_token")
@@ -1399,6 +1408,17 @@ pub async fn handle_vault_enable(
         Err(resp) => return *resp,
     };
 
+    if !state
+        .vault_unlock_limiter
+        .check_and_record(&session.canonical_id)
+    {
+        return json_response_with_credentials(
+            429,
+            &json!({"error": "too many requests, try again later"}),
+            cors,
+        );
+    }
+
     let body_value: serde_json::Value = match serde_json::from_slice(body) {
         Ok(v) => v,
         Err(_) => {
@@ -1607,6 +1627,17 @@ pub fn handle_vault_lock(state: &ServerState, headers: &HeaderMap) -> HttpRespon
         Ok((sid, s)) => (sid, s),
         Err(resp) => return *resp,
     };
+
+    if !state
+        .vault_unlock_limiter
+        .check_and_record(&session.canonical_id)
+    {
+        return json_response_with_credentials(
+            429,
+            &json!({"error": "too many requests, try again later"}),
+            cors,
+        );
+    }
 
     state.vault_key_store.remove(&session.canonical_id);
     state
@@ -2471,7 +2502,7 @@ pub async fn handle_verify_submit(
     if status != "pending" && status != "delivered" {
         return json_response_with_credentials(
             400,
-            &json!({"error": format!("challenge is {status}")}),
+            &json!({"error": "invalid or expired challenge"}),
             cors,
         );
     }
@@ -2977,7 +3008,7 @@ pub async fn handle_password_reset_submit(
     if status != "pending" && status != "delivered" {
         return json_response_with_credentials(
             400,
-            &json!({"error": format!("challenge is {status}")}),
+            &json!({"error": "invalid or expired challenge"}),
             cors,
         );
     }

--- a/crates/mqdb-agent/src/http/server.rs
+++ b/crates/mqdb-agent/src/http/server.rs
@@ -109,6 +109,7 @@ impl HttpServer {
             } else {
                 5
             }),
+            refresh_rate_limiter: RateLimiter::new(if no_rate_limit { u32::MAX } else { 10 }),
         });
 
         initialize_identity_constraints(&state).await;

--- a/crates/mqdb-core/src/protocol/mod.rs
+++ b/crates/mqdb-core/src/protocol/mod.rs
@@ -13,6 +13,8 @@ pub enum ProtocolError {
     MissingId(DbOp),
     #[error("invalid JSON payload: {0}")]
     InvalidPayload(#[from] serde_json::Error),
+    #[error("payload too large ({0} bytes, max {MAX_PAYLOAD_SIZE})")]
+    PayloadTooLarge(usize),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -83,6 +85,26 @@ pub enum AdminOperation {
     PasswordResetSubmit,
 }
 
+const MAX_ENTITY_NAME_LEN: usize = 128;
+const MAX_RECORD_ID_LEN: usize = 512;
+const MAX_PAYLOAD_SIZE: usize = 4 * 1024 * 1024;
+
+fn is_valid_entity_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= MAX_ENTITY_NAME_LEN
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+fn is_valid_record_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= MAX_RECORD_ID_LEN
+        && !id.contains('+')
+        && !id.contains('#')
+        && !id.contains('/')
+}
+
 type ListOptions = (
     Vec<Filter>,
     Vec<SortOrder>,
@@ -135,21 +157,31 @@ pub fn parse_admin_topic(topic: &str) -> Option<AdminOperation> {
     let parts: Vec<&str> = topic.strip_prefix("$DB/_admin/")?.split('/').collect();
 
     match parts.as_slice() {
-        ["schema", entity, "set"] => Some(AdminOperation::SchemaSet {
-            entity: (*entity).to_string(),
-        }),
-        ["schema", entity, "get"] => Some(AdminOperation::SchemaGet {
-            entity: (*entity).to_string(),
-        }),
-        ["constraint", entity, "add"] => Some(AdminOperation::ConstraintAdd {
-            entity: (*entity).to_string(),
-        }),
-        ["constraint", entity, "list"] => Some(AdminOperation::ConstraintList {
-            entity: (*entity).to_string(),
-        }),
-        ["index", entity, "add"] => Some(AdminOperation::IndexAdd {
-            entity: (*entity).to_string(),
-        }),
+        ["schema", entity, "set"] if is_valid_entity_name(entity) => {
+            Some(AdminOperation::SchemaSet {
+                entity: (*entity).to_string(),
+            })
+        }
+        ["schema", entity, "get"] if is_valid_entity_name(entity) => {
+            Some(AdminOperation::SchemaGet {
+                entity: (*entity).to_string(),
+            })
+        }
+        ["constraint", entity, "add"] if is_valid_entity_name(entity) => {
+            Some(AdminOperation::ConstraintAdd {
+                entity: (*entity).to_string(),
+            })
+        }
+        ["constraint", entity, "list"] if is_valid_entity_name(entity) => {
+            Some(AdminOperation::ConstraintList {
+                entity: (*entity).to_string(),
+            })
+        }
+        ["index", entity, "add"] if is_valid_entity_name(entity) => {
+            Some(AdminOperation::IndexAdd {
+                entity: (*entity).to_string(),
+            })
+        }
         ["backup"] => Some(AdminOperation::Backup),
         ["backup", "list"] => Some(AdminOperation::BackupList),
         ["restore"] => Some(AdminOperation::Restore),
@@ -179,31 +211,37 @@ pub fn parse_db_topic(topic: &str) -> Option<DbOperation> {
     let parts: Vec<&str> = topic.strip_prefix("$DB/")?.split('/').collect();
 
     match parts.as_slice() {
-        [entity, "create"] => Some(DbOperation {
+        [entity, "create"] if is_valid_entity_name(entity) => Some(DbOperation {
             entity: (*entity).to_string(),
             operation: DbOp::Create,
             id: None,
         }),
-        [entity, "list"] => Some(DbOperation {
+        [entity, "list"] if is_valid_entity_name(entity) => Some(DbOperation {
             entity: (*entity).to_string(),
             operation: DbOp::List,
             id: None,
         }),
-        [entity, id] => Some(DbOperation {
-            entity: (*entity).to_string(),
-            operation: DbOp::Read,
-            id: Some((*id).to_string()),
-        }),
-        [entity, id, "update"] => Some(DbOperation {
-            entity: (*entity).to_string(),
-            operation: DbOp::Update,
-            id: Some((*id).to_string()),
-        }),
-        [entity, id, "delete"] => Some(DbOperation {
-            entity: (*entity).to_string(),
-            operation: DbOp::Delete,
-            id: Some((*id).to_string()),
-        }),
+        [entity, id] if is_valid_entity_name(entity) && is_valid_record_id(id) => {
+            Some(DbOperation {
+                entity: (*entity).to_string(),
+                operation: DbOp::Read,
+                id: Some((*id).to_string()),
+            })
+        }
+        [entity, id, "update"] if is_valid_entity_name(entity) && is_valid_record_id(id) => {
+            Some(DbOperation {
+                entity: (*entity).to_string(),
+                operation: DbOp::Update,
+                id: Some((*id).to_string()),
+            })
+        }
+        [entity, id, "delete"] if is_valid_entity_name(entity) && is_valid_record_id(id) => {
+            Some(DbOperation {
+                entity: (*entity).to_string(),
+                operation: DbOp::Delete,
+                id: Some((*id).to_string()),
+            })
+        }
         _ => None,
     }
 }
@@ -213,6 +251,9 @@ pub fn parse_db_topic(topic: &str) -> Option<DbOperation> {
 /// # Errors
 /// Returns an error if JSON deserialization fails or a required ID is missing.
 pub fn build_request(op: DbOperation, payload: &[u8]) -> Result<Request, ProtocolError> {
+    if payload.len() > MAX_PAYLOAD_SIZE {
+        return Err(ProtocolError::PayloadTooLarge(payload.len()));
+    }
     let data: Value = if payload.is_empty() {
         Value::Null
     } else {
@@ -528,6 +569,51 @@ mod tests {
         ));
         assert!(parse_admin_topic("$DB/_auth/unknown").is_none());
         assert!(parse_admin_topic("$DB/_auth/password/reset/other").is_none());
+    }
+
+    #[test]
+    fn entity_name_validation() {
+        assert!(parse_db_topic("$DB/users/create").is_some());
+        assert!(parse_db_topic("$DB/my-entity/create").is_some());
+        assert!(parse_db_topic("$DB/my_entity/create").is_some());
+        assert!(parse_db_topic("$DB/Entity123/create").is_some());
+        assert!(parse_db_topic("$DB//create").is_none());
+        assert!(parse_db_topic("$DB/has space/create").is_none());
+        assert!(parse_db_topic("$DB/has.dot/create").is_none());
+        assert!(parse_db_topic(&format!("$DB/{}/create", "a".repeat(129))).is_none());
+        assert!(parse_db_topic(&format!("$DB/{}/create", "a".repeat(128))).is_some());
+    }
+
+    #[test]
+    fn record_id_validation() {
+        assert!(parse_db_topic("$DB/users/valid-id").is_some());
+        assert!(parse_db_topic("$DB/users/abc123").is_some());
+        assert!(parse_db_topic("$DB/users/+").is_none());
+        assert!(parse_db_topic("$DB/users/#").is_none());
+        let long_id = "x".repeat(513);
+        assert!(parse_db_topic(&format!("$DB/users/{long_id}")).is_none());
+        let ok_id = "x".repeat(512);
+        assert!(parse_db_topic(&format!("$DB/users/{ok_id}")).is_some());
+    }
+
+    #[test]
+    fn admin_entity_name_validation() {
+        assert!(parse_admin_topic("$DB/_admin/schema/users/set").is_some());
+        assert!(parse_admin_topic("$DB/_admin/schema/has space/set").is_none());
+        assert!(parse_admin_topic("$DB/_admin/constraint/has.dot/add").is_none());
+        assert!(parse_admin_topic(&format!("$DB/_admin/index/{}/add", "a".repeat(129))).is_none());
+    }
+
+    #[test]
+    fn payload_too_large_rejected() {
+        let op = DbOperation {
+            entity: "users".to_string(),
+            operation: DbOp::Create,
+            id: None,
+        };
+        let big_payload = vec![b'{'; MAX_PAYLOAD_SIZE + 1];
+        let result = build_request(op, &big_payload);
+        assert!(matches!(result, Err(ProtocolError::PayloadTooLarge(_))));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Cap password length at 256 bytes to prevent Argon2id DoS
- Add rate limiters to vault enable and vault change MQTT handlers, and OAuth token refresh HTTP endpoint
- Validate entity names (alphanumeric + `_` + `-`, max 128 chars) and record IDs (reject `+`, `#`, `/`, max 512 bytes) in topic parsers
- Reject JSON payloads over 4 MiB before parsing in `build_request`
- Normalize challenge error messages to generic "invalid or expired challenge" instead of leaking internal status
- Replace bare SHA256 with HMAC-SHA256 for email hash fallback when no identity crypto is configured

## Test plan
- [x] `cargo make dev` passes (format + clippy pedantic + 961 tests)
- [x] Verify entity name validation rejects spaces, dots, and names over 128 chars
- [x] Verify record ID validation rejects `+`, `#`, and IDs over 512 bytes
- [x] Verify payload over 4 MiB returns `PayloadTooLarge` error
- [x] Verify vault enable/change MQTT handlers are rate-limited
- [x] Verify OAuth refresh endpoint is rate-limited
- [x] Verify challenge submit responses no longer leak internal status values