### PR TITLE
extract release notes from date-headed changelog entries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,7 +194,39 @@ jobs:
         id: changelog
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
-          BODY=$(awk "/^## \[$TAG\]/{found=1; next} /^## \[/{if(found) exit} found{print}" CHANGELOG.md)
+          BODY=$(python3 - "$TAG" <<'PY'
+          import re, sys
+          tag = sys.argv[1]
+          lines = open("CHANGELOG.md").read().splitlines()
+          # Headings look like: ## YYYY-MM-DD — mqdb-<crate> <version>[, mqdb-... <version>]*
+          heading = re.compile(r"^## (\d{4}-\d{2}-\d{2}) — (.*)$")
+          # Find the heading that lists mqdb-cli <tag>; that anchors the release date.
+          anchor_date = None
+          for line in lines:
+              m = heading.match(line)
+              if m and re.search(rf"\bmqdb-cli\s+{re.escape(tag)}\b", m.group(2)):
+                  anchor_date = m.group(1)
+                  break
+          if anchor_date is None:
+              # No matching heading — emit empty body so the release still publishes.
+              sys.exit(0)
+          # Collect every section dated anchor_date (covers parallel crate bumps).
+          out, capturing = [], False
+          for line in lines:
+              m = heading.match(line)
+              if m:
+                  capturing = (m.group(1) == anchor_date)
+                  if capturing:
+                      out.append(line)
+                  continue
+              if capturing:
+                  out.append(line)
+          # Trim trailing blank lines.
+          while out and out[-1].strip() == "":
+              out.pop()
+          print("\n".join(out))
+          PY
+          )
           {
             echo "body<<CHANGELOG_EOF"
             echo "$BODY"


### PR DESCRIPTION
## Summary

The release workflow at `.github/workflows/release.yml` extracts the GitHub Release body via:

\`\`\`awk
/^## \[$TAG\]/{found=1; next} /^## \[/{if(found) exit} found{print}
\`\`\`

That pattern looks for \`## [0.7.5]\`-style headings, but every CHANGELOG entry in this repo uses the date-led form \`## YYYY-MM-DD — mqdb-<crate> <version>\`. Net effect: every release since at least v0.7.5 has shipped with an empty release body. Confirmed via \`gh release view v0.7.5 --json body\` (length: 0).

This PR replaces the awk one-liner with a small Python script (heredoc inside the existing \`run:\` step — no new tooling) that:

1. Finds the heading containing \`mqdb-cli <tag>\` and remembers its date (the release date).
2. Walks the file again and emits every section dated the same day — covering parallel crate bumps like the pending v0.7.6, which carries both \`mqdb-cli 0.7.6\` and \`mqdb-cluster 0.3.4\` dated 2026-05-06.
3. Trims trailing blank lines.
4. Falls back to an empty body (not a failure) if no matching heading is found, so a release where the CHANGELOG was forgotten still publishes binaries.

No CHANGELOG content moves; the existing date-led convention is preserved.

## Test plan

- [x] Dry-run for tag \`0.7.6\` against current \`CHANGELOG.md\` — extracts both the \`mqdb-cli 0.7.6\` and \`mqdb-cluster 0.3.4\` sections plus the \"Discovered while running the new E2E\" subsection.
- [x] Dry-run for tag \`0.7.5\` against current \`CHANGELOG.md\` — extracts the \`mqdb-cluster 0.3.2\` and \`mqdb-cli 0.7.5\` sections (both dated 2026-04-25). Confirms backward extraction.
- [x] YAML parses cleanly via \`yaml.safe_load\`; the heredoc closing \`PY\` lands at column 0 after block-scalar de-indentation.
- [x] \`cargo make format-check\` — clean.
- [x] \`cargo make clippy\` — clean (pedantic, all targets + wasm).
- [x] Pre-commit hook ran on the commit and passed.