### PR TITLE
bump versions and add changelog for pr #49 and #50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
-## 2026-04-25 — mqdb-core 0.7.0, mqdb-agent 0.8.0, mqdb-wasm 0.3.2, mqdb-vault 0.1.0, mqdb-cluster 0.3.1, mqdb-cli 0.7.4
+## 2026-04-24 — mqdb-core 0.7.0, mqdb-agent 0.8.0, mqdb-wasm 0.3.2, mqdb-vault 0.1.0, mqdb-cluster 0.3.1, mqdb-cli 0.7.4
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-04-25 — mqdb-core 0.7.0, mqdb-agent 0.8.0, mqdb-wasm 0.3.2, mqdb-vault 0.1.0, mqdb-cluster 0.3.1, mqdb-cli 0.7.4
+
+### Added
+
+- New `mqdb-vault` crate (AGPL-3.0-only) housing all vault transparent-encryption logic behind a `VaultBackend` trait defined in `mqdb-agent`. The CLI instantiates `VaultBackendImpl` after the license check; unlicensed agents bind `NoopVaultBackend` and every `$DB/_vault/*` admin topic returns `vault not available`.
+- `DbAccess` trait in `mqdb-agent::db_helpers` so vault admin methods work in both agent (direct `Database`) and cluster (MQTT-mediated `MqttDbAccess`) modes without duplicating logic.
+- `.githooks/pre-commit` running `cargo make format-check` + `cargo make clippy` on every commit. Activation is per-clone: `git config core.hooksPath .githooks` (documented in `CONTRIBUTING.md`).
+- Four unit tests in `mqdb-core::license` covering `check_runtime_expiry` past/future/boundary semantics and the `is_expired` wrapper.
+- 11 integration tests in `crates/mqdb-vault/tests/backend_integration.rs` covering NoopBackend `Unavailable` responses, admin passphrase/identity error paths, encrypt-on-write / decrypt-on-read roundtrip with ciphertext-at-rest assertion, admin_change rotation, and admin_disable clearing vault state.
+- `export_import_roundtrip_preserves_db_data` test in `mqdb-cluster::store_manager::partition_io` guarding against future regressions in partition snapshot export.
+
+### Changed
+
+- **License split.** `mqdb-core`, `mqdb-agent`, and `mqdb-wasm` are now **Apache-2.0** so downstream consumers can embed them without copyleft obligations. `mqdb-vault`, `mqdb-cluster`, and `mqdb-cli` remain **AGPL-3.0-only** (Pro/Enterprise features + the network-service binary). Dep graph is unidirectional: Apache crates never depend on AGPL crates.
+- `LICENSE` renamed to `LICENSE-AGPL`; new `LICENSE-APACHE` added; `NOTICE` rewritten to describe the split; `README.md` licensing section updated; `deny.toml` AGPL exceptions narrowed to the three AGPL crates.
+- `VaultBackend` uses native `Pin<Box<dyn Future>>` futures (no `async_trait` crate), matching the existing `AuthProvider` pattern in `topic_protection.rs`.
+- `MqdbAgent` no longer owns `vault_key_store`, `vault_min_passphrase_length`, or `vault_unlock_limiter` — those are backend-internal now.
+- Six MQTT and six HTTP vault admin handlers in `mqdb-agent` collapsed into thin dispatchers that delegate to the backend (~1000 lines deleted, net shrinkage).
+- `handle_message` gates `vault_backend.encrypt_request` and `decrypt_response` on the sync `is_eligible` check so the NoopBackend path costs zero `Box::pin` allocations.
+- Cluster HTTP vault admin now works end-to-end via `MqttDbAccess`. Cluster MQTT vault admin remains intentionally unsupported (returns "vault admin not supported in cluster mode" as before).
+- `examples/vault-mqtt-admin/run.sh` and `examples/vault-cluster/run.sh` now require `MQDB_LICENSE_FILE` and pass `--license` to the agent/cluster.
+
+### Fixed
+
+- **Partition snapshot export was missing user data.** `StoreManager::export_partition` in `mqdb-cluster` was exporting 9 of 15 entity store types and omitting `db_data`. Not visible in normal operation (primaries write locally and replicate via the Raft log) but on rebalance-driven replica promotion the new primary returned `entity not found` for pre-rebalance records. Fix adds `db_data` to the export array, the `import_partition` match arm, and `clear_partition`.
+- Cluster E2E probe loop in `examples/vault-cluster/run.sh` now reads `.data.id` from `mqdb create` output (had been reading `.id` since the script landed, silently leaving 20 ghost records per run and skewing count-based test assertions by 20).
+- Cluster vault E2E node 4 `--peers` expanded to all three predecessors so QUIC connections are established to every prior node. Peer auto-discovery via Raft/gossip is tracked as future work.
+- Regressions caught in self-review of the vault extraction: `$DB/_vault/change` and `POST /vault/change` parse `old_passphrase` (not `current_passphrase`); MQTT `VaultError::RateLimited` returns `ErrorCode::RateLimited` (429); `identity not found` returns `NotFound` (404); MQTT `InvalidPassphrase` returns `ErrorCode::Forbidden` (matching pre-refactor behavior).
+
+### Removed
+
+- `mqdb-agent::vault_ops` module (560 lines). Replaced by `mqdb-vault::backend::VaultBackendImpl` behind the `VaultBackend` trait.
+- `mqdb-core::vault_keys` module. Moved to `mqdb-vault::key_store`.
+- `mqdb-agent::vault_transform` module. Moved to `mqdb-vault::transform`.
+- `mqdb-agent::http::vault_crypto`. Moved to `mqdb-vault::crypto`.
+
+### Breaking changes
+
+- `mqdb-core` 0.6.0 → **0.7.0**: `vault_keys` module removed from public API; consumers should depend on `mqdb-vault` directly (AGPL) or rely on the `VaultBackend` trait.
+- `mqdb-agent` 0.7.2 → **0.8.0**: `vault_ops` module removed; `MqdbAgent` lost vault-specific public fields; six vault admin handlers re-shaped as thin dispatchers over `VaultBackend`. Downstream callers that previously imported vault types from `mqdb-agent` must now import the trait from `mqdb-agent::vault_backend` and the implementation from `mqdb-vault` (under AGPL).
+
 ## 2026-04-22 — mqdb-core 0.6.0, mqdb-wasm 0.3.1, mqdb-agent 0.7.2, mqdb-cli 0.7.3
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "base64",
  "bebytes",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cluster"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "arc-swap",
  "bebytes",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.7.2"
+version = "0.8.0"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true
@@ -8,7 +8,7 @@ repository.workspace = true
 description = "Standalone MQTT broker agent with embedded database for MQDB"
 
 [dependencies]
-mqdb-core = { path = "../mqdb-core", version = "0.6.0", features = ["fjall-backend"] }
+mqdb-core = { path = "../mqdb-core", version = "0.7.0", features = ["fjall-backend"] }
 
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.7.3"
+version = "0.7.4"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/Cargo.toml
+++ b/crates/mqdb-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cluster"
-version = "0.3.0"
+version = "0.3.1"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -7,6 +7,7 @@ use super::{
     PendingFkWork, PendingUniqueWork, ReplicationWrite, UniqueCheckContinuation,
     UniqueReservationParams, UniqueReserveStatus, entity,
 };
+use crate::cluster::replication::ReplicaState;
 use crate::cluster::store_manager::outbox::{CascadeOutboxPayload, CascadeRemoteOp, OutboxPayload};
 use mqdb_core::events::ChangeEvent;
 use mqdb_core::types::{MAX_LIST_RESULTS, OwnershipDecision};
@@ -2062,10 +2063,7 @@ impl<T: ClusterTransport> NodeController<T> {
         };
 
         if primary == self.node_id {
-            let replica_role = self
-                .replicas
-                .get(&partition.get())
-                .map(crate::cluster::replication::ReplicaState::role);
+            let replica_role = self.replicas.get(&partition.get()).map(ReplicaState::role);
             tracing::warn!(
                 node = node_id,
                 partition = partition.get(),

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -2062,7 +2062,10 @@ impl<T: ClusterTransport> NodeController<T> {
         };
 
         if primary == self.node_id {
-            let replica_role = self.replicas.get(&partition.get()).map(|s| s.role());
+            let replica_role = self
+                .replicas
+                .get(&partition.get())
+                .map(crate::cluster::replication::ReplicaState::role);
             tracing::warn!(
                 node = node_id,
                 partition = partition.get(),

--- a/crates/mqdb-core/Cargo.toml
+++ b/crates/mqdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-core"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-vault/Cargo.toml
+++ b/crates/mqdb-vault/Cargo.toml
@@ -10,8 +10,8 @@ description = "Vault transparent encryption for MQDB (AGPL, Pro/Enterprise featu
 
 [dependencies]
 base64.workspace = true
-mqdb-agent = { version = "0.7.2", path = "../mqdb-agent" }
-mqdb-core = { version = "0.6.0", path = "../mqdb-core" }
+mqdb-agent = { version = "0.8.0", path = "../mqdb-agent" }
+mqdb-core = { version = "0.7.0", path = "../mqdb-core" }
 mqtt5.workspace = true
 ring.workspace = true
 serde.workspace = true

--- a/crates/mqdb-wasm/Cargo.lock
+++ b/crates/mqdb-wasm/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "arc-swap",
  "bebytes",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-wasm"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "console_error_panic_hook",
  "futures-channel",

--- a/crates/mqdb-wasm/Cargo.toml
+++ b/crates/mqdb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-wasm"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["LabOverWire"]


### PR DESCRIPTION
## Summary

- **This is a metadata-only catch-up PR.** The actual code referenced in the CHANGELOG entry shipped via #49 (license split + vault extraction into `mqdb-vault`) and #50 (`db_data` partition snapshot fix). This PR contains only `Cargo.toml` version edits, a CHANGELOG entry, regenerated lockfiles, and one drive-by fix for a pedantic clippy warning that pre-commit surfaced.
- Bumps crate versions and adds a single dated CHANGELOG entry covering the two functional PRs that have landed on main since v0.7.3. Decoupled from the functional PRs so versioning is clean and reviewable on its own.
- Drive-by fix: pedantic `redundant_closure_for_method_calls` warning at `crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs:2065`, introduced by the diagnostic `warn!()` site added in #50. Replaced `|s| s.role()` with a direct method reference + top-level `use crate::cluster::replication::ReplicaState`.

## Version map

| Crate | From | To | Reason |
|---|---|---|---|
| `mqdb-core` | 0.6.0 | **0.7.0** | breaking: `vault_keys` module removed from public API |
| `mqdb-agent` | 0.7.2 | **0.8.0** | breaking: `vault_ops` module removed, `MqdbAgent` public fields dropped, vault handlers re-shaped around `VaultBackend` |
| `mqdb-wasm` | 0.3.1 | **0.3.2** | license flip only (Apache-2.0) |
| `mqdb-vault` | — | **0.1.0** | new crate (AGPL-3.0-only, publish = false) |
| `mqdb-cluster` | 0.3.0 | **0.3.1** | db_data partition snapshot fix + `DbAccess` integration (publish = false) |
| `mqdb-cli` | 0.7.3 | **0.7.4** | license gating + cluster vault admin routing (publish = false) |

Downstream `Cargo.toml` version specifiers (`mqdb-agent/Cargo.toml` → mqdb-core, `mqdb-vault/Cargo.toml` → mqdb-agent + mqdb-core) updated in lockstep. Both `Cargo.lock` files (workspace + `crates/mqdb-wasm/`) regenerated.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test --workspace --no-run` — all test binaries build clean against the new version specifiers
- [x] `cargo make clippy` (pedantic, all targets + wasm) — clean (fixed the `redundant_closure_for_method_calls` warning)
- [x] `cargo make format-check` — clean
- [x] Pre-commit hook ran `format-check` + `clippy` and passed on every commit