### PR TITLE
add agent readiness signaling and fix flaky tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.7.2] - 2026-04-10
+
+Affected crates: mqdb-agent (0.7.0), mqdb-cli (0.7.2).
+
+### Added
+
+- `MqdbAgent::start()` method that returns a `JoinHandle` and a `watch::Receiver<bool>` readiness signal, firing only after both the TCP accept loop and the internal `$DB/#` handler are ready
+- Handler readiness oneshot in `spawn_handler_task` — signals after the `$DB/#` subscribe succeeds
+
+### Fixed
+
+- Replace hardcoded 500ms sleep in CLI tests with deterministic `start()` + `ready_rx` readiness signal
+- Replace `wait_for_port` + `wait_for_ready` polling in admin tests with `start()` + `ready_rx`
+- Replace static port counters with OS-assigned ephemeral ports in all test suites (agent, cli, cluster) to eliminate cross-binary port collisions
+
 ## [0.7.1] - 2026-04-10
 
 Affected crates: mqdb-core (0.5.1), mqdb-agent (0.6.1).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -130,9 +130,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -226,9 +226,9 @@ checksum = "1c53ba0f290bfc610084c05582d9c5d421662128fc69f4bf236707af6fd321b9"
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -296,9 +296,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -549,11 +549,11 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -564,9 +564,9 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fjall"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a9530ff159bc3ad3a15da746da0f6e95375c2ac64708cbb85ec1ebd26761a84"
+checksum = "fdf46551c9abc5fb0e0d540da36c875197285af2a29833892d7d3434b8617343"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -814,6 +814,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,9 +894,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -903,7 +909,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -966,12 +971,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -979,9 +985,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -992,9 +998,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1006,15 +1012,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1026,15 +1032,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1074,12 +1080,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -1101,9 +1107,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -1139,7 +1145,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -1148,9 +1154,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -1164,10 +1192,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -1203,9 +1233,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1215,9 +1245,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -1257,9 +1287,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lsm-tree"
-version = "3.1.2"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d67f95fd716870329c30aaeedf87f23d426564e6ce46efa045a91444faf2a19"
+checksum = "f38ed727e0965f218f4e419231b9ecacc1db8fb5066cf1df0d2bafeef88459d4"
 dependencies = [
  "byteorder-lite",
  "byteview",
@@ -1309,9 +1339,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -1435,8 +1465,8 @@ dependencies = [
 
 [[package]]
 name = "mqtt5"
-version = "0.31.0"
-source = "git+https://github.com/LabOverWire/mqtt-lib.git#b34ce4d4739db5eea19a9f13b0064db0bc647de2"
+version = "0.31.2"
+source = "git+https://github.com/LabOverWire/mqtt-lib.git#b4bc8d10886c7dab55bcdf23c3b0ad786678f72c"
 dependencies = [
  "argon2",
  "base64",
@@ -1484,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "mqtt5-protocol"
 version = "0.12.0"
-source = "git+https://github.com/LabOverWire/mqtt-lib.git#b34ce4d4739db5eea19a9f13b0064db0bc647de2"
+source = "git+https://github.com/LabOverWire/mqtt-lib.git#b4bc8d10886c7dab55bcdf23c3b0ad786678f72c"
 dependencies = [
  "bebytes",
  "bytes",
@@ -1518,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1711,12 +1741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1733,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2052,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -2144,9 +2168,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2221,9 +2245,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2270,9 +2294,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -2564,9 +2588,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -2589,9 +2613,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -2606,9 +2630,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2691,18 +2715,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.10+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.7+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f17aaa1c6e3dc22b1da4b6bba97d066e354c7945cac2f7852d4e4e7ca7a6b56d"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
@@ -2912,9 +2936,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -2972,9 +2996,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -3044,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3057,23 +3081,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3081,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3094,9 +3114,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -3137,9 +3157,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3469,9 +3489,9 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 
 [[package]]
 name = "wit-bindgen"
@@ -3563,9 +3583,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xxhash-rust"
@@ -3575,9 +3595,9 @@ checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3586,9 +3606,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3598,18 +3618,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3618,18 +3638,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3645,9 +3665,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -3656,9 +3676,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3667,9 +3687,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1355,7 +1355,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64",
  "bebytes",

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ let agent = MqdbAgent::new(db)
 agent.run().await?;
 
 // Non-blocking: returns a handle and a readiness signal
-let (handle, mut ready_rx) = agent.start().await?;
+let (handle, mut ready_rx, shutdown_tx) = agent.start().await?;
 ready_rx.changed().await?; // wait until broker + handler are ready
 ```
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,12 @@ let agent = MqdbAgent::new(db)
     .with_password_file("passwd.txt".into())
     .with_acl_file("acl.txt".into());
 
+// Blocking: runs the agent until shutdown
 agent.run().await?;
+
+// Non-blocking: returns a handle and a readiness signal
+let (handle, mut ready_rx) = agent.start().await?;
+ready_rx.changed().await?; // wait until broker + handler are ready
 ```
 
 ### MQTT Topic Structure

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.6.1"
+version = "0.7.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/mqdb-agent/src/agent/mod.rs
+++ b/crates/mqdb-agent/src/agent/mod.rs
@@ -254,13 +254,12 @@ impl MqdbAgent {
         info!("MQDB Agent listening on {}", self.bind_address);
 
         let bind_addr = self.bind_address;
-        let (handler_ready_tx, _handler_ready_rx) = oneshot::channel();
         let handler_task = self.spawn_handler_task(
             bind_addr,
             service_username.clone(),
             service_password.clone(),
             auth_providers,
-            handler_ready_tx,
+            None,
         );
         let event_task = self.spawn_event_task(
             bind_addr,
@@ -294,7 +293,11 @@ impl MqdbAgent {
     pub async fn start(
         self,
     ) -> Result<
-        (tokio::task::JoinHandle<()>, watch::Receiver<bool>),
+        (
+            tokio::task::JoinHandle<()>,
+            watch::Receiver<bool>,
+            broadcast::Sender<()>,
+        ),
         Box<dyn std::error::Error + Send + Sync>,
     > {
         let (ready_tx, ready_rx) = watch::channel(false);
@@ -331,7 +334,7 @@ impl MqdbAgent {
             service_username.clone(),
             service_password.clone(),
             auth_providers,
-            handler_ready_tx,
+            Some(handler_ready_tx),
         );
         let event_task = self.spawn_event_task(
             bind_addr,
@@ -366,7 +369,8 @@ impl MqdbAgent {
             }
         });
 
-        Ok((handle, ready_rx))
+        let caller_shutdown_tx = self.shutdown_tx.clone();
+        Ok((handle, ready_rx, caller_shutdown_tx))
     }
 
     pub fn shutdown(&self) {

--- a/crates/mqdb-agent/src/agent/mod.rs
+++ b/crates/mqdb-agent/src/agent/mod.rs
@@ -13,7 +13,7 @@ use std::collections::HashSet;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, oneshot, watch};
 use tracing::info;
 
 #[cfg(feature = "http-api")]
@@ -254,11 +254,13 @@ impl MqdbAgent {
         info!("MQDB Agent listening on {}", self.bind_address);
 
         let bind_addr = self.bind_address;
+        let (handler_ready_tx, _handler_ready_rx) = oneshot::channel();
         let handler_task = self.spawn_handler_task(
             bind_addr,
             service_username.clone(),
             service_password.clone(),
             auth_providers,
+            handler_ready_tx,
         );
         let event_task = self.spawn_event_task(
             bind_addr,
@@ -285,6 +287,86 @@ impl MqdbAgent {
         }
 
         Ok(())
+    }
+
+    /// # Errors
+    /// Returns an error if the broker fails to start.
+    pub async fn start(
+        self,
+    ) -> Result<
+        (tokio::task::JoinHandle<()>, watch::Receiver<bool>),
+        Box<dyn std::error::Error + Send + Sync>,
+    > {
+        let (ready_tx, ready_rx) = watch::channel(false);
+        let shutdown_tx = self.shutdown_tx.clone();
+
+        let (mut config, service_username, service_password, needs_composite, admin_users) =
+            self.build_broker_config().await?;
+
+        self.apply_transport_config(&mut config);
+
+        let broker = mqtt5::broker::MqttBroker::with_config(config).await?;
+        let (mut broker, auth_providers) = Self::apply_auth_providers(
+            broker,
+            broker::AuthProviderConfig {
+                needs_composite,
+                service_username: service_username.as_ref(),
+                service_password: service_password.as_ref(),
+                password_file: self.auth_setup.password_file.as_deref(),
+                acl_file: self.auth_setup.acl_file.as_deref(),
+                admin_users: &admin_users,
+                allow_anonymous: self.auth_setup.allow_anonymous,
+            },
+        )
+        .await?;
+
+        info!("MQDB Agent listening on {}", self.bind_address);
+
+        let mut broker_ready_rx = broker.ready_receiver();
+
+        let bind_addr = self.bind_address;
+        let (handler_ready_tx, handler_ready_rx) = oneshot::channel();
+        let handler_task = self.spawn_handler_task(
+            bind_addr,
+            service_username.clone(),
+            service_password.clone(),
+            auth_providers,
+            handler_ready_tx,
+        );
+        let event_task = self.spawn_event_task(
+            bind_addr,
+            service_username.clone(),
+            service_password.clone(),
+        );
+        let http_task = self.spawn_http_task(
+            bind_addr,
+            service_username.as_ref(),
+            service_password.as_ref(),
+        );
+        let license_task = self.spawn_license_check_task();
+
+        tokio::spawn(async move {
+            let _ = broker_ready_rx.changed().await;
+            let _ = handler_ready_rx.await;
+            let _ = ready_tx.send(true);
+        });
+
+        let handle = tokio::spawn(async move {
+            if let Err(e) = broker.run().await {
+                tracing::error!("broker error: {e}");
+            }
+            let _ = shutdown_tx.send(());
+            let _ = handler_task.await;
+            let _ = event_task.await;
+            if let Some(http) = http_task {
+                let _ = http.await;
+            }
+            if let Some(lic) = license_task {
+                let _ = lic.await;
+            }
+        });
+
+        Ok((handle, ready_rx))
     }
 
     pub fn shutdown(&self) {

--- a/crates/mqdb-agent/src/agent/tasks.rs
+++ b/crates/mqdb-agent/src/agent/tasks.rs
@@ -43,7 +43,7 @@ impl MqdbAgent {
         handler_username: Option<String>,
         handler_password: Option<String>,
         auth_providers: Option<Arc<ComprehensiveAuthProvider>>,
-        handler_ready_tx: oneshot::Sender<()>,
+        handler_ready_tx: Option<oneshot::Sender<()>>,
     ) -> tokio::task::JoinHandle<()> {
         let db = Arc::clone(&self.db);
         let mut shutdown_rx = self.shutdown_tx.subscribe();
@@ -98,7 +98,9 @@ impl MqdbAgent {
             }
 
             info!("Internal handler subscribed to $DB/#");
-            let _ = handler_ready_tx.send(());
+            if let Some(tx) = handler_ready_tx {
+                let _ = tx.send(());
+            }
 
             let response_client = MqttClient::new("mqdb-response-publisher");
             if let Err(e) = connect_mqtt_client(

--- a/crates/mqdb-agent/src/agent/tasks.rs
+++ b/crates/mqdb-agent/src/agent/tasks.rs
@@ -9,7 +9,7 @@ use mqtt5::time::Duration;
 use mqtt5::types::Message;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 use tracing::{debug, error, info, warn};
 
 impl MqdbAgent {
@@ -43,6 +43,7 @@ impl MqdbAgent {
         handler_username: Option<String>,
         handler_password: Option<String>,
         auth_providers: Option<Arc<ComprehensiveAuthProvider>>,
+        handler_ready_tx: oneshot::Sender<()>,
     ) -> tokio::task::JoinHandle<()> {
         let db = Arc::clone(&self.db);
         let mut shutdown_rx = self.shutdown_tx.subscribe();
@@ -97,6 +98,7 @@ impl MqdbAgent {
             }
 
             info!("Internal handler subscribed to $DB/#");
+            let _ = handler_ready_tx.send(());
 
             let response_client = MqttClient::new("mqdb-response-publisher");
             if let Err(e) = connect_mqtt_client(

--- a/crates/mqdb-agent/tests/admin_test.rs
+++ b/crates/mqdb-agent/tests/admin_test.rs
@@ -67,7 +67,7 @@ async fn start_agent(port: u16) -> (TempDir, tokio::task::JoinHandle<()>) {
     let agent = MqdbAgent::new(db)
         .with_bind_address(addr)
         .with_anonymous(true);
-    let (handle, mut ready_rx) = agent.start().await.unwrap();
+    let (handle, mut ready_rx, _shutdown) = agent.start().await.unwrap();
     let _ = ready_rx.changed().await;
     (tmp, handle)
 }
@@ -85,7 +85,7 @@ async fn start_agent_with_admin(
         .with_bind_address(addr)
         .with_anonymous(true)
         .with_admin_users(admin_users);
-    let (handle, mut ready_rx) = agent.start().await.unwrap();
+    let (handle, mut ready_rx, _shutdown) = agent.start().await.unwrap();
     let _ = ready_rx.changed().await;
     (tmp, handle)
 }

--- a/crates/mqdb-agent/tests/admin_test.rs
+++ b/crates/mqdb-agent/tests/admin_test.rs
@@ -3,7 +3,7 @@
 
 mod common;
 
-use common::{next_test_port, wait_for_port};
+use common::next_test_port;
 use mqdb_agent::{Database, MqdbAgent};
 use mqtt5::client::MqttClient;
 use mqtt5::types::{ConnectOptions, PublishOptions, PublishProperties};
@@ -60,17 +60,22 @@ fn get_response_data(response: &Value) -> Option<&Value> {
     response.get("data")
 }
 
-async fn start_agent(port: u16) -> (TempDir, MqdbAgent) {
+async fn start_agent(port: u16) -> (TempDir, tokio::task::JoinHandle<()>) {
     let tmp = TempDir::new().unwrap();
     let db = Database::open(tmp.path()).await.unwrap();
     let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
     let agent = MqdbAgent::new(db)
         .with_bind_address(addr)
         .with_anonymous(true);
-    (tmp, agent)
+    let (handle, mut ready_rx) = agent.start().await.unwrap();
+    let _ = ready_rx.changed().await;
+    (tmp, handle)
 }
 
-async fn start_agent_with_admin(port: u16, admin_user: &str) -> (TempDir, MqdbAgent) {
+async fn start_agent_with_admin(
+    port: u16,
+    admin_user: &str,
+) -> (TempDir, tokio::task::JoinHandle<()>) {
     let tmp = TempDir::new().unwrap();
     let db = Database::open(tmp.path()).await.unwrap();
     let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
@@ -80,46 +85,21 @@ async fn start_agent_with_admin(port: u16, admin_user: &str) -> (TempDir, MqdbAg
         .with_bind_address(addr)
         .with_anonymous(true)
         .with_admin_users(admin_users);
-    (tmp, agent)
-}
-
-async fn wait_for_ready(client: &MqttClient, max_attempts: u32) -> bool {
-    for _ in 0..max_attempts {
-        if let Some(resp) = mqtt_request_response(client, "$DB/_health", b"{}", 1000).await
-            && resp
-                .get("data")
-                .and_then(|d| d.get("ready"))
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or(false)
-        {
-            return true;
-        }
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
-    false
+    let (handle, mut ready_rx) = agent.start().await.unwrap();
+    let _ = ready_rx.changed().await;
+    (tmp, handle)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_health_endpoint_agent_mode() {
     let port = next_test_port();
-    let (_tmp, agent) = start_agent(port).await;
-
-    let agent_handle = tokio::spawn(async move {
-        let _ = agent.run().await;
-    });
-
-    wait_for_port(port).await;
+    let (_tmp, agent_handle) = start_agent(port).await;
 
     let client = MqttClient::new("test-health-agent");
     client
         .connect(&format!("mqtt://127.0.0.1:{port}"))
         .await
         .unwrap();
-
-    assert!(
-        wait_for_ready(&client, 10).await,
-        "agent should become ready"
-    );
 
     let response = mqtt_request_response(&client, "$DB/_health", b"{}", 2000)
         .await
@@ -142,24 +122,13 @@ async fn test_health_endpoint_agent_mode() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_admin_schema_set_and_get() {
     let port = next_test_port();
-    let (_tmp, agent) = start_agent_with_admin(port, "admin").await;
-
-    let agent_handle = tokio::spawn(async move {
-        let _ = agent.run().await;
-    });
-
-    wait_for_port(port).await;
+    let (_tmp, agent_handle) = start_agent_with_admin(port, "admin").await;
 
     let client = MqttClient::new("test-schema-ops");
     let options = ConnectOptions::new("test-schema-ops").with_credentials("admin", "");
     Box::pin(client.connect_with_options(&format!("mqtt://127.0.0.1:{port}"), options))
         .await
         .unwrap();
-
-    assert!(
-        wait_for_ready(&client, 10).await,
-        "agent should become ready"
-    );
 
     let schema = json!({
         "name": {"type": "string", "required": true},
@@ -193,24 +162,13 @@ async fn test_admin_schema_set_and_get() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_admin_constraint_add_and_list() {
     let port = next_test_port();
-    let (_tmp, agent) = start_agent_with_admin(port, "admin").await;
-
-    let agent_handle = tokio::spawn(async move {
-        let _ = agent.run().await;
-    });
-
-    wait_for_port(port).await;
+    let (_tmp, agent_handle) = start_agent_with_admin(port, "admin").await;
 
     let client = MqttClient::new("test-constraint-ops");
     let options = ConnectOptions::new("test-constraint-ops").with_credentials("admin", "");
     Box::pin(client.connect_with_options(&format!("mqtt://127.0.0.1:{port}"), options))
         .await
         .unwrap();
-
-    assert!(
-        wait_for_ready(&client, 10).await,
-        "agent should become ready"
-    );
 
     let constraint = json!({
         "type": "unique",
@@ -242,24 +200,13 @@ async fn test_admin_constraint_add_and_list() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_crud_via_mqtt() {
     let port = next_test_port();
-    let (_tmp, agent) = start_agent(port).await;
-
-    let agent_handle = tokio::spawn(async move {
-        let _ = agent.run().await;
-    });
-
-    wait_for_port(port).await;
+    let (_tmp, agent_handle) = start_agent(port).await;
 
     let client = MqttClient::new("test-crud-mqtt");
     client
         .connect(&format!("mqtt://127.0.0.1:{port}"))
         .await
         .unwrap();
-
-    assert!(
-        wait_for_ready(&client, 10).await,
-        "agent should become ready"
-    );
 
     let user = json!({
         "name": "Alice",
@@ -319,24 +266,13 @@ async fn test_crud_via_mqtt() {
 #[tokio::test]
 async fn test_list_query_complexity_limits_via_mqtt() {
     let port = next_test_port();
-    let (_tmp, agent) = start_agent(port).await;
-
-    let agent_handle = tokio::spawn(async move {
-        let _ = agent.run().await;
-    });
-
-    wait_for_port(port).await;
+    let (_tmp, agent_handle) = start_agent(port).await;
 
     let client = MqttClient::new("test-query-limits");
     client
         .connect(&format!("mqtt://127.0.0.1:{port}"))
         .await
         .unwrap();
-
-    assert!(
-        wait_for_ready(&client, 10).await,
-        "agent should become ready"
-    );
 
     let too_many_filters: Vec<Value> = (0..17)
         .map(|i| json!({"field": format!("f{i}"), "op": "eq", "value": "x"}))

--- a/crates/mqdb-agent/tests/common/mod.rs
+++ b/crates/mqdb-agent/tests/common/mod.rs
@@ -1,23 +1,7 @@
 // Copyright 2027 LabOverWire. All rights reserved.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use std::sync::atomic::{AtomicU16, Ordering};
-use std::time::Duration;
-
-static PORT_COUNTER: AtomicU16 = AtomicU16::new(21000);
-
 pub fn next_test_port() -> u16 {
-    PORT_COUNTER.fetch_add(1, Ordering::SeqCst)
-}
-
-#[allow(dead_code)]
-pub async fn wait_for_port(port: u16) {
-    let addr = format!("127.0.0.1:{port}");
-    for attempt in 1..=50u32 {
-        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
-            return;
-        }
-        assert!(attempt != 50, "port {port} not ready after 5s");
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind to ephemeral port");
+    listener.local_addr().expect("local_addr").port()
 }

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.7.1"
+version = "0.7.2"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/crates/mqdb-cli/tests/cli_test.rs
+++ b/crates/mqdb-cli/tests/cli_test.rs
@@ -7,7 +7,6 @@ use common::next_test_port;
 use mqdb_agent::{Database, MqdbAgent};
 use serde_json::Value;
 use std::net::SocketAddr;
-use std::time::Duration;
 use tempfile::TempDir;
 use tokio::process::Command;
 
@@ -19,11 +18,8 @@ async fn start_agent_background(port: u16) -> (TempDir, tokio::task::JoinHandle<
         .with_bind_address(addr)
         .with_anonymous(true);
 
-    let handle = tokio::spawn(async move {
-        let _ = agent.run().await;
-    });
-
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    let (handle, mut ready_rx) = agent.start().await.unwrap();
+    let _ = ready_rx.changed().await;
 
     (tmp, handle)
 }

--- a/crates/mqdb-cli/tests/cli_test.rs
+++ b/crates/mqdb-cli/tests/cli_test.rs
@@ -18,7 +18,7 @@ async fn start_agent_background(port: u16) -> (TempDir, tokio::task::JoinHandle<
         .with_bind_address(addr)
         .with_anonymous(true);
 
-    let (handle, mut ready_rx) = agent.start().await.unwrap();
+    let (handle, mut ready_rx, _shutdown) = agent.start().await.unwrap();
     let _ = ready_rx.changed().await;
 
     (tmp, handle)

--- a/crates/mqdb-cli/tests/cli_test.rs
+++ b/crates/mqdb-cli/tests/cli_test.rs
@@ -41,6 +41,16 @@ async fn run_mqdb(args: &[&str]) -> (bool, String, String) {
     (output.status.success(), stdout, stderr)
 }
 
+fn parse_json(stdout: &str, stderr: &str) -> Value {
+    serde_json::from_str(stdout.trim()).unwrap_or_else(|e| {
+        panic!(
+            "JSON parse failed: {e}\nstdout ({} bytes): {stdout:?}\nstderr ({} bytes): {stderr:?}",
+            stdout.len(),
+            stderr.len(),
+        )
+    })
+}
+
 #[tokio::test]
 async fn test_cli_create_and_read() {
     let port = next_test_port();
@@ -63,14 +73,14 @@ async fn test_cli_create_and_read() {
         "create should succeed: stderr={stderr}, stdout={stdout}"
     );
 
-    let created: Value = serde_json::from_str(&stdout).expect("should parse JSON output");
+    let created = parse_json(&stdout, &stderr);
     let id = created
         .get("data")
         .and_then(|d| d.get("id"))
         .and_then(|v| v.as_str())
         .expect("should have data.id");
 
-    let (success, stdout, _stderr) = run_mqdb(&[
+    let (success, stdout, stderr) = run_mqdb(&[
         "read",
         "users",
         id,
@@ -83,7 +93,7 @@ async fn test_cli_create_and_read() {
 
     assert!(success, "read should succeed");
 
-    let read: Value = serde_json::from_str(&stdout).expect("should parse JSON output");
+    let read = parse_json(&stdout, &stderr);
     let data = read.get("data").expect("should have data");
     assert_eq!(data.get("name").and_then(|v| v.as_str()), Some("Alice"));
 
@@ -109,7 +119,7 @@ async fn test_cli_list() {
         assert!(success, "create should succeed: {stderr}");
     }
 
-    let (success, stdout, _stderr) = run_mqdb(&[
+    let (success, stdout, stderr) = run_mqdb(&[
         "list",
         "users",
         "--broker",
@@ -121,7 +131,7 @@ async fn test_cli_list() {
 
     assert!(success, "list should succeed");
 
-    let list: Value = serde_json::from_str(&stdout).expect("should parse JSON output");
+    let list = parse_json(&stdout, &stderr);
     let data = list.get("data").expect("should have data");
     let items = data.as_array().expect("data should be array");
     assert_eq!(items.len(), 3);
@@ -134,7 +144,7 @@ async fn test_cli_update_and_delete() {
     let port = next_test_port();
     let (_tmp, handle) = start_agent_background(port).await;
 
-    let (success, stdout, _stderr) = run_mqdb(&[
+    let (success, stdout, stderr) = run_mqdb(&[
         "create",
         "users",
         "-d",
@@ -147,14 +157,14 @@ async fn test_cli_update_and_delete() {
     .await;
     assert!(success, "create should succeed");
 
-    let created: Value = serde_json::from_str(&stdout).expect("should parse JSON");
+    let created = parse_json(&stdout, &stderr);
     let id = created
         .get("data")
         .and_then(|d| d.get("id"))
         .and_then(|v| v.as_str())
         .unwrap();
 
-    let (success, stdout, _stderr) = run_mqdb(&[
+    let (success, stdout, stderr) = run_mqdb(&[
         "update",
         "users",
         id,
@@ -168,7 +178,7 @@ async fn test_cli_update_and_delete() {
     .await;
     assert!(success, "update should succeed");
 
-    let updated: Value = serde_json::from_str(&stdout).expect("should parse JSON");
+    let updated = parse_json(&stdout, &stderr);
     let data = updated.get("data").expect("should have data");
     assert_eq!(data.get("name").and_then(|v| v.as_str()), Some("Bob Smith"));
 
@@ -182,7 +192,7 @@ async fn test_cli_update_and_delete() {
     .await;
     assert!(success, "delete should succeed");
 
-    let (_success, stdout, _stderr) = run_mqdb(&[
+    let (_success, stdout, stderr) = run_mqdb(&[
         "read",
         "users",
         id,
@@ -192,7 +202,7 @@ async fn test_cli_update_and_delete() {
         "json",
     ])
     .await;
-    let response: Value = serde_json::from_str(&stdout).expect("should parse JSON");
+    let response = parse_json(&stdout, &stderr);
     assert_eq!(
         response.get("status").and_then(|v| v.as_str()),
         Some("error"),

--- a/crates/mqdb-cli/tests/common/mod.rs
+++ b/crates/mqdb-cli/tests/common/mod.rs
@@ -1,23 +1,7 @@
 // Copyright 2027 LabOverWire. All rights reserved.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use std::sync::atomic::{AtomicU16, Ordering};
-use std::time::Duration;
-
-static PORT_COUNTER: AtomicU16 = AtomicU16::new(22000);
-
 pub fn next_test_port() -> u16 {
-    PORT_COUNTER.fetch_add(1, Ordering::SeqCst)
-}
-
-#[allow(dead_code)]
-pub async fn wait_for_port(port: u16) {
-    let addr = format!("127.0.0.1:{port}");
-    for attempt in 1..=50u32 {
-        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
-            return;
-        }
-        assert!(attempt != 50, "port {port} not ready after 5s");
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind to ephemeral port");
+    listener.local_addr().expect("local_addr").port()
 }

--- a/crates/mqdb-cluster/tests/common/mod.rs
+++ b/crates/mqdb-cluster/tests/common/mod.rs
@@ -1,23 +1,7 @@
 // Copyright 2027 LabOverWire. All rights reserved.
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use std::sync::atomic::{AtomicU16, Ordering};
-use std::time::Duration;
-
-static PORT_COUNTER: AtomicU16 = AtomicU16::new(23000);
-
 pub fn next_test_port() -> u16 {
-    PORT_COUNTER.fetch_add(1, Ordering::SeqCst)
-}
-
-#[allow(dead_code)]
-pub async fn wait_for_port(port: u16) {
-    let addr = format!("127.0.0.1:{port}");
-    for attempt in 1..=50u32 {
-        if tokio::net::TcpStream::connect(&addr).await.is_ok() {
-            return;
-        }
-        assert!(attempt != 50, "port {port} not ready after 5s");
-        tokio::time::sleep(Duration::from_millis(100)).await;
-    }
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind to ephemeral port");
+    listener.local_addr().expect("local_addr").port()
 }

--- a/crates/mqdb-wasm/Cargo.lock
+++ b/crates/mqdb-wasm/Cargo.lock
@@ -12,10 +12,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "arc-swap"
-version = "1.8.0"
+name = "anyhow"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -59,16 +65,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.19.1"
+name = "bitflags"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cast"
@@ -78,9 +90,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.53"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755d2fce177175ffca841e9a06afdb2c4ab0f593d53b4dee48147dfaade85932"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -112,19 +124,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
+name = "equivalent"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
 ]
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8591b0bcc8a98a64310a2fae1bb3e9b8564dd10e381e6e28010fde8e8e8568db"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flume"
@@ -139,56 +157,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "foldhash"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -198,9 +208,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -210,32 +235,79 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
-name = "itoa"
-version = "1.0.17"
+name = "hashbrown"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "lock_api"
@@ -247,10 +319,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.7.6"
+name = "log"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "minicov"
@@ -320,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"
@@ -332,30 +410,34 @@ checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -367,10 +449,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "regex"
-version = "1.12.2"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -380,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -391,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustversion"
@@ -415,6 +503,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -478,9 +572,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "spin"
@@ -493,9 +587,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -555,17 +649,23 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "uuid"
-version = "1.19.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e054861b4bd027cd373e18e8d8d8e6548085000e41290d95ce0c373a654b4a"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -581,12 +681,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
-
-[[package]]
 name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,10 +690,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.108"
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -610,23 +713,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -634,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -647,18 +746,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.58"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45649196a53b0b7a15101d845d44d2dda7374fc1b5b5e2bbf58b7577ff4b346d"
+checksum = "6bb55e2540ad1c56eec35fd63e2aea15f83b11ce487fd2de9ad11578dfc047ea"
 dependencies = [
  "async-trait",
  "cast",
@@ -678,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.58"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f579cdd0123ac74b94e1a4a72bd963cf30ebac343f2df347da0b8df24cdebed2"
+checksum = "caf0ca1bd612b988616bac1ab34c4e4290ef18f7148a1d8b7f31c150080e9295"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -689,15 +788,49 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-shared"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8145dd1593bf0fb137dbfa85b8be79ec560a447298955877804640e40c2d6ea"
+checksum = "23cda5ecc67248c48d3e705d3e03e00af905769b78b9d2a1678b663b8b9d4472"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -742,6 +875,88 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "zeroize"
@@ -751,6 +966,6 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"
-version = "1.0.16"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfcd145825aace48cff44a8844de64bf75feec3080e0aa5cdbde72961ae51a65"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1051,7 +1051,7 @@ let agent = MqdbAgent::new(db)
 agent.run().await?;
 
 // Non-blocking alternative: returns a handle and a readiness signal
-let (handle, mut ready_rx) = agent.start().await?;
+let (handle, mut ready_rx, shutdown_tx) = agent.start().await?;
 ready_rx.changed().await?; // wait until broker + handler are ready
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1047,7 +1047,12 @@ let agent = MqdbAgent::new(db)
     .with_acl_file("acl.txt".into())
     .with_backup_dir("./backups".into());
 
+// Blocking: runs the agent until shutdown
 agent.run().await?;
+
+// Non-blocking alternative: returns a handle and a readiness signal
+let (handle, mut ready_rx) = agent.start().await?;
+ready_rx.changed().await?; // wait until broker + handler are ready
 ```
 
 **Architecture:**


### PR DESCRIPTION
## Summary

- Add `MqdbAgent::start()` method that returns a `JoinHandle` and `watch::Receiver<bool>` readiness signal, firing only after both the TCP accept loop and the internal `$DB/#` handler are subscribed
- Add handler readiness oneshot to `spawn_handler_task` — signals after the `$DB/#` subscribe succeeds
- Replace hardcoded 500ms sleep in CLI tests and `wait_for_port` + `wait_for_ready` polling in admin tests with deterministic `start()` + `ready_rx`
- Replace static port counters (21000/22000/23000) with OS-assigned ephemeral ports in all test suites to eliminate cross-binary port collisions
- Bump mqdb-agent 0.6.1 → 0.7.0, mqdb-cli 0.7.1 → 0.7.2

## Test plan

- [x] `cargo make dev` passes (format + clippy + all 961 tests)
- [x] `cargo test -p mqdb-cli --test cli_test` passes 3/3 consecutive runs
- [x] `cargo test -p mqdb-agent --test admin_test` passes 3/3 consecutive runs
- [x] Full `cargo make test` passes with no port collisions between parallel test binaries