### PR TITLE
bump mqdb-cli to 0.7.3 for v0.7.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
-## 2026-04-22 — mqdb-core 0.6.0, mqdb-wasm 0.3.1, mqdb-agent 0.7.2
+## 2026-04-22 — mqdb-core 0.6.0, mqdb-wasm 0.3.1, mqdb-agent 0.7.2, mqdb-cli 0.7.3
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "base64",
  "bebytes",

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.7.2"
+version = "0.7.3"
 publish = false
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

- Bump `mqdb-cli` from 0.7.2 to 0.7.3 to cut a new release tag that carries the WASM-parity work merged in #46
- Update the 2026-04-22 CHANGELOG header to include `mqdb-cli 0.7.3`

CLI itself has no code changes since 0.7.2 — the version bump exists to mark the release line, in keeping with the convention that git tags track the CLI version.

## Test plan

- [x] `cargo check -p mqdb-cli` clean
- [x] Cargo.lock refreshed to reflect the new version