### PR TITLE
remove dead clear_partition for broadcast catalog stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-05-19 — mqdb-cluster 0.3.5
+
+### Removed
+
+- `StoreManager::clear_partition` (the 15-line aggregator at `partition_io.rs:206`). It had **no callers anywhere in the codebase** — production, tests, or otherwise — and aggregated per-partition wipes across stores that included the broadcast catalog (schemas, constraints). With schemas and constraints now treated as broadcast state on the export side (every partition snapshot ships the full catalog, per the 0.3.2 / 0.3.4 work), the aggregator was wrong-by-construction: a partition wipe must not drop catalog entries that every node is supposed to hold.
+- `SchemaStore::clear_partition` and its `clear_partition_removes_only_target` unit test. The method was referenced only by its own test; nothing in the migration, rebalance, or snapshot paths called it.
+- `ConstraintStore::clear_partition` and its `clear_partition_removes_only_target` unit test. Same dead-code-with-self-test status as above.
+- Per-partition `clear_partition` on `DbDataStore`, `IndexStore`, `UniqueStore`, `FkValidationStore`, and the MQTT-side stores (sessions, retained, topics, wildcards, inflight, offsets, idempotency, qos2) is intentionally preserved — those stores are genuinely partition-scoped.
+
+### Changed
+
+- Added struct-level doc comments on `SchemaStore` and `ConstraintStore` documenting the broadcast-catalog invariant: every node holds the full catalog, every partition snapshot ships all entries, and there is intentionally no per-partition clearing API. Makes the invariant explicit at the point where a future contributor would otherwise consider adding a clearing method.
+
+### Notes
+
+- Follow-up to the broadcast-catalog model established by PR #61 (the export-side counterpart). 83 deletions across `partition_io.rs`, `schema_store.rs`, and `constraint_store.rs`; 12 lines of documentation added.
+
 ## 2026-05-06 — mqdb-cli 0.7.6
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cluster"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/crates/mqdb-cluster/Cargo.toml
+++ b/crates/mqdb-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cluster"
-version = "0.3.4"
+version = "0.3.5"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/src/cluster/db/constraint_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/constraint_store.rs
@@ -205,6 +205,12 @@ impl std::fmt::Display for ConstraintStoreError {
 
 impl std::error::Error for ConstraintStoreError {}
 
+/// Cluster-wide constraint catalog (unique + foreign-key definitions).
+///
+/// Constraints are broadcast state: every node holds the full catalog and
+/// every partition snapshot ships all entries. There is intentionally no
+/// per-partition clearing API — a partition wipe must not drop catalog
+/// entries that every node is supposed to hold.
 pub struct ConstraintStore {
     node_id: NodeId,
     constraints: RwLock<HashMap<String, ClusterConstraint>>,

--- a/crates/mqdb-cluster/src/cluster/db/constraint_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/constraint_store.rs
@@ -533,15 +533,6 @@ impl ConstraintStore {
 
         Ok(imported)
     }
-
-    /// # Panics
-    /// Panics if the internal lock is poisoned.
-    pub fn clear_partition(&self, partition: PartitionId) -> usize {
-        let mut constraints = self.constraints.write().unwrap();
-        let before = constraints.len();
-        constraints.retain(|_, c| c.partition() != partition);
-        before - constraints.len()
-    }
 }
 
 impl std::fmt::Debug for ConstraintStore {
@@ -974,32 +965,6 @@ mod tests {
                     "constraint from partition {} leaked into snapshot",
                     src_c.partition().get()
                 );
-            }
-        }
-    }
-
-    #[test]
-    fn clear_partition_removes_only_target() {
-        let store = ConstraintStore::new(node(1));
-        let entities = ["alpha", "beta", "gamma", "delta"];
-        for entity in &entities {
-            store
-                .add(ClusterConstraint::unique(
-                    entity,
-                    &format!("uniq_{entity}"),
-                    "email",
-                ))
-                .unwrap();
-        }
-
-        let target = store.get("alpha", "uniq_alpha").unwrap().partition();
-        let removed = store.clear_partition(target);
-        assert!(removed >= 1);
-
-        for entity in &entities {
-            let c = store.get(entity, &format!("uniq_{entity}"));
-            if let Some(c) = c {
-                assert_ne!(c.partition(), target);
             }
         }
     }

--- a/crates/mqdb-cluster/src/cluster/db/schema_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/schema_store.rs
@@ -341,15 +341,6 @@ impl SchemaStore {
 
         Ok(imported)
     }
-
-    /// # Panics
-    /// Panics if the internal lock is poisoned.
-    pub fn clear_partition(&self, partition: PartitionId) -> usize {
-        let mut schemas = self.schemas.write().unwrap();
-        let before = schemas.len();
-        schemas.retain(|_, s| s.partition() != partition);
-        before - schemas.len()
-    }
 }
 
 impl std::fmt::Debug for SchemaStore {
@@ -495,25 +486,6 @@ mod tests {
                     "schema {:?} from a different partition leaked into snapshot",
                     schema.entity_str()
                 );
-            }
-        }
-    }
-
-    #[test]
-    fn clear_partition_removes_only_target() {
-        let store = SchemaStore::new(node(1));
-        store.register("alpha", b"{}").unwrap();
-        store.register("beta", b"{}").unwrap();
-        store.register("gamma", b"{}").unwrap();
-
-        let target = store.get("alpha").unwrap().partition();
-        let removed = store.clear_partition(target);
-
-        assert!(removed >= 1);
-        assert!(store.get("alpha").is_none());
-        for entity in ["beta", "gamma"] {
-            if let Some(s) = store.get(entity) {
-                assert_ne!(s.partition(), target);
             }
         }
     }

--- a/crates/mqdb-cluster/src/cluster/db/schema_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/schema_store.rs
@@ -94,6 +94,12 @@ impl std::fmt::Display for SchemaStoreError {
 
 impl std::error::Error for SchemaStoreError {}
 
+/// Cluster-wide schema catalog.
+///
+/// Schemas are broadcast state: every node holds the full catalog and every
+/// partition snapshot ships all entries. There is intentionally no
+/// per-partition clearing API — a partition wipe must not drop catalog
+/// entries that every node is supposed to hold.
 pub struct SchemaStore {
     node_id: NodeId,
     schemas: RwLock<HashMap<String, ClusterSchema>>,

--- a/crates/mqdb-cluster/src/cluster/store_manager/partition_io.rs
+++ b/crates/mqdb-cluster/src/cluster/store_manager/partition_io.rs
@@ -196,26 +196,6 @@ impl StoreManager {
             }
         }
     }
-
-    pub fn clear_partition(&self, partition: PartitionId) -> usize {
-        let mut total_cleared = 0;
-        total_cleared += self.sessions.clear_partition(partition);
-        total_cleared += self.qos2.clear_partition(partition);
-        total_cleared += self.subscriptions.clear_partition(partition);
-        total_cleared += self.retained.clear_partition(partition);
-        total_cleared += self.topics.clear_partition(partition);
-        total_cleared += self.wildcards.clear_partition(partition);
-        total_cleared += self.inflight.clear_partition(partition);
-        total_cleared += self.offsets.clear_partition(partition);
-        total_cleared += self.idempotency.clear_partition(partition);
-        total_cleared += self.db_data.clear_partition(partition);
-        total_cleared += self.db_schema.clear_partition(partition);
-        total_cleared += self.db_index.clear_partition(partition);
-        total_cleared += self.db_unique.clear_partition(partition);
-        total_cleared += self.db_fk.clear_partition(partition);
-        total_cleared += self.db_constraints.clear_partition(partition);
-        total_cleared
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Follow-up to #61. With schemas and constraints now treated as broadcast state on the export side (every partition snapshot carries the full catalog), the per-partition `clear_partition` methods on `SchemaStore` and `ConstraintStore` are wrong-by-construction — they let a partition wipe drop catalog entries that every node is supposed to hold.

Audit finding before deleting:

- `StoreManager::clear_partition` (the aggregator at `partition_io.rs:206-224`) has **zero callers anywhere** in the codebase — not production, not tests. Pure dead code.
- `SchemaStore::clear_partition` and `ConstraintStore::clear_partition` are referenced only by their own unit tests (`clear_partition_removes_only_target`). Nothing in the migration, rebalance, or snapshot paths calls them.
- `import_partition` (`snapshot.rs:95`) does not clear before importing, so the broadcast invariant established by #61 is intact today.

Rather than leaving a comment warning future readers not to wire these into a partition-relinquishment path, this PR removes the footgun outright:

- Deletes `StoreManager::clear_partition` (15-line dead aggregator).
- Deletes `SchemaStore::clear_partition` + its unit test.
- Deletes `ConstraintStore::clear_partition` + its unit test.

Per-partition `clear_partition` on `DataStore`, `IndexStore`, `UniqueStore`, `FkStore`, and the MQTT-side stores (sessions, retained, topics, etc.) is unchanged — those are genuinely partition-scoped.

83 deletions, 0 additions, 3 files.

## Test plan

- [x] `cargo make clippy` — clean (pedantic, all targets + wasm).
- [x] `cargo make format-check` — clean.
- [x] `cargo make test` — full workspace clean.
- [x] Pre-commit hook (format-check + clippy) ran on the commit and passed.
- [x] `grep -rn 'clear_partition'` across `crates/` confirms no residual references to the removed methods.

## Depends on

#61 — this PR is conceptually a follow-up; it makes sense regardless of merge order but the motivation comes from the broadcast-catalog model #61 establishes.