### PR TITLE
persist index definitions across agent restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Each entry lists the date and the crate versions that were released.
 
-## [0.7.2] - 2026-04-10
+## 2026-04-15 — mqdb-core 0.5.2, mqdb-agent 0.7.1
 
-Affected crates: mqdb-core (0.5.1), mqdb-agent (0.7.0), mqdb-cli (0.7.2).
+### Added
+
+- Index definitions persist to `meta/index/{entity}` and reload on agent startup — indexes survive restarts without re-issuing `index add`
+
+## 2026-04-10 — mqdb-core 0.5.1, mqdb-agent 0.7.0, mqdb-cli 0.7.2
 
 ### Added
 
@@ -21,9 +25,7 @@ Affected crates: mqdb-core (0.5.1), mqdb-agent (0.7.0), mqdb-cli (0.7.2).
 - Ensure database directory tree exists before fjall open to prevent EBADF on `FROM scratch` Docker images
 - Direct tracing subscriber output to stderr in CLI to prevent log lines from corrupting JSON stdout
 
-## [0.7.1] - 2026-04-10
-
-Affected crates: mqdb-core (0.5.1), mqdb-agent (0.6.1).
+## 2026-04-10 — mqdb-core 0.5.1, mqdb-agent 0.6.1
 
 ### Security
 
@@ -34,9 +36,7 @@ Affected crates: mqdb-core (0.5.1), mqdb-agent (0.6.1).
 - Normalize challenge error messages to prevent internal status leakage
 - Replace bare SHA256 with HMAC-SHA256 for email hash fallback
 
-## [0.7.0] - 2026-04-05
-
-Affected crates: mqdb-core (0.5.0), mqdb-agent (0.6.0), mqdb-cli (0.7.0).
+## 2026-04-05 — mqdb-core 0.5.0, mqdb-agent 0.6.0, mqdb-cli 0.7.0
 
 ### Added
 
@@ -51,9 +51,7 @@ Affected crates: mqdb-core (0.5.0), mqdb-agent (0.6.0), mqdb-cli (0.7.0).
 
 - Promote `$DB/_verify/#` to `AdminRequired` topic protection tier to prevent leakage of verification codes and receipt spoofing
 
-## [0.6.0] - 2026-04-04
-
-Affected crates: mqdb-core (0.4.0), mqdb-agent (0.5.0), mqdb-cluster (0.3.0), mqdb-cli (0.6.0).
+## 2026-04-04 — mqdb-core 0.4.0, mqdb-agent 0.5.0, mqdb-cluster 0.3.0, mqdb-cli 0.6.0
 
 ### Added
 
@@ -66,9 +64,7 @@ Affected crates: mqdb-core (0.4.0), mqdb-agent (0.5.0), mqdb-cluster (0.3.0), mq
 
 - Cluster mode returns explicit error for `$DB/_auth/` topics (agent-only)
 
-## [0.5.0] - 2026-04-03
-
-Affected crates: mqdb-core (0.3.0), mqdb-agent (0.4.0), mqdb-cluster (0.2.0), mqdb-cli (0.5.0).
+## 2026-04-03 — mqdb-core 0.3.0, mqdb-agent 0.4.0, mqdb-cluster 0.2.0, mqdb-cli 0.5.0
 
 ### Added
 
@@ -84,9 +80,7 @@ Affected crates: mqdb-core (0.3.0), mqdb-agent (0.4.0), mqdb-cluster (0.2.0), mq
 - Vault HTTP handlers refactored to thin wrappers over shared `vault_ops` functions
 - Cluster mode returns explicit error for vault admin topics (vault requires agent mode)
 
-## [0.4.0] - 2026-04-02
-
-Affected crates: mqdb-agent, mqdb-cli.
+## 2026-04-02 — mqdb-agent, mqdb-cli
 
 ### Added
 
@@ -103,9 +97,7 @@ Affected crates: mqdb-agent, mqdb-cli.
 
 - OAuth client secret no longer required when `--email-auth` is used without OAuth providers
 
-## [0.3.0] - 2026-03-30
-
-Affected crates: mqdb-cli.
+## 2026-03-30 — mqdb-cli
 
 ### Added
 
@@ -113,9 +105,7 @@ Affected crates: mqdb-cli.
 - Inline content environment variables for file-path flags: `MQDB_PASSWD`, `MQDB_ACL`, `MQDB_SCRAM`, `MQDB_JWT_KEY`, `MQDB_PASSPHRASE`, `MQDB_LICENSE`, `MQDB_QUIC_CERT`, `MQDB_QUIC_KEY`, `MQDB_QUIC_CA`, `MQDB_OAUTH_CLIENT_SECRET`, `MQDB_IDENTITY_KEY`, `MQDB_FEDERATED_JWT_CONFIG`, `MQDB_CERT_AUTH`
 - Precedence: CLI flags > inline env vars (`MQDB_*`) > file-path env vars (`MQDB_*_FILE`)
 
-## [0.2.0] - 2026-03-28
-
-Affected crates: mqdb-core, mqdb-agent, mqdb-cli.
+## 2026-03-28 — mqdb-core, mqdb-agent, mqdb-cli
 
 ### Added
 
@@ -130,9 +120,7 @@ Affected crates: mqdb-core, mqdb-agent, mqdb-cli.
 - Deferred tracing subscriber initialization for `agent start` to avoid conflict with mqtt-lib's OTLP subscriber
 - Extracted `AgentStartFields` struct from `AgentAction::Start` enum variant (clippy large_enum_variant fix)
 
-## [0.1.0] - 2026-03-23
-
-Initial open-source release.
+## 2026-03-23 — initial release
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1443,7 +1443,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ idx/{entity}/{field}/{value}/{id} → secondary index entries
 sub/{subscription_id}           → subscription metadata
 dedup/{correlation_id}          → cached responses for idempotency
 meta/{key}                      → system metadata (sequences, etc.)
+meta/index/{entity}             → index definitions (survive restarts)
 _outbox/{operation_id}          → pending events for delivery
 _dead_letter/{operation_id}     → failed events after max retries
 ```

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "Standalone MQTT broker agent with embedded database for MQDB"
 
 [dependencies]
-mqdb-core = { path = "../mqdb-core", version = "0.5.1", features = ["fjall-backend"] }
+mqdb-core = { path = "../mqdb-core", version = "0.5.2", features = ["fjall-backend"] }
 
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mqdb-agent/src/database/mod.rs
+++ b/crates/mqdb-agent/src/database/mod.rs
@@ -105,7 +105,9 @@ impl Database {
             config.shared_subscription.num_partitions,
         ));
         let outbox = Arc::new(Outbox::new(Arc::clone(&storage)));
-        let index_manager = Arc::new(RwLock::new(IndexManager::new()));
+        let mut index_manager = IndexManager::new();
+        index_manager.load_indexes(&storage)?;
+        let index_manager = Arc::new(RwLock::new(index_manager));
         let relationship_registry = Arc::new(RwLock::new(RelationshipRegistry::new()));
 
         let mut schema_registry = SchemaRegistry::new();

--- a/crates/mqdb-agent/src/database/schema_ops.rs
+++ b/crates/mqdb-agent/src/database/schema_ops.rs
@@ -34,6 +34,7 @@ impl Database {
 
     /// # Errors
     /// Returns an error if any index field doesn't exist in the entity's schema.
+    #[tracing::instrument(skip(self), fields(entity = %entity))]
     pub async fn add_index(&self, entity: String, fields: Vec<String>) -> Result<()> {
         let schema_registry = self.schema_registry.read().await;
         let field_refs: Vec<&str> = fields.iter().map(String::as_str).collect();
@@ -45,9 +46,9 @@ impl Database {
             let mut batch = self.storage.batch();
             let mut manager = self.index_manager.write().await;
             manager.persist_index(&mut batch, &definition)?;
+            batch.commit()?;
             manager.add_index(definition);
             drop(manager);
-            batch.commit()?;
         }
 
         let prefix = format!("data/{entity}/");

--- a/crates/mqdb-agent/src/database/schema_ops.rs
+++ b/crates/mqdb-agent/src/database/schema_ops.rs
@@ -41,11 +41,13 @@ impl Database {
         drop(schema_registry);
 
         {
+            let definition = mqdb_core::index::IndexDefinition::new(entity.clone(), fields);
+            let mut batch = self.storage.batch();
             let mut manager = self.index_manager.write().await;
-            manager.add_index(mqdb_core::index::IndexDefinition::new(
-                entity.clone(),
-                fields,
-            ));
+            manager.persist_index(&mut batch, &definition)?;
+            manager.add_index(definition);
+            drop(manager);
+            batch.commit()?;
         }
 
         let prefix = format!("data/{entity}/");

--- a/crates/mqdb-core/Cargo.toml
+++ b/crates/mqdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-core"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/mqdb-core/src/index.rs
+++ b/crates/mqdb-core/src/index.rs
@@ -4,9 +4,11 @@
 use crate::entity::Entity;
 use crate::error::Result;
 use crate::keys;
-use crate::storage::BatchWriter;
+use crate::storage::{BatchWriter, Storage};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+#[derive(Serialize, Deserialize)]
 pub struct IndexDefinition {
     pub entity: String,
     pub fields: Vec<String>,
@@ -98,6 +100,33 @@ impl IndexManager {
         self.indexes
             .get(entity)
             .is_some_and(|idx| idx.fields.iter().any(|f| f == field))
+    }
+
+    /// # Errors
+    /// Returns an error if serialization fails.
+    pub fn persist_index(
+        &self,
+        batch: &mut BatchWriter,
+        definition: &IndexDefinition,
+    ) -> Result<()> {
+        let key = keys::encode_index_definition_key(&definition.entity);
+        let value = serde_json::to_vec(definition)?;
+        batch.insert(key, value);
+        Ok(())
+    }
+
+    /// # Errors
+    /// Returns an error if reading or deserializing index definitions fails.
+    pub fn load_indexes(&mut self, storage: &Storage) -> Result<()> {
+        let prefix = b"meta/index/";
+        let items = storage.prefix_scan(prefix)?;
+
+        for (_key, value) in items {
+            let definition: IndexDefinition = serde_json::from_slice(&value)?;
+            self.indexes.insert(definition.entity.clone(), definition);
+        }
+
+        Ok(())
     }
 
     /// # Errors
@@ -346,5 +375,35 @@ mod tests {
         assert!(ids.contains(&"u1".to_string()));
         assert!(ids.contains(&"u2".to_string()));
         assert!(ids.contains(&"u3".to_string()));
+    }
+
+    #[test]
+    fn persist_and_load_indexes_round_trip() {
+        let storage = Storage::memory();
+        let mut mgr = IndexManager::new();
+        mgr.add_index(IndexDefinition::new(
+            "users".into(),
+            vec!["email".into(), "status".into()],
+        ));
+        mgr.add_index(IndexDefinition::new("posts".into(), vec!["title".into()]));
+
+        for def in mgr.indexes.values() {
+            let mut batch = storage.batch();
+            mgr.persist_index(&mut batch, def).unwrap();
+            batch.commit().unwrap();
+        }
+
+        let mut loaded = IndexManager::new();
+        loaded.load_indexes(&storage).unwrap();
+
+        assert_eq!(
+            loaded.get_indexed_fields("users").unwrap(),
+            &vec!["email".to_string(), "status".to_string()]
+        );
+        assert_eq!(
+            loaded.get_indexed_fields("posts").unwrap(),
+            &vec!["title".to_string()]
+        );
+        assert!(loaded.get_indexed_fields("nonexistent").is_none());
     }
 }

--- a/crates/mqdb-core/src/keys.rs
+++ b/crates/mqdb-core/src/keys.rs
@@ -150,6 +150,11 @@ pub fn encode_value_for_index(value: &serde_json::Value) -> Result<Vec<u8>> {
 }
 
 #[must_use]
+pub fn encode_index_definition_key(entity: &str) -> Vec<u8> {
+    format!("meta/index/{entity}").into_bytes()
+}
+
+#[must_use]
 pub fn encode_schema_key(entity: &str) -> Vec<u8> {
     format!("meta/schema/{entity}").into_bytes()
 }
@@ -222,6 +227,12 @@ mod tests {
                 pair[1]
             );
         }
+    }
+
+    #[test]
+    fn test_encode_index_definition_key() {
+        let key = encode_index_definition_key("users");
+        assert_eq!(key, b"meta/index/users");
     }
 
     #[test]

--- a/crates/mqdb-wasm/Cargo.lock
+++ b/crates/mqdb-wasm/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,6 +173,7 @@ sub/{subscription_id}                       → Persistent subscriptions
 dedup/{correlation_id}                      → Idempotency cache
 meta/{key}                                  → Sequences, metadata
 meta/schema/{entity}                        → Schema definitions
+meta/index/{entity}                         → Index definitions
 meta/constraint/{type}/{entity}/{name}      → Constraint definitions
 _outbox/{operation_id}                      → Pending events for delivery
 _dead_letter/{operation_id}                 → Failed events after max retries
@@ -195,6 +196,7 @@ fkref/{target_entity}/{target_id}/...       → FK reverse lookups (reserved)
 data/users/123                              → User entity with ID 123
 idx/users/email/alice@example.com/123       → Email index entry
 meta/schema/users                           → Users schema definition
+meta/index/users                            → Users index definition
 meta/constraint/fk/posts/posts_author_id_fk → Foreign key constraint
 ```
 
@@ -247,6 +249,7 @@ idx/users/email/alice@example.com/123
 ```
 
 **Index Lifecycle:**
+- **Define**: Persist definition to `meta/index/{entity}`, reload on startup
 - **Create**: Insert index entries for indexed fields
 - **Update**: Remove old index entries, insert new ones
 - **Delete**: Remove all index entries for entity

--- a/docs/testing/05-indexes.md
+++ b/docs/testing/05-indexes.md
@@ -531,3 +531,101 @@ mqdb list products --filter 'price>100' --user admin --pass admin123
 - [ ] Adding same index twice causes no error (idempotent)
 - [ ] First equality filter uses index, subsequent filters post-filter
 - [ ] Range filter uses index correctly
+
+---
+
+## 43. Index Definition Persistence Across Restarts
+
+Index definitions are persisted to storage under `meta/index/{entity}` and reloaded on agent
+startup. This means indexes survive restarts without requiring users to re-issue `index add`.
+
+> **Note:** Agent-mode only. Cluster mode rejects `index add`.
+
+### Setup
+
+```bash
+mqdb passwd admin -b admin123 -f /tmp/mqdb-persist-idx-passwd
+mqdb agent start --db /tmp/mqdb-persist-idx --bind 127.0.0.1:1883 \
+    --passwd /tmp/mqdb-persist-idx-passwd --admin-users admin
+```
+
+Create schema, add index, and seed data:
+
+```bash
+echo '{"name": {"type": "string"}, "price": {"type": "number"}}' > /tmp/products_schema.json
+mqdb schema set products -f /tmp/products_schema.json --user admin --pass admin123
+
+mqdb index add products --fields price --user admin --pass admin123
+
+mqdb create products --data '{"name":"Phone","price":999}' --user admin --pass admin123
+mqdb create products --data '{"name":"Laptop","price":1500}' --user admin --pass admin123
+mqdb create products --data '{"name":"Mouse","price":25}' --user admin --pass admin123
+```
+
+#### Test 1: Range Query Works Before Restart
+
+```bash
+mqdb list products --filter 'price>100' --user admin --pass admin123
+```
+
+**Expected:** Returns Phone (999) and Laptop (1500). Mouse (25) excluded.
+
+#### Test 2: Stop and Restart Agent
+
+```bash
+# Stop the agent (Ctrl-C or pkill)
+# Restart with the SAME --db path
+mqdb agent start --db /tmp/mqdb-persist-idx --bind 127.0.0.1:1883 \
+    --passwd /tmp/mqdb-persist-idx-passwd --admin-users admin
+```
+
+#### Test 3: Range Query Works After Restart (No Re-Index)
+
+```bash
+mqdb list products --filter 'price>100' --user admin --pass admin123
+```
+
+**Expected:** Returns Phone (999) and Laptop (1500). The index definition was loaded from
+storage on startup — no need to re-issue `index add`.
+
+#### Test 4: New Records Are Indexed After Restart
+
+```bash
+mqdb create products --data '{"name":"Tablet","price":500}' --user admin --pass admin123
+mqdb list products --filter 'price>100' --user admin --pass admin123
+```
+
+**Expected:** Returns Tablet (500), Phone (999), and Laptop (1500). The loaded index
+definition is active, so new writes are indexed automatically.
+
+#### Test 5: Combined Range After Restart
+
+```bash
+mqdb list products --filter 'price>=500' --filter 'price<=999' --user admin --pass admin123
+```
+
+**Expected:** Returns Tablet (500) and Phone (999).
+
+#### Test 6: Re-Adding Same Index Is Idempotent
+
+```bash
+mqdb index add products --fields price --user admin --pass admin123
+mqdb list products --filter 'price>100' --user admin --pass admin123
+```
+
+**Expected:** `index add` succeeds. Range query still returns correct results.
+
+### Cleanup
+
+```bash
+# Stop agent
+rm -rf /tmp/mqdb-persist-idx /tmp/mqdb-persist-idx-passwd /tmp/products_schema.json
+```
+
+### Verification Checklist
+
+- [ ] Range query works before restart
+- [ ] After restart, range query returns same results without re-issuing `index add`
+- [ ] New records created after restart are indexed
+- [ ] Combined range filters work after restart
+- [ ] Re-adding the same index after restart is idempotent

--- a/docs/testing/14-checklists.md
+++ b/docs/testing/14-checklists.md
@@ -82,6 +82,11 @@ Run through this checklist to verify MQDB works completely:
 - [ ] Consumer groups (list, show)
 - [ ] Backup/Restore
 
+### Agent Mode — Index Persistence
+- [ ] Index definitions survive agent restart (no re-issue needed)
+- [ ] New records indexed after restart
+- [ ] Re-adding same index after restart is idempotent
+
 ### Agent Mode — Index Range Queries
 - [ ] Range filters (>, >=, <, <=) on indexed field return correct results
 - [ ] Combined range (>= AND <=) on indexed field returns correct range
@@ -221,6 +226,13 @@ Run through this checklist to verify MQDB works completely:
 - [ ] Index on existing data backfills correctly
 - [ ] Index add is idempotent
 - [ ] First Eq filter uses index, rest post-filter
+
+### Index Persistence (Section 43, Agent Only)
+- [ ] Range query works before restart
+- [ ] After restart, range query returns same results without re-issuing `index add`
+- [ ] New records created after restart are indexed
+- [ ] Combined range filters work after restart
+- [ ] Re-adding same index after restart is idempotent
 
 ### Cluster Scatter-Gather (Section 37)
 - [ ] Sort consistency across all nodes


### PR DESCRIPTION
## Summary
- Index definitions are now persisted to `meta/index/{entity}` keys and loaded on agent startup, matching the schema/constraint persistence pattern
- Added `Serialize`/`Deserialize` to `IndexDefinition`, `persist_index()` and `load_indexes()` to `IndexManager`, `encode_index_definition_key()` to keys
- Added E2E test scenario (Section 43) and checklist entries for index persistence across restarts

## Test plan
- [x] `cargo make dev` passes (format + clippy + test, 748 tests)
- [x] New unit test: round-trip persist/load of index definitions
- [x] New unit test: `encode_index_definition_key` produces correct key
- [x] E2E verified: range query works before restart, after restart without re-issuing `index add`, new records indexed after restart, combined range works, re-add is idempotent