### PR TITLE
add agent-mode diagram sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-05-28 — mqdb-core 0.7.1, mqdb-agent 0.8.5, mqdb-vault 0.1.1, mqdb-wasm 0.3.3, mqdb-cli 0.8.5
+
+### Added
+
+- Resource sharing for agent mode. An owner can grant another user `view` or `edit` on any ownership-enabled entity (the motivating case is diagrams) through four new resource-scoped MQTT topics: `$DB/{entity}/{id}/share` (`{"grantee","permission":"view|edit","cascade":true}`), `$DB/{entity}/{id}/unshare` (`{"grantee","cascade":true}`), `$DB/{entity}/{id}/shares` (owner/admin lists a resource's grants), and `$DB/{entity}/shared` (caller lists resources shared with them). Grants are stored in a server-managed `_shares` entity that is not reachable through generic CRUD — direct `$DB/_shares/...` returns 403. Read now requires `view` and update requires `edit`; delete stays owner-only, and deleting a resource clears its grants so a record reusing the same id cannot inherit them. `share`/`unshare` cascade by default over self-referencing diagram→diagram references (bounded at 256, cycle-safe; a direct share sets the level while a cascade only raises an existing grant). In OAuth deployments the grantee email is resolved to its canonical id via `_identity_links` (resolve-existing only — sharing with an unregistered email returns 404; password/SCRAM use the username verbatim). The authorization core is verified in TLA+ (`specs/DiagramSharing.tla`, `CascadeClosure.tla`, `GrantLifecycle.tla`).
+- New `mqdb-core` public API backing the feature: `AccessLevel` (`View`/`Edit`, ordered), `SHARES_ENTITY`, and the `Share`/`Unshare`/`Shares`/`Shared` variants on `Request` and `DbOp`. Cluster parity is tracked in #75; the embedded `mqdb-wasm` build rejects these operations with "sharing is not supported in embedded mode".
+
 ## 2026-05-24 — mqdb-agent 0.8.4
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.4"
+version = "0.8.5"
 dependencies = [
  "base64",
  "bebytes",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arc-swap",
  "bebytes",
@@ -1466,7 +1466,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-vault"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "mqdb-agent",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -77,8 +77,23 @@ args = ["fmt", "--manifest-path", "crates/mqdb-wasm/Cargo.toml", "--check"]
 
 [tasks.check]
 description = "Quick compilation check"
+dependencies = ["check-native", "check-wasm"]
+
+[tasks.check-native]
+description = "Quick compilation check (native)"
 command = "cargo"
 args = ["check", "--all-targets", "--all-features"]
+
+[tasks.check-wasm]
+description = "Quick compilation check (WASM)"
+command = "cargo"
+args = [
+    "check",
+    "--target",
+    "wasm32-unknown-unknown",
+    "--manifest-path",
+    "crates/mqdb-wasm/Cargo.toml",
+]
 
 [tasks.build]
 description = "Build all targets (debug)"

--- a/README.md
+++ b/README.md
@@ -365,6 +365,19 @@ ready_rx.changed().await?; // wait until broker + handler are ready
 | `$DB/{entity}/list` | List entities (payload: filters, sort, projection) |
 | `$DB/{entity}/events/#` | Subscribe to change events |
 
+#### Sharing Operations
+
+An owner can share any ownership-enabled entity (the motivating case is diagrams) with a named user at `view` or `edit`. Grants are stored in a server-managed `_shares` entity that is **not** reachable via generic CRUD — mutate them only through these topics. Agent mode only (cluster parity tracked separately); the embedded WASM build rejects these operations.
+
+| Topic | Action |
+|-------|--------|
+| `$DB/{entity}/{id}/share` | Grant access (payload: `{"grantee","permission","cascade"}`; permission is `view` or `edit`, cascade defaults to `true`) |
+| `$DB/{entity}/{id}/unshare` | Revoke a grant (payload: `{"grantee","cascade"}`) |
+| `$DB/{entity}/{id}/shares` | List a resource's grants (owner/admin only) |
+| `$DB/{entity}/shared` | List resources shared with the caller |
+
+`share`/`unshare` cascade by default over self-references (a diagram and the diagrams it links to); a direct share sets the level while a cascade only raises an existing grant. Read requires `view`, update requires `edit`; delete stays owner-only and clears the resource's grants. In OAuth deployments `grantee` is an email resolved to the registered user's canonical id (an unregistered email returns 404); with password/SCRAM auth it is the username.
+
 #### Admin Operations
 
 | Topic | Action |

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.8.4"
+version = "0.8.5"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-agent/src/agent/broker.rs
+++ b/crates/mqdb-agent/src/agent/broker.rs
@@ -25,6 +25,20 @@ pub(super) struct AuthProviderConfig<'a> {
 }
 
 impl MqdbAgent {
+    async fn register_share_indexes(&self) {
+        if self.ownership_config.is_empty() {
+            return;
+        }
+        let fields = vec!["resource_id".to_string(), "grantee".to_string()];
+        if let Err(e) = self
+            .db
+            .ensure_index(mqdb_core::types::SHARES_ENTITY.to_string(), fields)
+            .await
+        {
+            tracing::warn!(error = %e, "failed to register _shares indexes");
+        }
+    }
+
     pub(super) async fn build_broker_config(
         &self,
     ) -> Result<
@@ -37,6 +51,7 @@ impl MqdbAgent {
         ),
         Box<dyn std::error::Error + Send + Sync>,
     > {
+        self.register_share_indexes().await;
         let mqtt_storage_dir = self.db.path().join("mqtt_storage");
         let mut config = BrokerConfig {
             bind_addresses: vec![self.bind_address],

--- a/crates/mqdb-agent/src/agent/handlers.rs
+++ b/crates/mqdb-agent/src/agent/handlers.rs
@@ -67,6 +67,77 @@ pub(super) struct MessageContext<'a> {
     pub jti_revocation: Option<&'a Arc<crate::http::JtiRevocationStore>>,
 }
 
+/// Resolve a grantee email to its canonical identity via `_identity_links`.
+/// Returns `None` when no registered identity matches the email.
+#[cfg(feature = "http-api")]
+pub(crate) async fn resolve_grantee_email(
+    db: &Database,
+    crypto: &crate::http::IdentityCrypto,
+    email: &str,
+) -> Option<String> {
+    let hash = crypto.blind_index("_identity_links", email);
+    let records =
+        crate::db_helpers::list_entities_db(db, "_identity_links", &format!("email_hash={hash}"))
+            .await
+            .ok()?;
+    records
+        .first()?
+        .get("canonical_id")
+        .and_then(Value::as_str)
+        .map(String::from)
+}
+
+/// For `Share`/`Unshare` in identity (OAuth) deployments, rewrite the grantee email
+/// to its canonical id. A `Share` for an unregistered email is rejected (`Err(email)`);
+/// an `Unshare` for an unknown email is left as-is (a harmless no-op revoke).
+/// When no identity crypto is configured (password mode), the grantee is used verbatim.
+#[cfg(feature = "http-api")]
+async fn resolve_share_request(
+    db: &Database,
+    crypto: Option<&Arc<crate::http::IdentityCrypto>>,
+    request: mqdb_core::transport::Request,
+) -> Result<mqdb_core::transport::Request, String> {
+    use mqdb_core::transport::Request;
+    let Some(crypto) = crypto else {
+        return Ok(request);
+    };
+    match request {
+        Request::Share {
+            entity,
+            id,
+            grantee,
+            permission,
+            cascade,
+        } => match resolve_grantee_email(db, crypto, &grantee).await {
+            Some(canonical_id) => Ok(Request::Share {
+                entity,
+                id,
+                grantee: canonical_id,
+                permission,
+                cascade,
+            }),
+            None => Err(grantee),
+        },
+        Request::Unshare {
+            entity,
+            id,
+            grantee,
+            cascade,
+        } => {
+            let resolved = resolve_grantee_email(db, crypto, &grantee)
+                .await
+                .unwrap_or(grantee);
+            Ok(Request::Unshare {
+                entity,
+                id,
+                grantee: resolved,
+                cascade,
+            })
+        }
+        other => Ok(other),
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 pub(super) async fn handle_message(ctx: &MessageContext<'_>, message: Message) {
     let db = ctx.db;
@@ -172,6 +243,29 @@ pub(super) async fn handle_message(ctx: &MessageContext<'_>, message: Message) {
         }
     } else {
         (request, None)
+    };
+
+    #[cfg(feature = "http-api")]
+    let request = match resolve_share_request(db, ctx.identity_crypto, request).await {
+        Ok(resolved) => resolved,
+        Err(unknown_email) => {
+            if let Some(response_topic) = &message.properties.response_topic {
+                let response = Response::error(
+                    mqdb_core::ErrorCode::NotFound,
+                    format!("unknown user '{unknown_email}'"),
+                );
+                if let Ok(payload) = serde_json::to_vec(&response) {
+                    publish_response(
+                        client,
+                        response_topic,
+                        message.properties.correlation_data.as_deref(),
+                        payload,
+                    )
+                    .await;
+                }
+            }
+            return;
+        }
     };
 
     let span = info_span!(
@@ -1618,4 +1712,44 @@ async fn handle_password_reset_submit_mqtt(ctx: &AdminContext<'_>, payload: &Val
     invalidate_http_sessions(ctx, canonical_id);
 
     Response::ok(json!({"status": "password_reset"}))
+}
+
+#[cfg(all(test, feature = "http-api"))]
+mod tests {
+    use super::resolve_grantee_email;
+    use crate::database::Database;
+    use crate::http::IdentityCrypto;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn resolve_grantee_email_maps_known_email_to_canonical_id() {
+        let tmp = TempDir::new().unwrap();
+        let db = Database::open_without_background_tasks(tmp.path())
+            .await
+            .unwrap();
+        let (crypto, _key) = IdentityCrypto::generate().unwrap();
+
+        let hash = crypto.blind_index("_identity_links", "bob@example.com");
+        crate::db_helpers::create_entity_db(
+            &db,
+            "_identity_links",
+            &json!({
+                "id": "google:bob",
+                "canonical_id": "cid-bob",
+                "email_hash": hash,
+            }),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            resolve_grantee_email(&db, &crypto, "bob@example.com").await,
+            Some("cid-bob".to_string())
+        );
+        assert_eq!(
+            resolve_grantee_email(&db, &crypto, "nobody@example.com").await,
+            None
+        );
+    }
 }

--- a/crates/mqdb-agent/src/database/crud.rs
+++ b/crates/mqdb-agent/src/database/crud.rs
@@ -7,9 +7,10 @@ use mqdb_core::error::{Error, Result};
 use mqdb_core::events::ChangeEvent;
 use mqdb_core::keys;
 use mqdb_core::types::ScopeConfig;
+use mqdb_core::{Filter, FilterOp};
 use serde_json::Value;
 
-use mqdb_core::types::OwnershipConfig;
+use mqdb_core::types::{AccessLevel, OwnershipConfig, SHARES_ENTITY};
 
 pub struct CallerContext<'a> {
     pub sender: Option<&'a str>,
@@ -406,6 +407,25 @@ impl Database {
     }
 
     /// # Errors
+    /// Returns `NotFound` if the entity does not exist.
+    pub fn is_owner(
+        &self,
+        entity_name: &str,
+        id: &str,
+        owner_field: &str,
+        sender: &str,
+    ) -> Result<bool> {
+        let key = keys::encode_data_key(entity_name, id);
+        let existing_data = self.storage.get(&key)?.ok_or_else(|| Error::NotFound {
+            entity: entity_name.to_string(),
+            id: id.to_string(),
+        })?;
+        let entity = Entity::deserialize(entity_name.to_string(), id.to_string(), &existing_data)?;
+        let owner_value = entity.data.get(owner_field).and_then(|v| v.as_str());
+        Ok(owner_value == Some(sender))
+    }
+
+    /// # Errors
     /// Returns `Forbidden` if the sender doesn't own the entity, or `NotFound` if it doesn't exist.
     pub fn check_ownership(
         &self,
@@ -414,17 +434,83 @@ impl Database {
         owner_field: &str,
         sender: &str,
     ) -> Result<()> {
-        let key = keys::encode_data_key(entity_name, id);
-        let existing_data = self.storage.get(&key)?.ok_or_else(|| Error::NotFound {
-            entity: entity_name.to_string(),
-            id: id.to_string(),
-        })?;
-        let entity = Entity::deserialize(entity_name.to_string(), id.to_string(), &existing_data)?;
-        let owner_value = entity.data.get(owner_field).and_then(|v| v.as_str());
-        if owner_value != Some(sender) {
-            return Err(Error::Forbidden("permission denied".to_string()));
+        if self.is_owner(entity_name, id, owner_field, sender)? {
+            Ok(())
+        } else {
+            Err(Error::Forbidden("permission denied".to_string()))
         }
-        Ok(())
+    }
+
+    /// Highest access level granted to `sender` on a specific resource via `_shares`.
+    ///
+    /// # Errors
+    /// Returns an error if scanning the share records fails.
+    pub(crate) async fn share_level(
+        &self,
+        entity_name: &str,
+        id: &str,
+        sender: &str,
+    ) -> Result<Option<AccessLevel>> {
+        let filters = vec![
+            Filter::new(
+                "resource_entity".to_string(),
+                FilterOp::Eq,
+                Value::String(entity_name.to_string()),
+            ),
+            Filter::new(
+                "resource_id".to_string(),
+                FilterOp::Eq,
+                Value::String(id.to_string()),
+            ),
+            Filter::new(
+                "grantee".to_string(),
+                FilterOp::Eq,
+                Value::String(sender.to_string()),
+            ),
+        ];
+        let records = self
+            .list_core(
+                SHARES_ENTITY.to_string(),
+                filters,
+                vec![],
+                None,
+                vec![],
+                None,
+            )
+            .await?;
+        let mut best: Option<AccessLevel> = None;
+        for rec in &records {
+            if let Some(level) = rec
+                .get("permission")
+                .and_then(Value::as_str)
+                .and_then(AccessLevel::parse)
+            {
+                best = Some(best.map_or(level, |b| b.max(level)));
+            }
+        }
+        Ok(best)
+    }
+
+    /// Authorize an operation on an ownership-enabled entity: the sender must own
+    /// the record or hold a share grant at least as strong as `required`.
+    ///
+    /// # Errors
+    /// Returns `Forbidden` if access is denied, or `NotFound` if the record is missing.
+    pub async fn check_access(
+        &self,
+        entity_name: &str,
+        id: &str,
+        owner_field: &str,
+        sender: &str,
+        required: AccessLevel,
+    ) -> Result<()> {
+        if self.is_owner(entity_name, id, owner_field, sender)? {
+            return Ok(());
+        }
+        match self.share_level(entity_name, id, sender).await? {
+            Some(level) if level >= required => Ok(()),
+            _ => Err(Error::Forbidden("permission denied".to_string())),
+        }
     }
 
     pub(super) fn generate_id(entity_name: &str, data: &[u8]) -> String {

--- a/crates/mqdb-agent/src/database/mod.rs
+++ b/crates/mqdb-agent/src/database/mod.rs
@@ -6,6 +6,7 @@ mod backup;
 mod crud;
 mod query;
 mod schema_ops;
+mod sharing;
 mod subscriptions;
 
 pub use crud::CallerContext;

--- a/crates/mqdb-agent/src/database/schema_ops.rs
+++ b/crates/mqdb-agent/src/database/schema_ops.rs
@@ -77,6 +77,23 @@ impl Database {
         Ok(())
     }
 
+    /// Register an index only if the entity is not already indexed on all of `fields`.
+    /// Idempotent: skips the reindex scan when the index already exists.
+    ///
+    /// # Errors
+    /// Returns an error if field validation or persisting the index fails.
+    pub async fn ensure_index(&self, entity: String, fields: Vec<String>) -> Result<()> {
+        {
+            let manager = self.index_manager.read().await;
+            if let Some(existing) = manager.get_indexed_fields(&entity)
+                && fields.iter().all(|f| existing.contains(f))
+            {
+                return Ok(());
+            }
+        }
+        self.add_index(entity, fields).await
+    }
+
     pub async fn add_relationship(
         &self,
         source_entity: String,

--- a/crates/mqdb-agent/src/database/sharing.rs
+++ b/crates/mqdb-agent/src/database/sharing.rs
@@ -1,0 +1,204 @@
+// Copyright 2025-2026 LabOverWire. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Database;
+use mqdb_core::error::{Error, Result};
+use mqdb_core::keys;
+use mqdb_core::types::{AccessLevel, OwnershipConfig, SHARES_ENTITY, ScopeConfig};
+use mqdb_core::{Filter, FilterOp};
+use serde_json::{Value, json};
+
+fn eq_filter(field: &str, value: &str) -> Filter {
+    Filter::new(
+        field.to_string(),
+        FilterOp::Eq,
+        Value::String(value.to_string()),
+    )
+}
+
+impl Database {
+    fn resource_filters(entity: &str, id: &str) -> Vec<Filter> {
+        vec![
+            eq_filter("resource_entity", entity),
+            eq_filter("resource_id", id),
+        ]
+    }
+
+    fn require_owner_or_admin(
+        &self,
+        ownership: &OwnershipConfig,
+        entity: &str,
+        id: &str,
+        sender: Option<&str>,
+    ) -> Result<()> {
+        let Some(owner_field) = ownership.owner_field(entity) else {
+            return Err(Error::Validation(format!(
+                "entity '{entity}' is not shareable"
+            )));
+        };
+        let Some(uid) = sender else {
+            return Ok(());
+        };
+        if ownership.is_admin(uid) || self.is_owner(entity, id, owner_field, uid)? {
+            Ok(())
+        } else {
+            Err(Error::Forbidden("permission denied".to_string()))
+        }
+    }
+
+    async fn clear_grant(&self, entity: &str, id: &str, grantee_key: &str) -> Result<()> {
+        let mut filters = Self::resource_filters(entity, id);
+        filters.push(eq_filter("grantee_key", grantee_key));
+        let records = self
+            .list_core(
+                SHARES_ENTITY.to_string(),
+                filters,
+                vec![],
+                None,
+                vec![],
+                None,
+            )
+            .await?;
+        let scope = ScopeConfig::default();
+        let ownership = OwnershipConfig::default();
+        for rec in &records {
+            if let Some(sid) = rec.get("id").and_then(Value::as_str) {
+                self.delete(
+                    SHARES_ENTITY.to_string(),
+                    sid.to_string(),
+                    None,
+                    None,
+                    &scope,
+                    &ownership,
+                )
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Grant `grantee` access to a resource at `permission` (`view`/`edit`).
+    /// Direct share is set-to-level: any existing grant for the same grantee is replaced.
+    ///
+    /// # Errors
+    /// Returns `Forbidden` if the sender is not the owner/admin, `Validation` for a
+    /// bad permission or non-shareable entity, or `NotFound` if the resource is missing.
+    pub async fn share_grant(
+        &self,
+        entity: &str,
+        id: &str,
+        grantee: &str,
+        permission: &str,
+        sender: Option<&str>,
+        ownership: &OwnershipConfig,
+    ) -> Result<Value> {
+        self.require_owner_or_admin(ownership, entity, id, sender)?;
+        if grantee.trim().is_empty() {
+            return Err(Error::Validation("grantee is required".to_string()));
+        }
+        let level = AccessLevel::parse(permission)
+            .ok_or_else(|| Error::Validation(format!("invalid permission '{permission}'")))?;
+        let key = keys::encode_data_key(entity, id);
+        if self.storage.get(&key)?.is_none() {
+            return Err(Error::NotFound {
+                entity: entity.to_string(),
+                id: id.to_string(),
+            });
+        }
+        self.clear_grant(entity, id, grantee).await?;
+        let record = json!({
+            "resource_entity": entity,
+            "resource_id": id,
+            "grantee": grantee,
+            "grantee_key": grantee,
+            "permission": level.as_str(),
+            "granted_by": sender.unwrap_or_default(),
+        });
+        self.create(
+            SHARES_ENTITY.to_string(),
+            record,
+            None,
+            None,
+            None,
+            &ScopeConfig::default(),
+        )
+        .await
+    }
+
+    /// Revoke `grantee`'s grant on a resource.
+    ///
+    /// # Errors
+    /// Returns `Forbidden` if the sender is not the owner/admin, or `Validation` for a
+    /// non-shareable entity.
+    pub async fn share_revoke(
+        &self,
+        entity: &str,
+        id: &str,
+        grantee: &str,
+        sender: Option<&str>,
+        ownership: &OwnershipConfig,
+    ) -> Result<Value> {
+        self.require_owner_or_admin(ownership, entity, id, sender)?;
+        self.clear_grant(entity, id, grantee).await?;
+        Ok(json!({ "status": "unshared", "grantee": grantee }))
+    }
+
+    /// List the grants on a resource (owner/admin only).
+    ///
+    /// # Errors
+    /// Returns `Forbidden` if the sender is not the owner/admin, or `Validation` for a
+    /// non-shareable entity.
+    pub async fn list_resource_shares(
+        &self,
+        entity: &str,
+        id: &str,
+        sender: Option<&str>,
+        ownership: &OwnershipConfig,
+    ) -> Result<Vec<Value>> {
+        self.require_owner_or_admin(ownership, entity, id, sender)?;
+        self.list_core(
+            SHARES_ENTITY.to_string(),
+            Self::resource_filters(entity, id),
+            vec![],
+            None,
+            vec![],
+            None,
+        )
+        .await
+    }
+
+    /// List the resources of `entity` shared with the caller.
+    ///
+    /// # Errors
+    /// Returns an error if scanning the share records or reading a resource fails.
+    pub async fn list_shared_with(&self, entity: &str, sender: Option<&str>) -> Result<Vec<Value>> {
+        let Some(uid) = sender else {
+            return Ok(vec![]);
+        };
+        let filters = vec![
+            eq_filter("resource_entity", entity),
+            eq_filter("grantee", uid),
+        ];
+        let grants = self
+            .list_core(
+                SHARES_ENTITY.to_string(),
+                filters,
+                vec![],
+                None,
+                vec![],
+                None,
+            )
+            .await?;
+        let mut resources = Vec::new();
+        for grant in &grants {
+            if let Some(rid) = grant.get("resource_id").and_then(Value::as_str)
+                && let Ok(record) = self
+                    .read(entity.to_string(), rid.to_string(), vec![], None)
+                    .await
+            {
+                resources.push(record);
+            }
+        }
+        Ok(resources)
+    }
+}

--- a/crates/mqdb-agent/src/database/sharing.rs
+++ b/crates/mqdb-agent/src/database/sharing.rs
@@ -50,9 +50,7 @@ impl Database {
         }
     }
 
-    async fn clear_grant(&self, entity: &str, id: &str, grantee_key: &str) -> Result<()> {
-        let mut filters = Self::resource_filters(entity, id);
-        filters.push(eq_filter("grantee_key", grantee_key));
+    async fn delete_grants(&self, filters: Vec<Filter>) -> Result<()> {
         let records = self
             .list_core(
                 SHARES_ENTITY.to_string(),
@@ -79,6 +77,21 @@ impl Database {
             }
         }
         Ok(())
+    }
+
+    async fn clear_grant(&self, entity: &str, id: &str, grantee_key: &str) -> Result<()> {
+        let mut filters = Self::resource_filters(entity, id);
+        filters.push(eq_filter("grantee_key", grantee_key));
+        self.delete_grants(filters).await
+    }
+
+    /// Remove every grant on a resource. Called when the resource itself is deleted
+    /// so stale grants cannot be inherited by a later record reusing the same id.
+    ///
+    /// # Errors
+    /// Returns an error if scanning or deleting the share records fails.
+    pub(crate) async fn clear_all_resource_grants(&self, entity: &str, id: &str) -> Result<()> {
+        self.delete_grants(Self::resource_filters(entity, id)).await
     }
 
     async fn write_grant(

--- a/crates/mqdb-agent/src/database/sharing.rs
+++ b/crates/mqdb-agent/src/database/sharing.rs
@@ -2,11 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Database;
+use mqdb_core::entity::Entity;
 use mqdb_core::error::{Error, Result};
 use mqdb_core::keys;
 use mqdb_core::types::{AccessLevel, OwnershipConfig, SHARES_ENTITY, ScopeConfig};
 use mqdb_core::{Filter, FilterOp};
 use serde_json::{Value, json};
+use std::collections::{BTreeSet, HashSet, VecDeque};
+
+const MAX_CASCADE_DIAGRAMS: usize = 256;
 
 fn eq_filter(field: &str, value: &str) -> Filter {
     Filter::new(
@@ -77,12 +81,89 @@ impl Database {
         Ok(())
     }
 
+    async fn write_grant(
+        &self,
+        entity: &str,
+        id: &str,
+        grantee: &str,
+        level: AccessLevel,
+        granted_by: &str,
+    ) -> Result<()> {
+        self.clear_grant(entity, id, grantee).await?;
+        let record = json!({
+            "resource_entity": entity,
+            "resource_id": id,
+            "grantee": grantee,
+            "grantee_key": grantee,
+            "permission": level.as_str(),
+            "granted_by": granted_by,
+        });
+        self.create(
+            SHARES_ENTITY.to_string(),
+            record,
+            None,
+            None,
+            None,
+            &ScopeConfig::default(),
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn self_reference_fields(&self, entity: &str) -> Vec<String> {
+        let mut fields = BTreeSet::new();
+        for rel in self.list_relationships(entity).await {
+            if rel.target_entity == entity {
+                fields.insert(rel.field_suffix);
+            }
+        }
+        for constraint in self.list_constraints(entity).await {
+            if let mqdb_core::constraint::Constraint::ForeignKey(fk) = constraint
+                && fk.target_entity == entity
+            {
+                fields.insert(fk.source_field);
+            }
+        }
+        fields.into_iter().collect()
+    }
+
+    async fn referenced_closure(&self, entity: &str, root_id: &str) -> Result<Vec<String>> {
+        let ref_fields = self.self_reference_fields(entity).await;
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut queue: VecDeque<String> = VecDeque::new();
+        queue.push_back(root_id.to_string());
+        while let Some(id) = queue.pop_front() {
+            if visited.len() >= MAX_CASCADE_DIAGRAMS {
+                break;
+            }
+            if !visited.insert(id.clone()) {
+                continue;
+            }
+            let key = keys::encode_data_key(entity, &id);
+            let Some(bytes) = self.storage.get(&key)? else {
+                continue;
+            };
+            let record = Entity::deserialize(entity.to_string(), id.clone(), &bytes)?;
+            for field in &ref_fields {
+                if let Some(ref_id) = record.data.get(field).and_then(Value::as_str)
+                    && !visited.contains(ref_id)
+                {
+                    queue.push_back(ref_id.to_string());
+                }
+            }
+        }
+        Ok(visited.into_iter().collect())
+    }
+
     /// Grant `grantee` access to a resource at `permission` (`view`/`edit`).
-    /// Direct share is set-to-level: any existing grant for the same grantee is replaced.
+    /// The root resource is set-to-level (a re-share may demote it); when `cascade`
+    /// is set, every diagram reachable via self-references is granted at max-of-levels
+    /// (never downgrading an existing grant).
     ///
     /// # Errors
     /// Returns `Forbidden` if the sender is not the owner/admin, `Validation` for a
     /// bad permission or non-shareable entity, or `NotFound` if the resource is missing.
+    #[allow(clippy::too_many_arguments)]
     pub async fn share_grant(
         &self,
         entity: &str,
@@ -91,6 +172,7 @@ impl Database {
         permission: &str,
         sender: Option<&str>,
         ownership: &OwnershipConfig,
+        cascade: bool,
     ) -> Result<Value> {
         self.require_owner_or_admin(ownership, entity, id, sender)?;
         if grantee.trim().is_empty() {
@@ -105,27 +187,33 @@ impl Database {
                 id: id.to_string(),
             });
         }
-        self.clear_grant(entity, id, grantee).await?;
-        let record = json!({
-            "resource_entity": entity,
-            "resource_id": id,
+        let granted_by = sender.unwrap_or_default();
+        self.write_grant(entity, id, grantee, level, granted_by)
+            .await?;
+        let mut shared = 1usize;
+        if cascade {
+            for ref_id in self.referenced_closure(entity, id).await? {
+                if ref_id == id {
+                    continue;
+                }
+                let existing = self.share_level(entity, &ref_id, grantee).await?;
+                if existing.is_none_or(|current| current < level) {
+                    self.write_grant(entity, &ref_id, grantee, level, granted_by)
+                        .await?;
+                }
+                shared += 1;
+            }
+        }
+        Ok(json!({
+            "status": "shared",
             "grantee": grantee,
-            "grantee_key": grantee,
             "permission": level.as_str(),
-            "granted_by": sender.unwrap_or_default(),
-        });
-        self.create(
-            SHARES_ENTITY.to_string(),
-            record,
-            None,
-            None,
-            None,
-            &ScopeConfig::default(),
-        )
-        .await
+            "resources_shared": shared,
+        }))
     }
 
-    /// Revoke `grantee`'s grant on a resource.
+    /// Revoke `grantee`'s grant on a resource, and (when `cascade` is set) across
+    /// every diagram reachable via self-references.
     ///
     /// # Errors
     /// Returns `Forbidden` if the sender is not the owner/admin, or `Validation` for a
@@ -137,9 +225,18 @@ impl Database {
         grantee: &str,
         sender: Option<&str>,
         ownership: &OwnershipConfig,
+        cascade: bool,
     ) -> Result<Value> {
         self.require_owner_or_admin(ownership, entity, id, sender)?;
         self.clear_grant(entity, id, grantee).await?;
+        if cascade {
+            for ref_id in self.referenced_closure(entity, id).await? {
+                if ref_id == id {
+                    continue;
+                }
+                self.clear_grant(entity, &ref_id, grantee).await?;
+            }
+        }
         Ok(json!({ "status": "unshared", "grantee": grantee }))
     }
 

--- a/crates/mqdb-agent/src/transport_execute.rs
+++ b/crates/mqdb-agent/src/transport_execute.rs
@@ -148,14 +148,30 @@ impl Database {
                     return e.into();
                 }
                 let id_clone = id.clone();
+                let shareable = ownership.owner_field(&entity).is_some();
+                let entity_clone = entity.clone();
                 match self
                     .delete(entity, id, sender, client_id, scope_config, ownership)
                     .await
                 {
-                    Ok(()) => Response::ok(serde_json::json!({
-                        "id": id_clone,
-                        "deleted": true
-                    })),
+                    Ok(()) => {
+                        if shareable
+                            && let Err(e) = self
+                                .clear_all_resource_grants(&entity_clone, &id_clone)
+                                .await
+                        {
+                            tracing::warn!(
+                                error = %e,
+                                entity = %entity_clone,
+                                id = %id_clone,
+                                "failed to clear shares after delete"
+                            );
+                        }
+                        Response::ok(serde_json::json!({
+                            "id": id_clone,
+                            "deleted": true
+                        }))
+                    }
                     Err(e) => e.into(),
                 }
             }

--- a/crates/mqdb-agent/src/transport_execute.rs
+++ b/crates/mqdb-agent/src/transport_execute.rs
@@ -3,7 +3,7 @@
 
 use crate::database::{CallerContext, Database};
 use mqdb_core::transport::{Request, Response, VaultConstraintData};
-use mqdb_core::types::{OwnershipConfig, OwnershipDecision, ScopeConfig};
+use mqdb_core::types::{AccessLevel, OwnershipConfig, OwnershipDecision, ScopeConfig};
 use serde_json::Value;
 
 fn value_from_unit(_: ()) -> Value {
@@ -73,7 +73,9 @@ impl Database {
                     owner_field,
                     sender: uid,
                 } = ownership.evaluate(&entity, sender)
-                    && let Err(e) = self.check_ownership(&entity, &id, owner_field, uid)
+                    && let Err(e) = self
+                        .check_access(&entity, &id, owner_field, uid, AccessLevel::View)
+                        .await
                 {
                     return e.into();
                 }
@@ -92,7 +94,10 @@ impl Database {
                     sender: uid,
                 } = ownership.evaluate(&entity, sender)
                 {
-                    if let Err(e) = self.check_ownership(&entity, &id, owner_field, uid) {
+                    if let Err(e) = self
+                        .check_access(&entity, &id, owner_field, uid, AccessLevel::Edit)
+                        .await
+                    {
                         return e.into();
                     }
                     if let Value::Object(ref mut map) = fields {

--- a/crates/mqdb-agent/src/transport_execute.rs
+++ b/crates/mqdb-agent/src/transport_execute.rs
@@ -221,8 +221,17 @@ impl Database {
                 id,
                 grantee,
                 permission,
+                cascade,
             } => match self
-                .share_grant(&entity, &id, &grantee, &permission, sender, ownership)
+                .share_grant(
+                    &entity,
+                    &id,
+                    &grantee,
+                    &permission,
+                    sender,
+                    ownership,
+                    cascade,
+                )
                 .await
             {
                 Ok(v) => Response::ok(v),
@@ -232,8 +241,9 @@ impl Database {
                 entity,
                 id,
                 grantee,
+                cascade,
             } => match self
-                .share_revoke(&entity, &id, &grantee, sender, ownership)
+                .share_revoke(&entity, &id, &grantee, sender, ownership, cascade)
                 .await
             {
                 Ok(v) => Response::ok(v),

--- a/crates/mqdb-agent/src/transport_execute.rs
+++ b/crates/mqdb-agent/src/transport_execute.rs
@@ -42,6 +42,21 @@ impl Database {
         scope_config: &ScopeConfig,
         vault_constraint: Option<VaultConstraintData>,
     ) -> Response {
+        match &request {
+            Request::Create { entity, .. }
+            | Request::Read { entity, .. }
+            | Request::Update { entity, .. }
+            | Request::Delete { entity, .. }
+            | Request::List { entity, .. }
+                if entity == mqdb_core::types::SHARES_ENTITY =>
+            {
+                return mqdb_core::error::Error::Forbidden(
+                    "direct access to shares is not permitted".to_string(),
+                )
+                .into();
+            }
+            _ => {}
+        }
         match request {
             Request::Create { entity, data } => {
                 let constraint_data = match vault_constraint {
@@ -199,6 +214,42 @@ impl Database {
             },
             Request::Unsubscribe { id } => match self.unsubscribe(&id).await {
                 Ok(()) => Response::ok(value_from_unit(())),
+                Err(e) => e.into(),
+            },
+            Request::Share {
+                entity,
+                id,
+                grantee,
+                permission,
+            } => match self
+                .share_grant(&entity, &id, &grantee, &permission, sender, ownership)
+                .await
+            {
+                Ok(v) => Response::ok(v),
+                Err(e) => e.into(),
+            },
+            Request::Unshare {
+                entity,
+                id,
+                grantee,
+            } => match self
+                .share_revoke(&entity, &id, &grantee, sender, ownership)
+                .await
+            {
+                Ok(v) => Response::ok(v),
+                Err(e) => e.into(),
+            },
+            Request::Shares { entity, id } => {
+                match self
+                    .list_resource_shares(&entity, &id, sender, ownership)
+                    .await
+                {
+                    Ok(v) => Response::ok(value_from_vec(v)),
+                    Err(e) => e.into(),
+                }
+            }
+            Request::Shared { entity } => match self.list_shared_with(&entity, sender).await {
+                Ok(v) => Response::ok(value_from_vec(v)),
                 Err(e) => e.into(),
             },
         }

--- a/crates/mqdb-agent/tests/integration_test.rs
+++ b/crates/mqdb-agent/tests/integration_test.rs
@@ -1701,6 +1701,7 @@ async fn test_ownership_isolates_user_data_on_list() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn test_share_grant_gates_read_update_delete() {
     use mqdb_core::{Request, Response};
 
@@ -1754,17 +1755,19 @@ async fn test_share_grant_gates_read_update_delete() {
         .await
     };
     let grant = async |permission: &str| {
-        db.execute(Request::Create {
-            entity: "_shares".into(),
-            data: json!({
-                "resource_entity": "diagrams",
-                "resource_id": diagram_id,
-                "grantee": "bob",
-                "grantee_key": "bob",
-                "permission": permission,
-                "granted_by": "alice",
-            }),
-        })
+        db.execute_with_sender(
+            Request::Share {
+                entity: "diagrams".into(),
+                id: diagram_id.clone(),
+                grantee: "bob".into(),
+                permission: permission.into(),
+            },
+            Some("alice"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
         .await
     };
 
@@ -1827,6 +1830,172 @@ async fn test_share_grant_gates_read_update_delete() {
             Response::Ok { .. }
         ),
         "owner delete should succeed"
+    );
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn test_share_endpoints_and_protection() {
+    use mqdb_core::{Request, Response};
+
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open_without_background_tasks(tmp.path())
+        .await
+        .unwrap();
+    let ownership = OwnershipConfig::parse("diagrams=userId").unwrap();
+    let scope = ScopeConfig::default();
+
+    let created = db
+        .execute(Request::Create {
+            entity: "diagrams".into(),
+            data: json!({"userId": "alice", "title": "Alice Diagram"}),
+        })
+        .await;
+    let diagram_id = match created {
+        Response::Ok { data } => data["id"].as_str().unwrap().to_string(),
+        Response::Error { code, message } => panic!("create failed {code}: {message}"),
+    };
+
+    let share = async |sender: &str, grantee: &str, permission: &str| {
+        db.execute_with_sender(
+            Request::Share {
+                entity: "diagrams".into(),
+                id: diagram_id.clone(),
+                grantee: grantee.into(),
+                permission: permission.into(),
+            },
+            Some(sender),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+    let list_shares = async |sender: &str| {
+        db.execute_with_sender(
+            Request::Shares {
+                entity: "diagrams".into(),
+                id: diagram_id.clone(),
+            },
+            Some(sender),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+    let shared_with = async |sender: &str| {
+        db.execute_with_sender(
+            Request::Shared {
+                entity: "diagrams".into(),
+            },
+            Some(sender),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+
+    assert!(
+        matches!(
+            share("carol", "mallory", "edit").await,
+            Response::Error { code: 403, .. }
+        ),
+        "non-owner share must be forbidden"
+    );
+    assert!(
+        matches!(share("alice", "bob", "view").await, Response::Ok { .. }),
+        "owner share should succeed"
+    );
+
+    match list_shares("alice").await {
+        Response::Ok { data } => {
+            let items = data.as_array().unwrap();
+            assert_eq!(items.len(), 1);
+            assert_eq!(items[0]["grantee"], "bob");
+            assert_eq!(items[0]["permission"], "view");
+        }
+        Response::Error { code, message } => panic!("shares list failed {code}: {message}"),
+    }
+
+    share("alice", "bob", "edit").await;
+    if let Response::Ok { data } = list_shares("alice").await {
+        let items = data.as_array().unwrap();
+        assert_eq!(
+            items.len(),
+            1,
+            "direct re-share must replace, not duplicate"
+        );
+        assert_eq!(items[0]["permission"], "edit");
+    } else {
+        panic!("shares list failed after re-share");
+    }
+
+    match shared_with("bob").await {
+        Response::Ok { data } => {
+            let items = data.as_array().unwrap();
+            assert_eq!(items.len(), 1);
+            assert_eq!(items[0]["id"], diagram_id);
+        }
+        Response::Error { code, message } => panic!("shared list failed {code}: {message}"),
+    }
+
+    assert!(
+        matches!(list_shares("bob").await, Response::Error { code: 403, .. }),
+        "non-owner shares list must be forbidden"
+    );
+
+    db.execute_with_sender(
+        Request::Unshare {
+            entity: "diagrams".into(),
+            id: diagram_id.clone(),
+            grantee: "bob".into(),
+        },
+        Some("alice"),
+        None,
+        &ownership,
+        &scope,
+        None,
+    )
+    .await;
+    if let Response::Ok { data } = shared_with("bob").await {
+        assert!(
+            data.as_array().unwrap().is_empty(),
+            "unshare should remove discovery"
+        );
+    } else {
+        panic!("shared list failed after unshare");
+    }
+
+    assert!(
+        matches!(
+            db.execute(Request::List {
+                entity: "_shares".into(),
+                filters: vec![],
+                sort: vec![],
+                pagination: None,
+                includes: vec![],
+                projection: None,
+            })
+            .await,
+            Response::Error { code: 403, .. }
+        ),
+        "direct _shares list must be forbidden"
+    );
+    assert!(
+        matches!(
+            db.execute(Request::Create {
+                entity: "_shares".into(),
+                data: json!({"x": 1}),
+            })
+            .await,
+            Response::Error { code: 403, .. }
+        ),
+        "direct _shares create must be forbidden"
     );
 }
 

--- a/crates/mqdb-agent/tests/integration_test.rs
+++ b/crates/mqdb-agent/tests/integration_test.rs
@@ -2128,6 +2128,98 @@ async fn test_share_cascade_follows_references() {
 }
 
 #[tokio::test]
+async fn test_shares_index_path_correct_and_idempotent() {
+    use mqdb_core::{Request, Response};
+
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open_without_background_tasks(tmp.path())
+        .await
+        .unwrap();
+    let ownership = OwnershipConfig::parse("diagrams=userId").unwrap();
+    let scope = ScopeConfig::default();
+
+    db.ensure_index(
+        "_shares".into(),
+        vec!["resource_id".into(), "grantee".into()],
+    )
+    .await
+    .unwrap();
+    db.ensure_index(
+        "_shares".into(),
+        vec!["resource_id".into(), "grantee".into()],
+    )
+    .await
+    .unwrap();
+
+    let created = db
+        .execute(Request::Create {
+            entity: "diagrams".into(),
+            data: json!({"userId": "alice", "title": "D"}),
+        })
+        .await;
+    let id = match created {
+        Response::Ok { data } => data["id"].as_str().unwrap().to_string(),
+        Response::Error { code, message } => panic!("create failed {code}: {message}"),
+    };
+
+    let shared = db
+        .execute_with_sender(
+            Request::Share {
+                entity: "diagrams".into(),
+                id: id.clone(),
+                grantee: "bob".into(),
+                permission: "view".into(),
+                cascade: false,
+            },
+            Some("alice"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await;
+    assert!(matches!(shared, Response::Ok { .. }));
+
+    let read = db
+        .execute_with_sender(
+            Request::Read {
+                entity: "diagrams".into(),
+                id: id.clone(),
+                includes: vec![],
+                projection: None,
+            },
+            Some("bob"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await;
+    assert!(
+        matches!(read, Response::Ok { .. }),
+        "indexed share_level lookup should authorize the read"
+    );
+
+    if let Response::Ok { data } = db
+        .execute_with_sender(
+            Request::Shared {
+                entity: "diagrams".into(),
+            },
+            Some("bob"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    {
+        assert_eq!(data.as_array().unwrap().len(), 1);
+    } else {
+        panic!("indexed discovery failed");
+    }
+}
+
+#[tokio::test]
 async fn test_ownership_list_with_additional_filter() {
     use mqdb_core::{Request, Response};
 

--- a/crates/mqdb-agent/tests/integration_test.rs
+++ b/crates/mqdb-agent/tests/integration_test.rs
@@ -2220,6 +2220,95 @@ async fn test_shares_index_path_correct_and_idempotent() {
 }
 
 #[tokio::test]
+async fn test_delete_clears_shares_no_inheritance() {
+    use mqdb_core::{Request, Response};
+
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open_without_background_tasks(tmp.path())
+        .await
+        .unwrap();
+    let ownership = OwnershipConfig::parse("diagrams=userId").unwrap();
+    let scope = ScopeConfig::default();
+
+    let created = db
+        .execute(Request::Create {
+            entity: "diagrams".into(),
+            data: json!({"userId": "alice", "title": "D"}),
+        })
+        .await;
+    let id = match created {
+        Response::Ok { data } => data["id"].as_str().unwrap().to_string(),
+        Response::Error { code, message } => panic!("create failed {code}: {message}"),
+    };
+
+    let read_as_bob = async |diagram_id: &str| {
+        db.execute_with_sender(
+            Request::Read {
+                entity: "diagrams".into(),
+                id: diagram_id.to_string(),
+                includes: vec![],
+                projection: None,
+            },
+            Some("bob"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+
+    db.execute_with_sender(
+        Request::Share {
+            entity: "diagrams".into(),
+            id: id.clone(),
+            grantee: "bob".into(),
+            permission: "view".into(),
+            cascade: false,
+        },
+        Some("alice"),
+        None,
+        &ownership,
+        &scope,
+        None,
+    )
+    .await;
+    assert!(
+        matches!(read_as_bob(&id).await, Response::Ok { .. }),
+        "bob should read while the grant exists"
+    );
+
+    db.execute_with_sender(
+        Request::Delete {
+            entity: "diagrams".into(),
+            id: id.clone(),
+        },
+        Some("alice"),
+        None,
+        &ownership,
+        &scope,
+        None,
+    )
+    .await;
+
+    let recreated = db
+        .execute(Request::Create {
+            entity: "diagrams".into(),
+            data: json!({"id": id, "userId": "alice", "title": "D2"}),
+        })
+        .await;
+    assert!(
+        matches!(recreated, Response::Ok { .. }),
+        "recreate with the same id should succeed"
+    );
+
+    assert!(
+        matches!(read_as_bob(&id).await, Response::Error { code: 403, .. }),
+        "stale grant must not be inherited by a record reusing the id"
+    );
+}
+
+#[tokio::test]
 async fn test_ownership_list_with_additional_filter() {
     use mqdb_core::{Request, Response};
 

--- a/crates/mqdb-agent/tests/integration_test.rs
+++ b/crates/mqdb-agent/tests/integration_test.rs
@@ -1701,6 +1701,136 @@ async fn test_ownership_isolates_user_data_on_list() {
 }
 
 #[tokio::test]
+async fn test_share_grant_gates_read_update_delete() {
+    use mqdb_core::{Request, Response};
+
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open_without_background_tasks(tmp.path())
+        .await
+        .unwrap();
+    let ownership = OwnershipConfig::parse("diagrams=userId").unwrap();
+    let scope = ScopeConfig::default();
+
+    let created = db
+        .execute(Request::Create {
+            entity: "diagrams".into(),
+            data: json!({"userId": "alice", "title": "Alice Diagram"}),
+        })
+        .await;
+    let diagram_id = match created {
+        Response::Ok { data } => data["id"].as_str().unwrap().to_string(),
+        Response::Error { code, message } => panic!("create failed {code}: {message}"),
+    };
+
+    let read_diagram = async |sender: &str| {
+        db.execute_with_sender(
+            Request::Read {
+                entity: "diagrams".into(),
+                id: diagram_id.clone(),
+                includes: vec![],
+                projection: None,
+            },
+            Some(sender),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+    let update_diagram = async |sender: &str, title: &str| {
+        db.execute_with_sender(
+            Request::Update {
+                entity: "diagrams".into(),
+                id: diagram_id.clone(),
+                fields: json!({ "title": title }),
+            },
+            Some(sender),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+    let grant = async |permission: &str| {
+        db.execute(Request::Create {
+            entity: "_shares".into(),
+            data: json!({
+                "resource_entity": "diagrams",
+                "resource_id": diagram_id,
+                "grantee": "bob",
+                "grantee_key": "bob",
+                "permission": permission,
+                "granted_by": "alice",
+            }),
+        })
+        .await
+    };
+
+    assert!(
+        matches!(read_diagram("bob").await, Response::Error { code: 403, .. }),
+        "non-grantee read should be forbidden"
+    );
+
+    grant("view").await;
+    assert!(
+        matches!(read_diagram("bob").await, Response::Ok { .. }),
+        "view grantee read should succeed"
+    );
+    assert!(
+        matches!(
+            update_diagram("bob", "hacked").await,
+            Response::Error { code: 403, .. }
+        ),
+        "view grantee update should be forbidden"
+    );
+
+    grant("edit").await;
+    assert!(
+        matches!(update_diagram("bob", "by bob").await, Response::Ok { .. }),
+        "edit grantee update should succeed"
+    );
+
+    assert!(
+        matches!(
+            db.execute_with_sender(
+                Request::Delete {
+                    entity: "diagrams".into(),
+                    id: diagram_id.clone(),
+                },
+                Some("bob"),
+                None,
+                &ownership,
+                &scope,
+                None,
+            )
+            .await,
+            Response::Error { code: 403, .. }
+        ),
+        "edit grantee delete should be forbidden (owner-only)"
+    );
+    assert!(
+        matches!(
+            db.execute_with_sender(
+                Request::Delete {
+                    entity: "diagrams".into(),
+                    id: diagram_id.clone(),
+                },
+                Some("alice"),
+                None,
+                &ownership,
+                &scope,
+                None,
+            )
+            .await,
+            Response::Ok { .. }
+        ),
+        "owner delete should succeed"
+    );
+}
+
+#[tokio::test]
 async fn test_ownership_list_with_additional_filter() {
     use mqdb_core::{Request, Response};
 

--- a/crates/mqdb-agent/tests/integration_test.rs
+++ b/crates/mqdb-agent/tests/integration_test.rs
@@ -1761,6 +1761,7 @@ async fn test_share_grant_gates_read_update_delete() {
                 id: diagram_id.clone(),
                 grantee: "bob".into(),
                 permission: permission.into(),
+                cascade: false,
             },
             Some("alice"),
             None,
@@ -1863,6 +1864,7 @@ async fn test_share_endpoints_and_protection() {
                 id: diagram_id.clone(),
                 grantee: grantee.into(),
                 permission: permission.into(),
+                cascade: false,
             },
             Some(sender),
             None,
@@ -1954,6 +1956,7 @@ async fn test_share_endpoints_and_protection() {
             entity: "diagrams".into(),
             id: diagram_id.clone(),
             grantee: "bob".into(),
+            cascade: false,
         },
         Some("alice"),
         None,
@@ -1997,6 +2000,131 @@ async fn test_share_endpoints_and_protection() {
         ),
         "direct _shares create must be forbidden"
     );
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn test_share_cascade_follows_references() {
+    use mqdb_core::{Request, Response};
+
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open_without_background_tasks(tmp.path())
+        .await
+        .unwrap();
+    let ownership = OwnershipConfig::parse("diagrams=userId").unwrap();
+    let scope = ScopeConfig::default();
+
+    db.add_relationship("diagrams".into(), "parent".into(), "diagrams".into())
+        .await;
+
+    let make_diagram = async |title: &str, parent: Option<&str>| {
+        let data = match parent {
+            Some(p) => json!({"userId": "alice", "title": title, "parent_id": p}),
+            None => json!({"userId": "alice", "title": title}),
+        };
+        match db
+            .execute(Request::Create {
+                entity: "diagrams".into(),
+                data,
+            })
+            .await
+        {
+            Response::Ok { data } => data["id"].as_str().unwrap().to_string(),
+            Response::Error { code, message } => panic!("create failed {code}: {message}"),
+        }
+    };
+    let c = make_diagram("C", None).await;
+    let b = make_diagram("B", Some(&c)).await;
+    let a = make_diagram("A", Some(&b)).await;
+
+    let read_as = async |sender: &str, id: &str| {
+        db.execute_with_sender(
+            Request::Read {
+                entity: "diagrams".into(),
+                id: id.to_string(),
+                includes: vec![],
+                projection: None,
+            },
+            Some(sender),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+
+    let shared = db
+        .execute_with_sender(
+            Request::Share {
+                entity: "diagrams".into(),
+                id: a.clone(),
+                grantee: "bob".into(),
+                permission: "edit".into(),
+                cascade: true,
+            },
+            Some("alice"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await;
+    assert!(
+        matches!(shared, Response::Ok { .. }),
+        "cascade share should succeed"
+    );
+
+    for id in [&a, &b, &c] {
+        assert!(
+            matches!(read_as("bob", id).await, Response::Ok { .. }),
+            "bob should read every diagram in the closure"
+        );
+    }
+
+    if let Response::Ok { data } = db
+        .execute_with_sender(
+            Request::Shared {
+                entity: "diagrams".into(),
+            },
+            Some("bob"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    {
+        assert_eq!(
+            data.as_array().unwrap().len(),
+            3,
+            "discovery should list the full closure"
+        );
+    } else {
+        panic!("shared discovery failed");
+    }
+
+    db.execute_with_sender(
+        Request::Unshare {
+            entity: "diagrams".into(),
+            id: a.clone(),
+            grantee: "bob".into(),
+            cascade: true,
+        },
+        Some("alice"),
+        None,
+        &ownership,
+        &scope,
+        None,
+    )
+    .await;
+
+    for id in [&a, &b, &c] {
+        assert!(
+            matches!(read_as("bob", id).await, Response::Error { code: 403, .. }),
+            "cascade unshare should revoke access across the closure"
+        );
+    }
 }
 
 #[tokio::test]

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.4"
+version = "0.8.5"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-core/Cargo.toml
+++ b/crates/mqdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-core"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-core/src/protocol/mod.rs
+++ b/crates/mqdb-core/src/protocol/mod.rs
@@ -347,11 +347,13 @@ pub fn build_request(op: DbOperation, payload: &[u8]) -> Result<Request, Protoco
                 .and_then(Value::as_str)
                 .unwrap_or("view")
                 .to_string();
+            let cascade = data.get("cascade").and_then(Value::as_bool).unwrap_or(true);
             Ok(Request::Share {
                 entity: op.entity,
                 id,
                 grantee,
                 permission,
+                cascade,
             })
         }
         DbOp::Unshare => {
@@ -361,10 +363,12 @@ pub fn build_request(op: DbOperation, payload: &[u8]) -> Result<Request, Protoco
                 .and_then(Value::as_str)
                 .unwrap_or_default()
                 .to_string();
+            let cascade = data.get("cascade").and_then(Value::as_bool).unwrap_or(true);
             Ok(Request::Unshare {
                 entity: op.entity,
                 id,
                 grantee,
+                cascade,
             })
         }
         DbOp::Shares => {
@@ -539,11 +543,13 @@ mod tests {
                 id,
                 grantee,
                 permission,
+                cascade,
             } => {
                 assert_eq!(entity, "diagrams");
                 assert_eq!(id, "abc");
                 assert_eq!(grantee, "bob");
                 assert_eq!(permission, "edit");
+                assert!(cascade, "cascade defaults to true");
             }
             other => panic!("expected Share, got {other:?}"),
         }

--- a/crates/mqdb-core/src/protocol/mod.rs
+++ b/crates/mqdb-core/src/protocol/mod.rs
@@ -24,6 +24,10 @@ pub enum DbOp {
     Update,
     Delete,
     List,
+    Share,
+    Unshare,
+    Shares,
+    Shared,
 }
 
 impl fmt::Display for DbOp {
@@ -34,6 +38,10 @@ impl fmt::Display for DbOp {
             Self::Update => f.write_str("update"),
             Self::Delete => f.write_str("delete"),
             Self::List => f.write_str("list"),
+            Self::Share => f.write_str("share"),
+            Self::Unshare => f.write_str("unshare"),
+            Self::Shares => f.write_str("shares"),
+            Self::Shared => f.write_str("shared"),
         }
     }
 }
@@ -221,6 +229,32 @@ pub fn parse_db_topic(topic: &str) -> Option<DbOperation> {
             operation: DbOp::List,
             id: None,
         }),
+        [entity, "shared"] if is_valid_entity_name(entity) => Some(DbOperation {
+            entity: (*entity).to_string(),
+            operation: DbOp::Shared,
+            id: None,
+        }),
+        [entity, id, "share"] if is_valid_entity_name(entity) && is_valid_record_id(id) => {
+            Some(DbOperation {
+                entity: (*entity).to_string(),
+                operation: DbOp::Share,
+                id: Some((*id).to_string()),
+            })
+        }
+        [entity, id, "unshare"] if is_valid_entity_name(entity) && is_valid_record_id(id) => {
+            Some(DbOperation {
+                entity: (*entity).to_string(),
+                operation: DbOp::Unshare,
+                id: Some((*id).to_string()),
+            })
+        }
+        [entity, id, "shares"] if is_valid_entity_name(entity) && is_valid_record_id(id) => {
+            Some(DbOperation {
+                entity: (*entity).to_string(),
+                operation: DbOp::Shares,
+                id: Some((*id).to_string()),
+            })
+        }
         [entity, id] if is_valid_entity_name(entity) && is_valid_record_id(id) => {
             Some(DbOperation {
                 entity: (*entity).to_string(),
@@ -301,6 +335,46 @@ pub fn build_request(op: DbOperation, payload: &[u8]) -> Result<Request, Protoco
                 projection,
             })
         }
+        DbOp::Share => {
+            let id = op.id.ok_or(ProtocolError::MissingId(DbOp::Share))?;
+            let grantee = data
+                .get("grantee")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            let permission = data
+                .get("permission")
+                .and_then(Value::as_str)
+                .unwrap_or("view")
+                .to_string();
+            Ok(Request::Share {
+                entity: op.entity,
+                id,
+                grantee,
+                permission,
+            })
+        }
+        DbOp::Unshare => {
+            let id = op.id.ok_or(ProtocolError::MissingId(DbOp::Unshare))?;
+            let grantee = data
+                .get("grantee")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string();
+            Ok(Request::Unshare {
+                entity: op.entity,
+                id,
+                grantee,
+            })
+        }
+        DbOp::Shares => {
+            let id = op.id.ok_or(ProtocolError::MissingId(DbOp::Shares))?;
+            Ok(Request::Shares {
+                entity: op.entity,
+                id,
+            })
+        }
+        DbOp::Shared => Ok(Request::Shared { entity: op.entity }),
     }
 }
 
@@ -430,6 +504,49 @@ mod tests {
         assert!(parse_db_topic("invalid/topic").is_none());
         assert!(parse_db_topic("$DB").is_none());
         assert!(parse_db_topic("$DB/").is_none());
+    }
+
+    #[test]
+    fn test_parse_db_topic_share_family() {
+        let grant_op = parse_db_topic("$DB/diagrams/abc/share").unwrap();
+        assert_eq!(grant_op.entity, "diagrams");
+        assert_eq!(grant_op.operation, DbOp::Share);
+        assert_eq!(grant_op.id, Some("abc".to_string()));
+
+        let revoke_op = parse_db_topic("$DB/diagrams/abc/unshare").unwrap();
+        assert_eq!(revoke_op.operation, DbOp::Unshare);
+
+        let list_grants_op = parse_db_topic("$DB/diagrams/abc/shares").unwrap();
+        assert_eq!(list_grants_op.operation, DbOp::Shares);
+        assert_eq!(list_grants_op.id, Some("abc".to_string()));
+
+        let discovery_op = parse_db_topic("$DB/diagrams/shared").unwrap();
+        assert_eq!(discovery_op.operation, DbOp::Shared);
+        assert!(discovery_op.id.is_none());
+    }
+
+    #[test]
+    fn test_build_share_request() {
+        let op = DbOperation {
+            entity: "diagrams".to_string(),
+            operation: DbOp::Share,
+            id: Some("abc".to_string()),
+        };
+        let payload = br#"{"grantee":"bob","permission":"edit"}"#;
+        match build_request(op, payload).unwrap() {
+            Request::Share {
+                entity,
+                id,
+                grantee,
+                permission,
+            } => {
+                assert_eq!(entity, "diagrams");
+                assert_eq!(id, "abc");
+                assert_eq!(grantee, "bob");
+                assert_eq!(permission, "edit");
+            }
+            other => panic!("expected Share, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/mqdb-core/src/transport.rs
+++ b/crates/mqdb-core/src/transport.rs
@@ -60,6 +60,24 @@ pub enum Request {
     Unsubscribe {
         id: String,
     },
+    Share {
+        entity: String,
+        id: String,
+        grantee: String,
+        permission: String,
+    },
+    Unshare {
+        entity: String,
+        id: String,
+        grantee: String,
+    },
+    Shares {
+        entity: String,
+        id: String,
+    },
+    Shared {
+        entity: String,
+    },
 }
 
 impl Request {
@@ -73,6 +91,10 @@ impl Request {
             Request::List { .. } => "list",
             Request::Subscribe { .. } => "subscribe",
             Request::Unsubscribe { .. } => "unsubscribe",
+            Request::Share { .. } => "share",
+            Request::Unshare { .. } => "unshare",
+            Request::Shares { .. } => "shares",
+            Request::Shared { .. } => "shared",
         }
     }
 }

--- a/crates/mqdb-core/src/transport.rs
+++ b/crates/mqdb-core/src/transport.rs
@@ -65,11 +65,15 @@ pub enum Request {
         id: String,
         grantee: String,
         permission: String,
+        #[serde(default = "default_cascade")]
+        cascade: bool,
     },
     Unshare {
         entity: String,
         id: String,
         grantee: String,
+        #[serde(default = "default_cascade")]
+        cascade: bool,
     },
     Shares {
         entity: String,
@@ -78,6 +82,10 @@ pub enum Request {
     Shared {
         entity: String,
     },
+}
+
+fn default_cascade() -> bool {
+    true
 }
 
 impl Request {

--- a/crates/mqdb-core/src/types.rs
+++ b/crates/mqdb-core/src/types.rs
@@ -165,6 +165,33 @@ pub enum OwnershipDecision<'a, 'b> {
     },
 }
 
+pub const SHARES_ENTITY: &str = "_shares";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum AccessLevel {
+    View,
+    Edit,
+}
+
+impl AccessLevel {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            AccessLevel::View => "view",
+            AccessLevel::Edit => "edit",
+        }
+    }
+
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "view" => Some(AccessLevel::View),
+            "edit" => Some(AccessLevel::Edit),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SortDirection {

--- a/crates/mqdb-vault/Cargo.toml
+++ b/crates/mqdb-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-vault"
-version = "0.1.0"
+version = "0.1.1"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-vault/src/backend.rs
+++ b/crates/mqdb-vault/src/backend.rs
@@ -242,7 +242,7 @@ impl VaultBackend for VaultBackendImpl {
                         vault_decrypt_fields(&crypto, entity, &id, data, &skip);
                     }
                 }
-                DbOp::List => {
+                DbOp::List | DbOp::Shared => {
                     if let Some(items) = data.as_array_mut() {
                         for item in items {
                             if let Some(id) =
@@ -253,7 +253,7 @@ impl VaultBackend for VaultBackendImpl {
                         }
                     }
                 }
-                DbOp::Delete => {}
+                DbOp::Delete | DbOp::Share | DbOp::Unshare | DbOp::Shares => {}
             }
         })
     }

--- a/crates/mqdb-wasm/Cargo.lock
+++ b/crates/mqdb-wasm/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "arc-swap",
  "bebytes",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-wasm"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "console_error_panic_hook",
  "futures-channel",

--- a/crates/mqdb-wasm/Cargo.toml
+++ b/crates/mqdb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-wasm"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["LabOverWire"]

--- a/crates/mqdb-wasm/src/execute.rs
+++ b/crates/mqdb-wasm/src/execute.rs
@@ -67,6 +67,12 @@ impl WasmDatabase {
             Request::Subscribe { .. } | Request::Unsubscribe { .. } => Err(JsValue::from_str(
                 "use subscribe/unsubscribe methods directly",
             )),
+            Request::Share { .. }
+            | Request::Unshare { .. }
+            | Request::Shares { .. }
+            | Request::Shared { .. } => Err(JsValue::from_str(
+                "sharing is not supported in embedded mode",
+            )),
         }
     }
 }

--- a/docs/design/diagram-sharing-phase1-plan.md
+++ b/docs/design/diagram-sharing-phase1-plan.md
@@ -1,0 +1,268 @@
+# Diagram Sharing — Phase 1 Implementation Plan
+
+Phase 1 of `diagram-sharing.md`: the **grants + access core**. Delivers a complete
+agent-mode vertical slice — share a diagram view/edit with a named user, grantee
+reads/updates, owner-only delete, revoke, transitive cascade — plus cluster parity
+for everything it touches. No child enforcement (phase 2), no event changes
+(phase 3), no public/anonymous (phase 4).
+
+## In scope
+
+- `_shares` system entity + indexes.
+- `AccessLevel` and the `check_access` refactor (owner **or** named grant).
+- `$DB/{entity}/{id}/share|unshare|shares` and `$DB/{entity}/shared` topics.
+- Grantee resolution (email→canonical_id) + pending grants.
+- Transitive cascade over diagram→diagram references.
+- Delete stays owner-only; read/update become share-aware.
+- Cluster parity, built in step-by-step (not deferred).
+
+## Explicitly deferred
+
+- Child-entity derivation → phase 2. (Phase 1 only gates the ownership-enabled
+  entity itself; children stay as they are today.)
+- Recipient-scoped event routing / confidentiality → phase 3. **Events keep
+  broadcasting in phase 1.** A grantee added in phase 1 can already read the
+  diagram, but live-update confidentiality is a phase-3 concern.
+- Public / anonymous (`_public`, anon ticket) → phase 4.
+
+---
+
+## Corrections from code verification (read before building)
+
+1. **Ownership transfer is design-only, not implemented** (`docs/design/ownership-transfer.md`
+   has no corresponding code). The sharing endpoints therefore follow the
+   *resource-scoped suffix* pattern that `update`/`delete` already use in
+   `parse_db_topic`, not an existing transfer implementation.
+2. **`find_canonical_id_by_email` is HTTP-only** (`http/handlers.rs:537`, private,
+   depends on `ServerState`) and **cannot be called from the MQTT request path**.
+   Resolving a grantee during a `$DB/.../share` request requires refactoring that
+   lookup into an MQTT-reachable helper. This is a real work item, not a detail.
+3. **System entities are schema/index-registered at startup via MQTT admin
+   publishes**, mirroring `initialize_identity_constraints`
+   (`http/server.rs:362`): publish `$DB/_admin/constraint/{e}/add` and
+   `$DB/_admin/index/{e}/add`. `_shares` registers the same way.
+
+---
+
+## Data model: `_shares`
+
+Entity constant `entity::SHARES = "_shares"`. Record:
+
+```json
+{
+  "id": "<uuid>",
+  "resource_entity": "diagrams",
+  "resource_id": "<uuid>",
+  "grantee_key":   "bob@gmail.com",   // the input identifier (email or username); always present
+  "grantee":       "<canonical-id | username | null-while-pending>",  // what `sender` will equal
+  "permission":    "view",            // "view" | "edit"
+  "granted_by":    "<owner-identity>",
+  "created_at":    "<rfc3339>"
+}
+```
+
+Refinement vs. the design doc: it used `grantee_email`; I split into
+**`grantee_key`** (the always-present input identifier — covers password usernames
+too) and **`grantee`** (the resolved match-identity, null only while a pending
+OAuth grant awaits the grantee's first sign-in). `can_see`/`can_edit` match on
+`grantee == sender`; a null `grantee` matches nobody, so pending grants are inert.
+
+Indexes / constraints (registered at startup):
+
+- index `(grantee)` — the per-operation access lookup and `/shared` discovery.
+- index `(resource_entity, resource_id)` — `/shares` listing and cleanup.
+- index `(grantee_key)` — pending-grant resolution on sign-in.
+- unique `(resource_entity, resource_id, grantee_key)` — one grant per
+  (resource, identifier); re-share updates in place. `grantee_key` is always
+  present, so no null-in-unique question. (Composite unique is supported — the
+  constraint payload takes a `fields` array.)
+
+`_shares` is **not** exposed via generic CRUD topics; it is read/written only by
+the share handlers below. Confirm during build: the mechanism that blocks external
+`$DB/_shares/...` CRUD (system/`_`-prefixed protection) — verify `_`-prefixed
+entities are already gated, or add `_shares` to the protected set.
+
+---
+
+## Topic / protocol API
+
+Resource-scoped, parsed by `parse_db_topic` (`protocol/mod.rs:210`). New `DbOp`
+variants and the arm ordering (the 3-part arms and `[entity,"shared"]` **must
+precede** the `[entity, id]` Read catch-all):
+
+| Topic | `DbOp` | parse arm |
+|-------|--------|-----------|
+| `$DB/{e}/{id}/share` | `Share` | `[e, id, "share"]` |
+| `$DB/{e}/{id}/unshare` | `Unshare` | `[e, id, "unshare"]` |
+| `$DB/{e}/{id}/shares` | `Shares` | `[e, id, "shares"]` |
+| `$DB/{e}/shared` | `Shared` | `[e, "shared"]` (beside `create`/`list`) |
+
+`Request` variants (`transport.rs:14`) + `build_request` parsing
+(`transport.rs:253`):
+
+```
+Share   { entity, id, grantee: String, permission: String, cascade: bool }
+Unshare { entity, id, grantee: String, cascade: bool }
+Shares  { entity, id }
+Shared  { entity }
+```
+
+Dispatch in `execute_with_sender` (`transport_execute.rs:36`) — new match arms
+calling the database methods below. (Note: the existing admin endpoints `_vault`,
+`_auth`, `_admin` go through `parse_admin_topic`; these resource-scoped share ops
+go through `parse_db_topic`, consistent with `update`/`delete`.)
+
+---
+
+## Access-check refactor
+
+Add to `mqdb-core/src/types.rs` (beside `OwnershipConfig`):
+
+```
+pub enum AccessLevel { View, Edit }   // Edit >= View
+```
+
+Replace the two share-relevant call sites of `check_ownership`
+(`crud.rs:410`) with a share-aware check:
+
+```
+check_access(entity, id, owner_field, sender, required: AccessLevel) -> Result<()>:
+    if is_owner(entity, id, owner_field, sender): Ok
+    else match share_level(entity, id, sender):   // _shares lookup by (grantee, resource)
+        Some(l) if l >= required: Ok
+        _: Err(Forbidden)
+```
+
+- `is_owner` = the existing exact-match logic extracted from `check_ownership`.
+- `share_level(entity, id, sender)` = read `_shares` for
+  `(resource_entity=entity, resource_id=id, grantee=sender)`; return its level.
+- Admin still short-circuits earlier in `OwnershipConfig::evaluate` → `Allowed`.
+
+Wire-up in `transport_execute.rs`:
+
+- **Read** (`:72`) → `check_access(..., View)`.
+- **Update** (`:90`) → `check_access(..., Edit)`; keep stripping the owner field.
+- **Delete** (`:122`) → **unchanged** (keep `check_ownership` / owner-only, per
+  Decision #1).
+- **List** (`:156`) → unchanged owner filter; discovery is the separate `/shared`.
+
+Phase-1 scope note: `check_access` here covers **owner + named grant only**. Child
+derivation and the public/anon branches are added in later phases — design the
+signature so they slot in without a rewrite.
+
+---
+
+## Grantee resolution + pending grants
+
+1. **Refactor the email lookup to be MQTT-reachable.** Extract the
+   `_identity_links` email→canonical_id query (`http/handlers.rs:537`) into a
+   public helper in `db_helpers.rs` (MQTT-path reachable, takes the agent's
+   MQTT client / db handle, not `ServerState`). The HTTP handler then calls the
+   shared helper too — no logic duplication.
+2. **Resolve on `/share`:**
+   - identities enabled + email found → `grantee = canonical_id`.
+   - identities enabled + email unknown → **pending**: store `grantee = null`,
+     `grantee_key = email`.
+   - password-only deployment (no `_identities`) → `grantee = grantee_key`
+     (username verbatim).
+3. **Pending sweep on sign-in.** In `resolve_or_create_identity`
+   (`http/handlers.rs:396`), after a canonical_id is established for a verified
+   email, query `_shares` by `grantee_key = email` with `grantee = null` and fill
+   in `grantee = canonical_id`. Bounded by the number of pending grants per email.
+
+This is the highest-uncertainty work item; it crosses the HTTP/MQTT module
+boundary. It can be split: **1c-i** resolve-existing-only (unknown email → 400),
+**1c-ii** pending + sweep, so the core lands before pending support.
+
+---
+
+## Cascade
+
+In the share/unshare handlers, walk diagram→diagram references — the registered
+relationships / FKs where `source_entity == target_entity == entity`
+(`relationship.rs`, `constraint.rs`). Bounded, cycle-safe BFS (already verified in
+`specs/CascadeClosure.tla`):
+
+```
+const MAX_CASCADE_DIAGRAMS = 256
+visited = {}; queue = [root]
+while queue and |visited| < MAX_CASCADE_DIAGRAMS:
+    id = pop; if id in visited: continue; visited.add(id)
+    for f in self_reference_fields(entity):
+        r = record(entity,id)[f]; if r and r not in visited: push(r)
+upsert a grant for each id in visited
+```
+
+Level rule (verified in `specs/GrantLifecycle.tla`): **direct share = set-to-level**
+(may demote); **cascade = max-of-levels** (never downgrades an existing grant).
+`unshare --cascade` removes across the same closure.
+
+---
+
+## Cluster parity (built incrementally, not deferred)
+
+For each piece above, mirror it on the cluster path in the same step — the two DB
+paths handle the same payloads in separate code (agent/cluster handler parity), and
+deferring all cluster work is where parity bugs hide. Touchpoints:
+
+- `cluster_agent/admin.rs` — dispatch the new `Request::Share|Unshare|Shares|Shared`.
+- `cluster/node_controller/db_ops.rs` — route `_shares` reads/writes and the access
+  check to the **resource's** partition primary (a grant is checked where the
+  resource lives).
+- `cluster/db_handler/` — apply `check_access` on the partitioned read/update path.
+
+`_shares` is a partitioned entity; the access check reads it on the resource's
+primary. Confirm the routing key during build.
+
+---
+
+## Ordered steps (each independently testable)
+
+1. **1a — types + `_shares` registration.** `AccessLevel`; `entity::SHARES`;
+   startup index/constraint registration; system-entity protection for `_shares`.
+2. **1b — protocol/transport.** `DbOp` + `Request` variants; `parse_db_topic` arms
+   (precedence!); `build_request`. Unit-test parsing in isolation.
+3. **1c — grant store + access core.** `is_owner`, `share_level`, grant
+   create/clear/list in `crud.rs`; `check_access`; wire Read/Update; delete
+   unchanged. Agent-mode test: owner + manually-inserted grant → read/update gated.
+4. **1d — share/unshare/shares/shared handlers** (agent) with grantee resolution
+   (1c-i resolve-existing; 1c-ii pending + sweep).
+5. **1e — cascade** in share/unshare.
+6. **1f — cluster parity** for 1b–1e; `_shares` orphan cleanup on diagram delete.
+
+Frontend hand-off: the client wrapper (`shareDiagram`, `unshareDiagram`,
+`listDiagramShares`, `listSharedWithMe`) wraps these MQTT topics — broker-side
+feature; the embedded-only WASM DB path does not participate.
+
+---
+
+## Tests (agent + 3-node cluster)
+
+- view grant → grantee reads, update 403; edit grant → reads + updates; delete 403
+  for both (owner-only).
+- direct re-share view demotes an edit grant; cascade does not downgrade.
+- cascade over A→B→A shares {A,B} once; respects `MAX_CASCADE_DIAGRAMS`.
+- grantee resolution: email→canonical_id; unknown→pending; pending filled on first
+  sign-in; password deployment uses username verbatim.
+- `/shared` returns exactly the caller's grants; `/shares` lists a resource's grants
+  (owner/admin only); non-owner cannot share.
+- revoke removes access on next op.
+- delete diagram removes its `_shares` rows.
+- `_shares` is not reachable via generic `$DB/_shares/...` CRUD.
+
+Extend `mqdb dev test` with a `--sharing` scenario for the agent + cluster matrix.
+
+---
+
+## Decisions / risks to confirm during build
+
+- **System-entity CRUD protection** — verify `_`-prefixed entities are already
+  blocked from external generic CRUD, or add `_shares` explicitly.
+- **Composite-unique null semantics** — using `grantee_key` (always present) as the
+  unique component avoids it; confirm the constraint engine accepts composite
+  `fields`.
+- **Email-lookup refactor** — the HTTP→shared-helper extraction is the main
+  cross-cutting change; confirm `db_helpers.rs` has (or can take) the db/client
+  handle needed from the MQTT path.
+- **`_shares` partition routing key** in cluster mode — confirm the resource's
+  primary is the right home for its grants.


### PR DESCRIPTION
## Summary
- share diagrams with named users at view/edit via `$DB/{e}/{id}/share|unshare|shares` and `$DB/{e}/shared`; owner/admin-only, set-to-level upsert, revoke, "shared with me" discovery
- share-aware access: read needs view, update needs edit, delete stays owner-only; `_shares` is server-managed (generic CRUD on it returns 403)
- transitive cascade over diagram→diagram references (bounded, cycle-safe); grantee email→canonical-id resolution in OAuth mode (resolve-existing)
- agent mode only — cluster parity tracked in #75; pending grants deferred

## Test plan
- [ ] share gating: view reads but can't update; edit updates but can't delete; owner deletes
- [ ] endpoints: owner-only share/list, set-to-level replace, discovery, non-owner 403, `_shares` CRUD blocked
- [ ] cascade A→B→C share + revoke across the closure
- [ ] indexed grant path correct and idempotent
- [ ] grantee email→canonical-id resolution (unit)