### PR TITLE
ensure database directory exists before fjall open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "mqtt5"
 version = "0.31.2"
-source = "git+https://github.com/LabOverWire/mqtt-lib.git#b4bc8d10886c7dab55bcdf23c3b0ad786678f72c"
+source = "git+https://github.com/LabOverWire/mqtt-lib.git#012a71159c99795b61bece8995e84e0e651d5360"
 dependencies = [
  "argon2",
  "base64",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "mqtt5-protocol"
 version = "0.12.0"
-source = "git+https://github.com/LabOverWire/mqtt-lib.git#b4bc8d10886c7dab55bcdf23c3b0ad786678f72c"
+source = "git+https://github.com/LabOverWire/mqtt-lib.git#012a71159c99795b61bece8995e84e0e651d5360"
 dependencies = [
  "bebytes",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1465,8 +1465,8 @@ dependencies = [
 
 [[package]]
 name = "mqtt5"
-version = "0.31.2"
-source = "git+https://github.com/LabOverWire/mqtt-lib.git#012a71159c99795b61bece8995e84e0e651d5360"
+version = "0.31.3"
+source = "git+https://github.com/LabOverWire/mqtt-lib.git#816caa29caca2dab946b9cbbb74cd2829db0e6e4"
 dependencies = [
  "argon2",
  "base64",
@@ -1514,7 +1514,7 @@ dependencies = [
 [[package]]
 name = "mqtt5-protocol"
 version = "0.12.0"
-source = "git+https://github.com/LabOverWire/mqtt-lib.git#012a71159c99795b61bece8995e84e0e651d5360"
+source = "git+https://github.com/LabOverWire/mqtt-lib.git#816caa29caca2dab946b9cbbb74cd2829db0e6e4"
 dependencies = [
  "bebytes",
  "bytes",
@@ -1911,9 +1911,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",

--- a/crates/mqdb-cli/src/main.rs
+++ b/crates/mqdb-cli/src/main.rs
@@ -40,6 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 fn init_default_tracing() {
     tracing_subscriber::fmt()
+        .with_writer(std::io::stderr)
         .with_env_filter(EnvFilter::from_default_env())
         .init();
 }

--- a/crates/mqdb-core/src/storage/fjall_backend.rs
+++ b/crates/mqdb-core/src/storage/fjall_backend.rs
@@ -17,6 +17,7 @@ impl FjallBackend {
     /// # Errors
     /// Returns an error if the storage fails to open.
     pub fn open<P: AsRef<Path>>(path: P, durability: DurabilityMode) -> Result<Self> {
+        std::fs::create_dir_all(path.as_ref()).map_err(fjall::Error::Io)?;
         let db = Database::builder(path.as_ref()).open()?;
         let keyspace = db.keyspace("main", KeyspaceCreateOptions::default)?;
 


### PR DESCRIPTION
## Summary

- Add `create_dir_all` before `Database::builder(path).open()` in `FjallBackend::open` to ensure the database directory tree exists
- Fixes EBADF errors when running on `FROM scratch` Docker images or EFS/NFS where parent directories don't exist

## Test plan

- [x] `cargo make dev` passes (961 tests, zero warnings)
- [x] Verify `create_dir_all` is a no-op when directory already exists (all existing tests exercise this path)