### PR TITLE
fix release workflow license rename and bump mqdb-cli to 0.7.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,7 @@ jobs:
             "name": "mqdb-wasm",
             "version": "${{ steps.wasm-version.outputs.version }}",
             "description": "WASM client library for MQDB reactive database",
-            "license": "AGPL-3.0-only",
+            "license": "Apache-2.0",
             "repository": {
               "type": "git",
               "url": "https://github.com/LabOverWire/MQDB"
@@ -124,7 +124,7 @@ jobs:
 
       - name: Copy LICENSE
         if: steps.npm-check.outputs.skip != 'true'
-        run: cp LICENSE pkg/
+        run: cp LICENSE-APACHE pkg/LICENSE
 
       - name: Publish to npm
         if: steps.npm-check.outputs.skip != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-04-25 — mqdb-cli 0.7.5
+
+### Fixed
+
+- Release workflow updated for the `LICENSE` file rename (introduced by the 0.7.0/0.8.0 license split). The npm publish step in `.github/workflows/release.yml` was still running `cp LICENSE pkg/` and declaring `"license": "AGPL-3.0-only"` in `pkg/package.json` — both incorrect after `LICENSE` was split into `LICENSE-APACHE` + `LICENSE-AGPL` and `mqdb-wasm` was relicensed to Apache-2.0. The v0.7.4 tag's workflow run failed at the `Copy LICENSE` step before the npm publish could happen, so `mqdb-wasm 0.3.2` was not published. Bumping `mqdb-cli` to 0.7.5 lets us cut a fresh `v0.7.5` tag whose workflow run will use the fixed steps and complete the npm publish.
+
 ## 2026-04-24 — mqdb-core 0.7.0, mqdb-agent 0.8.0, mqdb-wasm 0.3.2, mqdb-vault 0.1.0, mqdb-cluster 0.3.1, mqdb-cli 0.7.4
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "base64",
  "bebytes",

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.7.4"
+version = "0.7.5"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary

The v0.7.4 release workflow failed at the npm publish step with:

```
Run cp LICENSE pkg/
cp: cannot stat 'LICENSE': No such file or directory
Error: Process completed with exit code 1.
```

PR #49 split `LICENSE` into `LICENSE-APACHE` + `LICENSE-AGPL` and relicensed `mqdb-wasm` to Apache-2.0, but `.github/workflows/release.yml` was missed:

- Line 110 still declared `"license": "AGPL-3.0-only"` in the generated `pkg/package.json`.
- Line 127 still ran `cp LICENSE pkg/`, the file that no longer exists.

The crates.io publish step (mqdb-core 0.7.0, mqdb-agent 0.8.0) succeeded before this failure — those are live on crates.io. Only the npm publish of `mqdb-wasm 0.3.2` did not happen.

## Changes

- `pkg/package.json` license string: `AGPL-3.0-only` → `Apache-2.0`
- License copy step: `cp LICENSE pkg/` → `cp LICENSE-APACHE pkg/LICENSE` (npm tooling expects the file named `LICENSE`).
- `mqdb-cli` 0.7.4 → 0.7.5; CHANGELOG entry under 2026-04-25.

## Test plan

- [x] `cargo make format-check` + `cargo make clippy` clean (pre-commit hook ran on both commits)
- [x] `cargo check -p mqdb-cli` clean — Cargo.lock regenerated