### PR TITLE
tighten internal-entity topic protection and drop dead pub api

### DIFF
--- a/crates/mqdb-agent/src/topic_rules.rs
+++ b/crates/mqdb-agent/src/topic_rules.rs
@@ -54,23 +54,7 @@ pub const PROTECTED_TOPICS: &[TopicRule] = &[
         tier: ProtectionTier::ReadOnly,
     },
     TopicRule {
-        pattern: "$DB/_admin/#",
-        tier: ProtectionTier::AdminRequired,
-    },
-    TopicRule {
         pattern: "$DB/_verify/#",
-        tier: ProtectionTier::AdminRequired,
-    },
-    TopicRule {
-        pattern: "$DB/_oauth_tokens/#",
-        tier: ProtectionTier::AdminRequired,
-    },
-    TopicRule {
-        pattern: "$DB/_identities/#",
-        tier: ProtectionTier::AdminRequired,
-    },
-    TopicRule {
-        pattern: "$DB/_identity_links/#",
         tier: ProtectionTier::AdminRequired,
     },
 ];
@@ -202,22 +186,6 @@ pub fn check_topic_access(
     Ok(())
 }
 
-#[must_use]
-pub fn is_internal_entity(entity: &str) -> bool {
-    entity.starts_with('_')
-}
-
-/// # Errors
-///
-/// Returns `Err(BlockReason::InternalEntityAccess)` if the entity is internal and user is not admin.
-pub fn check_entity_access(entity: &str, is_admin: bool) -> Result<(), BlockReason> {
-    if is_internal_entity(entity) && !is_admin {
-        Err(BlockReason::InternalEntityAccess)
-    } else {
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -337,24 +305,24 @@ mod tests {
     }
 
     #[test]
-    fn check_access_admin_required() {
+    fn check_access_admin_topics_block_non_admin() {
         assert_eq!(
             check_topic_access("$DB/_admin/backup", true, false),
-            Err(BlockReason::AdminRequired)
+            Err(BlockReason::InternalEntityAccess)
         );
         assert_eq!(
             check_topic_access("$DB/_admin/backup", false, false),
-            Err(BlockReason::AdminRequired)
+            Err(BlockReason::InternalEntityAccess)
         );
         assert_eq!(check_topic_access("$DB/_admin/backup", true, true), Ok(()));
         assert_eq!(check_topic_access("$DB/_admin/backup", false, true), Ok(()));
     }
 
     #[test]
-    fn check_access_oauth_tokens_admin_required() {
+    fn check_access_oauth_tokens_block_non_admin() {
         assert_eq!(
             check_topic_access("$DB/_oauth_tokens/list", true, false),
-            Err(BlockReason::AdminRequired)
+            Err(BlockReason::InternalEntityAccess)
         );
         assert_eq!(
             check_topic_access("$DB/_oauth_tokens/abc123", true, true),
@@ -363,10 +331,10 @@ mod tests {
     }
 
     #[test]
-    fn check_access_identities_admin_required() {
+    fn check_access_identities_block_non_admin() {
         assert_eq!(
             check_topic_access("$DB/_identities/list", true, false),
-            Err(BlockReason::AdminRequired)
+            Err(BlockReason::InternalEntityAccess)
         );
         assert_eq!(
             check_topic_access("$DB/_identities/create", true, true),
@@ -375,10 +343,10 @@ mod tests {
     }
 
     #[test]
-    fn check_access_identity_links_admin_required() {
+    fn check_access_identity_links_block_non_admin() {
         assert_eq!(
             check_topic_access("$DB/_identity_links/list", true, false),
-            Err(BlockReason::AdminRequired)
+            Err(BlockReason::InternalEntityAccess)
         );
         assert_eq!(
             check_topic_access("$DB/_identity_links/google:123", true, true),
@@ -418,35 +386,6 @@ mod tests {
             check_topic_access("app/notifications", false, false),
             Ok(())
         );
-    }
-
-    #[test]
-    fn check_entity_access_internal_blocked() {
-        assert_eq!(
-            check_entity_access("_sessions", false),
-            Err(BlockReason::InternalEntityAccess)
-        );
-        assert_eq!(
-            check_entity_access("_mqtt_subs", false),
-            Err(BlockReason::InternalEntityAccess)
-        );
-        assert_eq!(
-            check_entity_access("_topic_index", false),
-            Err(BlockReason::InternalEntityAccess)
-        );
-    }
-
-    #[test]
-    fn check_entity_access_admin_allowed() {
-        assert_eq!(check_entity_access("_sessions", true), Ok(()));
-        assert_eq!(check_entity_access("_mqtt_subs", true), Ok(()));
-    }
-
-    #[test]
-    fn check_entity_access_regular_allowed() {
-        assert_eq!(check_entity_access("users", false), Ok(()));
-        assert_eq!(check_entity_access("posts", false), Ok(()));
-        assert_eq!(check_entity_access("orders", true), Ok(()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #41. The issue body claimed the four `AdminRequired` entries (`$DB/_admin/#`, `$DB/_oauth_tokens/#`, `$DB/_identities/#`, `$DB/_identity_links/#`) were redundant with Layer 2's `is_internal_entity_topic` default-deny and that `BlockReason` was "only logged, never pattern-matched" — that second half is wrong. `topic_protection.rs:102-115, 150-163` matches on `BlockReason::AdminRequired` to fall through to the inner ACL check; any other `BlockReason` short-circuits to `false`. So those four entries were not cosmetic: they enabled non-admins with explicit ACL grants to publish/subscribe on those topics.

For `_admin`, `_oauth_tokens`, `_identities`, `_identity_links` the ACL-grant escape hatch isn't desirable — these are admin-only by intent. This PR removes the four entries so they fall through to Layer 2 and return `InternalEntityAccess`, which short-circuits without an ACL fallback. Result: non-admins are now strictly blocked regardless of ACL grants. Admins still pass through both layers as before.

`$DB/_verify/#` stays in `PROTECTED_TOPICS` because `_verify` is on Layer 2's allowlist; without the explicit rule it would fall through to `Ok(())`.

Also removes `check_entity_access` and `is_internal_entity` from the public API — both had zero external callers.

## Test plan

- [x] `cargo make clippy` — clean (pedantic, all targets + wasm)
- [x] `cargo test -p mqdb-agent --lib topic_rules` — 22/22 pass, including updated assertions for the four affected topics (now `InternalEntityAccess`) and admin-allowed paths unchanged
- [x] Pre-commit hook (format-check + clippy) passed on the commit