### PR TITLE
bump mqdb-cli to 0.8.4 for v0.8.4 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.7.7"
+version = "0.8.4"
 dependencies = [
  "base64",
  "bebytes",

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.7.7"
+version = "0.8.4"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary

Release workflow's `Verify tag matches crate version` step compares the tag against `mqdb-cli`'s version. `v0.8.4` failed because mqdb-cli was still at `0.7.7`. Bumps mqdb-cli to `0.8.4` so the existing `v0.8.4` tag can be force-moved to this commit and the release workflow re-run.

## Test plan

- [ ] Merge → force-move `v0.8.4` tag → release workflow passes the version-check step