### PR TITLE
include db_data in partition snapshot export/import

### DIFF
--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -2062,16 +2062,13 @@ impl<T: ClusterTransport> NodeController<T> {
         };
 
         if primary == self.node_id {
-            let has_replica_role = self
-                .replicas
-                .get(&partition.get())
-                .map(|s| format!("{:?}", s.role()));
+            let replica_role = self.replicas.get(&partition.get()).map(|s| s.role());
             tracing::warn!(
                 node = node_id,
                 partition = partition.get(),
                 primary_from_map = primary.get(),
-                has_replica_role = ?has_replica_role,
-                "forward_failed_primary_is_self (is_primary_for_partition and partition_map disagree)"
+                replica_role = ?replica_role,
+                "forward_failed_primary_is_self"
             );
             return false;
         }

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -2053,11 +2053,26 @@ impl<T: ClusterTransport> NodeController<T> {
         let node_id = self.node_id.get();
 
         let Some(primary) = self.partition_map.primary(partition) else {
-            tracing::warn!(?partition, "cannot forward JSON request: no primary known");
+            tracing::warn!(
+                node = node_id,
+                partition = partition.get(),
+                "forward_failed_no_primary"
+            );
             return false;
         };
 
         if primary == self.node_id {
+            let has_replica_role = self
+                .replicas
+                .get(&partition.get())
+                .map(|s| format!("{:?}", s.role()));
+            tracing::warn!(
+                node = node_id,
+                partition = partition.get(),
+                primary_from_map = primary.get(),
+                has_replica_role = ?has_replica_role,
+                "forward_failed_primary_is_self (is_primary_for_partition and partition_map disagree)"
+            );
             return false;
         }
 

--- a/crates/mqdb-cluster/src/cluster/store_manager/partition_io.rs
+++ b/crates/mqdb-cluster/src/cluster/store_manager/partition_io.rs
@@ -167,6 +167,47 @@ impl StoreManager {
         total_cleared += self.inflight.clear_partition(partition);
         total_cleared += self.offsets.clear_partition(partition);
         total_cleared += self.idempotency.clear_partition(partition);
+        total_cleared += self.db_data.clear_partition(partition);
         total_cleared
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cluster::NodeId;
+
+    fn node(id: u16) -> NodeId {
+        NodeId::validated(id).unwrap()
+    }
+
+    #[test]
+    fn export_import_roundtrip_preserves_db_data() {
+        let src = StoreManager::new(node(1));
+        let dst = StoreManager::new(node(2));
+
+        src.db_data
+            .create("notes", "n1", b"{\"title\":\"hello\"}", 1000)
+            .unwrap();
+        src.db_data
+            .create("notes", "n2", b"{\"title\":\"world\"}", 2000)
+            .unwrap();
+
+        let partition = src.db_data.get("notes", "n1").unwrap().partition();
+
+        let payload = src.export_partition(partition);
+        assert!(!payload.is_empty(), "snapshot payload must not be empty");
+
+        let imported = dst.import_partition(&payload).expect("import");
+        assert!(
+            imported >= 1,
+            "at least one record for partition must survive the roundtrip"
+        );
+
+        let note = dst
+            .db_data
+            .get("notes", "n1")
+            .expect("n1 must exist on destination after snapshot import");
+        assert_eq!(note.data, b"{\"title\":\"hello\"}");
     }
 }

--- a/crates/mqdb-cluster/src/cluster/store_manager/partition_io.rs
+++ b/crates/mqdb-cluster/src/cluster/store_manager/partition_io.rs
@@ -44,6 +44,10 @@ impl StoreManager {
                 entity::IDEMPOTENCY,
                 self.idempotency.export_for_partition(partition),
             ),
+            (
+                entity::DB_DATA,
+                self.db_data.export_for_partition(partition),
+            ),
         ];
 
         buf.extend_from_slice(&(store_data.len() as u8).to_be_bytes());
@@ -139,6 +143,10 @@ impl StoreManager {
                     .idempotency
                     .import_records(store_data)
                     .map_err(|_| StoreApplyError::IdempotencyError)?,
+                entity::DB_DATA => self
+                    .db_data
+                    .import_entities(store_data)
+                    .map_err(|_| StoreApplyError::DbDataError)?,
                 _ => continue,
             };
 

--- a/examples/vault-cluster/run.sh
+++ b/examples/vault-cluster/run.sh
@@ -628,7 +628,7 @@ echo "  Starting node 4 (port $PORT4, no http)..."
 RUST_LOG=mqdb=debug "$MQDB_BIN" cluster start \
     --node-id 4 --bind "127.0.0.1:$PORT4" \
     --db "$TEST_DIR/db4" \
-    --peers "1@127.0.0.1:$PORT1" \
+    --peers "1@127.0.0.1:$PORT1,2@127.0.0.1:$PORT2,3@127.0.0.1:$PORT3" \
     "${COMMON_AUTH_ARGS[@]}" \
     "${COMMON_QUIC_ARGS[@]}" \
     > "$TEST_DIR/node4.log" 2>&1 &

--- a/examples/vault-cluster/run.sh
+++ b/examples/vault-cluster/run.sh
@@ -625,6 +625,10 @@ echo ""
 
 echo "--- Test 30: start node 4 and wait for rebalancing ---"
 echo "  Starting node 4 (port $PORT4, no http)..."
+# FIXME: node 4 should only need --peers 1@... here; the explicit entries for
+# nodes 2 and 3 work around the fact that nodes don't auto-discover peer
+# addresses (heartbeats carry NodeId but not SocketAddr). Remove once cluster
+# supports address propagation via Raft or gossip.
 RUST_LOG=mqdb=debug "$MQDB_BIN" cluster start \
     --node-id 4 --bind "127.0.0.1:$PORT4" \
     --db "$TEST_DIR/db4" \


### PR DESCRIPTION
## Summary

- `StoreManager::export_partition` in `crates/mqdb-cluster/src/cluster/store_manager/partition_io.rs` was exporting 9 of the 15 entity store types (sessions, qos2, subscriptions, retained, topics, wildcards, inflight, offsets, idempotency) and omitting `db_data` — the user record store. Every partition snapshot since the cluster feature landed has been missing user data.
- Not visible in normal operation because primaries write locally and replicate via the Raft log. Only visible when rebalance promotes a replica that received an empty snapshot — the new primary then returns `entity not found` for pre-rebalance records.
- Adds `db_data` to both the export array and the import match arm in `import_partition`. Three lines of real code.
- Also expands node 4's `--peers` in the cluster vault E2E to include all three predecessors, and adds two `warn!()` diagnostic sites in `forward_json_db_request`. Peer auto-discovery (addresses aren't carried in heartbeats) is a separate architectural gap tracked for future work.

## Investigation (scientific method)

Reproduced against `examples/vault-cluster/run.sh` test 31 (node 4 reads a pre-rebalance record):

1. Added two warn logs in `forward_json_db_request` to distinguish no-primary / primary-is-self / transport-failed.
2. First log on failure: `forward_json_request_failed ... NodeNotFound(NodeId { id: 3 })`. Hypothesis: node 4's QUIC transport only had a connection to node 1 (its sole `--peers` entry).
3. Fixed `--peers` to include all three predecessors. Rebuilt. Re-ran. Got a different failure: HTTP 404 `entity not found` — forwarding succeeded but the data was missing on the new primary.
4. Grep of node 3's log: `snapshot import complete partition=PartitionId(88) imported=0 sequence=4` — zero records despite the partition having 4 writes on node 1.
5. Traced to `export_partition` enumerating only 9 of 15 store types. Fixed.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo make clippy` (pedantic, all targets + wasm) — clean
- [x] `cargo test --package mqdb-cluster --lib` — 453 passed, 0 failed
- [x] `examples/vault-cluster/run.sh` — **70/70 passed** (was 64/70 before this fix — the 6 remaining failures were 4 off-by-20 count mismatches from an E2E script probe-loop bug fixed upstream, plus this test 31 pair)

## Known gaps not addressed here

- **Peer auto-discovery**: a new node only dials peers in its `--peers` flag. Existing nodes don't dial new joiners. The `--peers` script expansion is a workaround; the proper fix propagates peer addresses via Raft or a gossip layer. Out of scope for this PR.
- **Missing DB stores in snapshot**: schema / index / unique / fk / constraint stores lack `export_for_partition` entirely. Test 31 passes without these because the test doesn't use them, but a cluster with schemas or constraints would still lose them on replica snapshot.