### PR TITLE
clarify wasm openEncrypted is not the same as server-side vault

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,8 @@ Password change and reset are also available over MQTT 5.0 request-response for 
 
 ## Vault Encryption
 
+> **Server-side only.** This section describes the `mqdb-vault` crate, which provides selective field-level encryption for the agent and cluster. The client-side `mqdb-wasm` crate has a **separate** encryption feature (`Database.openEncrypted`) that wraps the entire IndexedDB-backed database. They share crypto primitives but solve different problems — see [crates/mqdb-wasm/README.md](crates/mqdb-wasm/README.md#client-side-encryption-vs-server-side-vault) for the comparison.
+
 Per-user transparent encryption at rest. Each user derives an AES-256-GCM key from a passphrase. When the vault is unlocked, MQTT reads and writes transparently decrypt and encrypt owned entity fields. When locked, raw ciphertext is returned. Users without the vault key always see ciphertext, proving data is encrypted at rest.
 
 All JSON leaf values at any depth are encrypted, including strings, numbers, booleans, and nulls inside nested objects and arrays. Non-string types are serialized before encryption and restored to their original types on decryption. Keys starting with `_` (system metadata) are skipped at all depths; the ownership field and `id` are skipped at the top level only.

--- a/crates/mqdb-wasm/README.md
+++ b/crates/mqdb-wasm/README.md
@@ -66,9 +66,28 @@ const listed = await db.execute("$DB/users/list", {});
 |-------------|---------|-------------|------------|--------------|
 | `new Database()` | Memory | No | No | Yes |
 | `Database.openPersistent(name)` | IndexedDB | Yes | No | No |
-| `Database.openEncrypted(name, passphrase)` | IndexedDB | Yes | AES-GCM | No |
+| `Database.openEncrypted(name, passphrase)` | IndexedDB | Yes | AES-256-GCM | No |
 
-Persistent backends automatically reload schemas, constraints, indexes, relationships, and ID counters on open. Encrypted backends derive a 256-bit key from the passphrase via PBKDF2 (100k iterations) and encrypt each record independently with AES-GCM.
+Persistent backends automatically reload schemas, constraints, indexes, relationships, and ID counters on open. Encrypted backends derive a 256-bit key from the passphrase via PBKDF2-SHA256 (600,000 iterations, 32-byte salt) using the browser's `SubtleCrypto` API, and encrypt every value going through the storage layer with AES-256-GCM (12-byte nonce, AAD bound to the storage key).
+
+## Client-Side Encryption vs Server-Side Vault
+
+`Database.openEncrypted` is **not** the same feature as MQDB's server-side **Vault** (`mqdb-vault`). They share crypto primitives (AES-256-GCM, PBKDF2-SHA256, 600k iterations) but solve different problems with different operational models — do not assume one is a port of the other.
+
+| | `openEncrypted` (this crate) | `mqdb-vault` (server-side) |
+|---|---|---|
+| **Where** | In-browser, via WebCrypto | Agent / cluster, via `ring` |
+| **License** | Apache-2.0 | AGPL-3.0-only (Pro/Enterprise) |
+| **Scope** | Whole database — every byte going through the storage backend (records, indexes, schemas, constraints, all metadata) | Selected JSON field values per entity, opt-in. Keys, IDs, owner field, and `_*` system fields stay plaintext |
+| **Granularity** | All-or-nothing at `open` time | Per-entity opt-in, can be enabled/disabled at runtime |
+| **Lock state machine** | None — passphrase entered once at `openEncrypted`, released only by closing the page | Full state machine: `enable`, `unlock`, `lock`, `disable`, `change` admin endpoints with rate-limited unlock |
+| **Migration** | Not needed — every byte encrypted from the start | Two-way migration: `enable` encrypts existing plaintext records; `disable` decrypts them |
+| **Indexes work on encrypted fields** | Yes — backend transparently decrypts index entries on lookup | No — encrypted field values become random base64 each write, so equality/range queries against encrypted fields fail |
+| **AAD** | Storage key (e.g. `data/people/rec-1`) | `entity:id` (e.g. `people:rec-1`) |
+| **Threat model** | Protects user data on the user's own device against other browser apps, IndexedDB inspection, device theft | Protects user data on a server operator's disk against the operator and their backups |
+| **Who holds the passphrase** | The end user | The application owner / operator |
+
+Use `openEncrypted` when you want a self-contained client-side database that never leaves plaintext at rest in the browser. Use `mqdb-vault` when you run a server and need selective field-level protection with operational lock/unlock controls.
 
 ## API
 
@@ -195,7 +214,7 @@ await db.execute("$DB/_catalog", {});
 
 - `new Database()` creates an in-memory instance (data lost on page refresh)
 - `Database.openPersistent(name)` creates an IndexedDB-backed instance that persists schemas, constraints, indexes, relationships, and data across page reloads
-- `Database.openEncrypted(name, passphrase)` adds AES-GCM encryption on top of IndexedDB persistence; wrong passphrase is detected on open
+- `Database.openEncrypted(name, passphrase)` adds AES-256-GCM encryption on top of IndexedDB persistence; wrong passphrase is detected on open. This is client-side whole-DB encryption — see "Client-Side Encryption vs Server-Side Vault" above for how this differs from `mqdb-vault`
 - Sync methods (`*Sync`) only work with the memory backend; they throw on IndexedDB
 - All records carry a `_version` field that increments on every update (used for CAS via `expect_value`)
 - Field types: `string`, `number`, `boolean`, `array`, `object`

--- a/docs/encryption-architecture.md
+++ b/docs/encryption-architecture.md
@@ -1,6 +1,8 @@
 # MQDB Encryption Architecture
 
-MQDB implements two independent encryption-at-rest systems: **Vault** (user-controlled) and **Identity** (server-managed). Both use AES-256-GCM authenticated encryption. This document describes the verified architecture as implemented in code.
+> **Scope:** this document covers **server-side** encryption — Vault and Identity — as implemented in `mqdb-vault` and `mqdb-agent`. The client-side `mqdb-wasm` crate has its own, **separate** encryption feature exposed as `Database.openEncrypted(name, passphrase)`. It shares crypto primitives (AES-256-GCM, PBKDF2-SHA256, 600k iterations) with Vault but is a different system with a different threat model: it encrypts the whole client-side IndexedDB at the storage layer to keep plaintext off the user's device. It is **not** a port of Vault, has no lock/unlock state machine, no per-entity opt-in, and no operator-side admin endpoints. See `crates/mqdb-wasm/README.md` ("Client-Side Encryption vs Server-Side Vault") for the comparison and `crates/mqdb-wasm/src/crypto.rs` for the implementation.
+
+MQDB implements two independent encryption-at-rest systems on the server: **Vault** (user-controlled) and **Identity** (server-managed). Both use AES-256-GCM authenticated encryption. This document describes the verified architecture as implemented in code.
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation gap: `mqdb-wasm`'s `Database.openEncrypted` and `mqdb-vault` share crypto primitives (AES-256-GCM, PBKDF2-SHA256, 600k iterations) but are different systems with different threat models. Nothing in the docs distinguished them, so a reader could reasonably assume one is a port of the other. This PR fixes that in three targeted edits — no new docs files.

## Changes

- **`crates/mqdb-wasm/README.md`**: added a "Client-Side Encryption vs Server-Side Vault" section with a side-by-side comparison table covering scope, granularity, lock state machine, migration, indexes, AAD, threat model, and passphrase ownership. Also fixed an inaccuracy in the existing description: it claimed PBKDF2 used 100k iterations, the code uses 600k. Strengthened the encryption description to name SubtleCrypto, salt length, nonce length, and AAD binding.
- **`docs/encryption-architecture.md`**: added a scope note at the top clarifying the doc covers server-side encryption only and pointing readers to the wasm README + `crates/mqdb-wasm/src/crypto.rs` for the client-side story.
- **`README.md`**: added a "Server-side only" callout at the top of the Vault Encryption section linking to the wasm README comparison.

## Test plan

- [x] `cargo make format-check` + `cargo make clippy` clean (pre-commit hook ran on the commit)
- [x] Verified the "100k iterations" claim against `crates/mqdb-wasm/src/crypto.rs:14` — actual is 600,000
- [x] Verified the comparison table claims against the actual implementations of `crates/mqdb-wasm/src/crypto.rs` + `crates/mqdb-wasm/src/lib.rs:open_encrypted` and `crates/mqdb-vault/src/{crypto,backend}.rs`