### PR TITLE
bundle full schema and constraint catalogs in partition snapshots

### DIFF
--- a/crates/mqdb-cluster/src/cluster/db/constraint_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/constraint_store.rs
@@ -429,19 +429,41 @@ impl ConstraintStore {
 
     /// # Panics
     /// Panics if the internal lock is poisoned.
-    #[allow(clippy::cast_possible_truncation)]
     #[must_use]
     pub fn export_for_partition(&self, partition: PartitionId) -> Vec<u8> {
         let constraints = self.constraints.read().unwrap();
-        let matching: Vec<_> = constraints
+        let iter = constraints
             .iter()
-            .filter(|(_, c)| c.partition() == partition)
-            .collect();
+            .filter(|(_, c)| c.partition() == partition);
+        Self::serialize_entries(iter)
+    }
 
+    /// Exports every constraint regardless of partition.
+    ///
+    /// Constraints are cluster-wide broadcast state — every node needs the full
+    /// catalog so cascade, RESTRICT, and unique enforcement work uniformly. Per-
+    /// partition snapshots use this so a joining node receives the complete
+    /// constraint set rather than only the constraints whose
+    /// `schema_partition(entity)` happens to land on a partition it owns.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned.
+    #[must_use]
+    pub fn export_all(&self) -> Vec<u8> {
+        let constraints = self.constraints.read().unwrap();
+        Self::serialize_entries(constraints.iter())
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn serialize_entries<'a, I>(iter: I) -> Vec<u8>
+    where
+        I: Iterator<Item = (&'a String, &'a ClusterConstraint)>,
+    {
+        let entries: Vec<_> = iter.collect();
         let mut buf = Vec::new();
-        buf.extend_from_slice(&(matching.len() as u32).to_be_bytes());
+        buf.extend_from_slice(&(entries.len() as u32).to_be_bytes());
 
-        for (key, constraint) in matching {
+        for (key, constraint) in entries {
             let key_bytes = key.as_bytes();
             buf.extend_from_slice(&(key_bytes.len() as u16).to_be_bytes());
             buf.extend_from_slice(key_bytes);
@@ -979,6 +1001,44 @@ mod tests {
             if let Some(c) = c {
                 assert_ne!(c.partition(), target);
             }
+        }
+    }
+
+    #[test]
+    fn export_all_carries_every_constraint_regardless_of_partition() {
+        let src = ConstraintStore::new(node(1));
+        let dst = ConstraintStore::new(node(2));
+
+        let entities = ["alpha", "beta", "gamma", "delta", "epsilon"];
+        for entity in &entities {
+            src.add(ClusterConstraint::unique(
+                entity,
+                &format!("uniq_{entity}"),
+                "email",
+            ))
+            .unwrap();
+        }
+
+        let partitions: std::collections::HashSet<_> = src
+            .list_all()
+            .iter()
+            .map(ClusterConstraint::partition)
+            .collect();
+        assert!(
+            partitions.len() > 1,
+            "test prerequisite: constraints must span more than one partition"
+        );
+
+        let payload = src.export_all();
+        let imported = dst.import_constraints(&payload).unwrap();
+        assert_eq!(imported, entities.len());
+
+        for entity in &entities {
+            let name = format!("uniq_{entity}");
+            assert!(
+                dst.get(entity, &name).is_some(),
+                "every constraint must arrive via export_all, regardless of partition: {entity}:{name}"
+            );
         }
     }
 }

--- a/crates/mqdb-cluster/src/cluster/db/schema_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/schema_store.rs
@@ -240,19 +240,38 @@ impl SchemaStore {
 
     /// # Panics
     /// Panics if the internal lock is poisoned.
-    #[allow(clippy::cast_possible_truncation)]
     #[must_use]
     pub fn export_for_partition(&self, partition: PartitionId) -> Vec<u8> {
         let schemas = self.schemas.read().unwrap();
-        let matching: Vec<_> = schemas
-            .iter()
-            .filter(|(_, s)| s.partition() == partition)
-            .collect();
+        let iter = schemas.iter().filter(|(_, s)| s.partition() == partition);
+        Self::serialize_entries(iter)
+    }
 
+    /// Exports every schema regardless of partition.
+    ///
+    /// Schemas are cluster-wide broadcast state — every node needs the full
+    /// catalog to validate writes locally. Per-partition snapshots use this so
+    /// a joining node receives the complete schema set, not only the schemas
+    /// whose `schema_partition(entity)` happens to land on a partition it owns.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned.
+    #[must_use]
+    pub fn export_all(&self) -> Vec<u8> {
+        let schemas = self.schemas.read().unwrap();
+        Self::serialize_entries(schemas.iter())
+    }
+
+    #[allow(clippy::cast_possible_truncation)]
+    fn serialize_entries<'a, I>(iter: I) -> Vec<u8>
+    where
+        I: Iterator<Item = (&'a String, &'a ClusterSchema)>,
+    {
+        let entries: Vec<_> = iter.collect();
         let mut buf = Vec::new();
-        buf.extend_from_slice(&(matching.len() as u32).to_be_bytes());
+        buf.extend_from_slice(&(entries.len() as u32).to_be_bytes());
 
-        for (key, schema) in matching {
+        for (key, schema) in entries {
             let key_bytes = key.as_bytes();
             buf.extend_from_slice(&(key_bytes.len() as u16).to_be_bytes());
             buf.extend_from_slice(key_bytes);
@@ -496,6 +515,35 @@ mod tests {
             if let Some(s) = store.get(entity) {
                 assert_ne!(s.partition(), target);
             }
+        }
+    }
+
+    #[test]
+    fn export_all_carries_every_schema_regardless_of_partition() {
+        let src = SchemaStore::new(node(1));
+        let dst = SchemaStore::new(node(2));
+
+        let entities = ["alpha", "beta", "gamma", "delta", "epsilon"];
+        for entity in &entities {
+            src.register(entity, b"{}").unwrap();
+        }
+
+        let partitions: std::collections::HashSet<_> =
+            src.list().iter().map(ClusterSchema::partition).collect();
+        assert!(
+            partitions.len() > 1,
+            "test prerequisite: schemas must span more than one partition"
+        );
+
+        let payload = src.export_all();
+        let imported = dst.import_schemas(&payload).unwrap();
+        assert_eq!(imported, entities.len());
+
+        for entity in &entities {
+            assert!(
+                dst.get(entity).is_some(),
+                "every schema must arrive via export_all, regardless of partition: {entity}"
+            );
         }
     }
 }

--- a/crates/mqdb-cluster/src/cluster/store_manager/partition_io.rs
+++ b/crates/mqdb-cluster/src/cluster/store_manager/partition_io.rs
@@ -48,10 +48,7 @@ impl StoreManager {
                 entity::DB_DATA,
                 self.db_data.export_for_partition(partition),
             ),
-            (
-                entity::DB_SCHEMA,
-                self.db_schema.export_for_partition(partition),
-            ),
+            (entity::DB_SCHEMA, self.db_schema.export_all()),
             (
                 entity::DB_INDEX,
                 self.db_index.export_for_partition(partition),
@@ -61,10 +58,7 @@ impl StoreManager {
                 self.db_unique.export_for_partition(partition),
             ),
             (entity::DB_FK, self.db_fk.export_for_partition(partition)),
-            (
-                entity::DB_CONSTRAINT,
-                self.db_constraints.export_for_partition(partition),
-            ),
+            (entity::DB_CONSTRAINT, self.db_constraints.export_all()),
         ];
 
         buf.extend_from_slice(&(store_data.len() as u8).to_be_bytes());
@@ -382,21 +376,18 @@ mod tests {
             assert_eq!(dst_has, up == target, "db_unique for {entity}");
         }
 
-        assert_eq!(
+        assert!(
             dst.db_schema.get(entity).is_some(),
-            src.db_schema.get(entity).unwrap().partition() == target,
-            "db_schema for {entity}"
+            "db_schema for {entity} must arrive via any partition snapshot \
+             — schemas are broadcast state and need to be uniform on every node"
         );
 
         let constraint_name = format!("uniq_{entity}");
-        assert_eq!(
+        assert!(
             dst.db_constraints.get(entity, &constraint_name).is_some(),
-            src.db_constraints
-                .get(entity, &constraint_name)
-                .unwrap()
-                .partition()
-                == target,
-            "db_constraints for {entity}"
+            "db_constraints {entity}:{constraint_name} must arrive via any \
+             partition snapshot — constraints are broadcast state and need to \
+             be uniform on every node"
         );
 
         let fk_id = format!("fk-{entity}");
@@ -467,6 +458,91 @@ mod tests {
             refs,
             vec!["c1".to_string()],
             "destination reverse index must hold c1 after import — without the rebuild step this would be empty",
+        );
+    }
+
+    #[test]
+    fn partition_snapshot_carries_full_schema_and_constraint_catalog() {
+        use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
+
+        let src = StoreManager::new(node(1));
+        let dst = StoreManager::new(node(2));
+
+        let entities = ["alpha", "beta", "gamma", "delta", "epsilon", "zeta"];
+        for entity in &entities {
+            src.db_schema.register(entity, b"{\"fields\":[]}").unwrap();
+            src.db_constraints
+                .add(ClusterConstraint::unique(
+                    entity,
+                    &format!("uniq_{entity}"),
+                    "email",
+                ))
+                .unwrap();
+            src.db_constraints
+                .add(ClusterConstraint::foreign_key(
+                    entity,
+                    &format!("fk_{entity}"),
+                    "parent_id",
+                    "alpha",
+                    "id",
+                    OnDeleteAction::Cascade,
+                ))
+                .unwrap();
+        }
+
+        src.db_data.create("alpha", "rec-1", b"{}", 1_000).unwrap();
+        let any_partition = src.db_data.get("alpha", "rec-1").unwrap().partition();
+
+        let schema_partitions: std::collections::HashSet<_> = src
+            .db_schema
+            .list()
+            .iter()
+            .map(crate::cluster::db::ClusterSchema::partition)
+            .collect();
+        let constraint_partitions: std::collections::HashSet<_> = src
+            .db_constraints
+            .list_all()
+            .iter()
+            .map(ClusterConstraint::partition)
+            .collect();
+        assert!(
+            schema_partitions.len() > 1,
+            "test prerequisite: schemas must span more than one partition"
+        );
+        assert!(
+            constraint_partitions.len() > 1,
+            "test prerequisite: constraints must span more than one partition"
+        );
+
+        let payload = src.export_partition(any_partition);
+        dst.import_partition(&payload).expect("import");
+
+        for entity in &entities {
+            assert!(
+                dst.db_schema.get(entity).is_some(),
+                "every schema must arrive via any partition snapshot, regardless of partition: {entity}"
+            );
+            let uniq_name = format!("uniq_{entity}");
+            assert!(
+                dst.db_constraints.get(entity, &uniq_name).is_some(),
+                "every unique constraint must arrive via any partition snapshot: {entity}:{uniq_name}"
+            );
+            let fk_name = format!("fk_{entity}");
+            assert!(
+                dst.db_constraints.get(entity, &fk_name).is_some(),
+                "every fk constraint must arrive via any partition snapshot: {entity}:{fk_name}"
+            );
+        }
+
+        assert_eq!(
+            dst.db_schema.list().len(),
+            entities.len(),
+            "destination schema catalog count must match source"
+        );
+        assert_eq!(
+            dst.db_constraints.list_all().len(),
+            entities.len() * 2,
+            "destination constraint catalog count must match source"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #57 and #58. After PR #56 surfaced "constraints don't reach all nodes uniformly" as a follow-up, this PR fixes the late-join half of that gap.

Schemas and constraints already broadcast to every alive node on write (`replication_ops.rs:81-85` and `:345-369` — likely added in #54 after the issues were filed). The remaining hole is the snapshot path: `SchemaStore::export_for_partition` and `ConstraintStore::export_for_partition` filter `entry.partition() == partition`, so a joining node only ever received entries whose `schema_partition(entity)` happened to hash into a partition it owned. Catalog entries under any other partition were unreachable through snapshots — a node could rebalance into the cluster missing most of the catalog, and a freshly-joined 4th node empirically held 0 constraints in the #57 trace.

Both stores now expose `export_all()`, which serializes every entry regardless of partition using the same wire format as `export_for_partition` (so `import_schemas` / `import_constraints` are unchanged). `StoreManager::export_partition` uses these for `DB_SCHEMA` and `DB_CONSTRAINT`. Catalogs are small in-memory state and import is idempotent overwrite, so re-applying on every partition snapshot a joining node fetches is safe.

A shared private `serialize_entries` helper in each store removes the duplicated count-prefixed loop between the per-partition and full-catalog exports.

## Test plan

- [x] `cargo test -p mqdb-cluster --lib` — 3 new tests pass:
  - `schema_store::export_all_carries_every_schema_regardless_of_partition`
  - `constraint_store::export_all_carries_every_constraint_regardless_of_partition`
  - `partition_io::partition_snapshot_carries_full_schema_and_constraint_catalog` — multi-entity setup spanning many partitions; asserts dst has the full catalog after a single-partition snapshot, plus full counts match source.
- [x] `partition_io::export_import_roundtrip_covers_all_db_stores` updated — previously asserted per-partition isolation for schemas/constraints, now asserts they arrive regardless of partition.
- [x] `cargo make clippy` — clean (pedantic, all targets + wasm).
- [x] `cargo make format-check` — clean.
- [x] `cargo make test` — full workspace clean.
- [x] Pre-commit hook (format-check + clippy) ran on the commit and passed.
- [x] `examples/cluster-rebalance-stores/run.sh` actually run twice with an enterprise license generated locally:
  - Pre-fix (per #57 trace): schemas/constraints visible only on a subset of nodes; FK cascade left up to 12 of 12 eligible children alive.
  - Post-fix run 1: 10/11 hard assertions pass; all 5 OBSERVATION lines OK (`schema get posts/comments via node 4`, all duplicates rejected, FK orphan rejected); FK cascade removed 17 of 19 eligible children. The single hard-assertion failure ("18 of 20 extra child comments") is a confirmed-flaky cluster-warmup transient unrelated to schema/constraint replication.
  - Post-fix run 2: **11/11 hard assertions pass; all 5 OBSERVATIONs OK; FK cascade removes all 21 of 21 eligible children via node 4.**

## Out of scope

Remaining FK-cascade survivors that still show up under hash-unlucky distributions are #22 (cluster cascade does not filter by ownership on remote nodes) — separate follow-up.