### PR TITLE
add child-entity access derivation (diagram sharing phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-05-28 — mqdb-core 0.7.2, mqdb-agent 0.8.6, mqdb-cli 0.8.7
+
+### Added
+
+- Child-entity access derivation (diagram sharing phase 2, #77). A new opt-in `--ownership-derive` flag (env `MQDB_OWNERSHIP_DERIVE`) maps a child entity to its parent: `child=fk_field>parent_entity` pairs, comma-separated (e.g. `nodes=diagramId>diagrams,edges=diagramId>diagrams`). A derived child inherits access from the referenced parent record — read requires `view` on the parent, and create/update/delete require `edit`. The parent reference is immutable on update, so an editor cannot reparent a child into a diagram they cannot edit. Absent a mapping a child entity stays unrestricted (prior behavior), so the change is opt-in per deployment. This closes the pre-existing hole where any authenticated user could read or edit a child record (e.g. a diagram's nodes/edges) just by knowing its id. New `mqdb-core` API: `OwnershipConfig::with_derivations`/`derivation` and the `OwnershipDecision::Derive` variant. Agent mode only; cluster parity tracked in #75. Verified in TLA+: `specs/DiagramSharing.tla` now models a mutable parent with an unrestricted reparent action, and all 13 invariants still hold across reparented states (52,488 states), confirming derived access cannot leak when a child moves between parents.
+
 ## 2026-05-28 — mqdb-cli 0.8.6
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.8.5"
+version = "0.8.6"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.6"
+version = "0.8.7"
 dependencies = [
  "base64",
  "bebytes",
@@ -1444,7 +1444,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/README.md
+++ b/README.md
@@ -378,6 +378,8 @@ An owner can share any ownership-enabled entity (the motivating case is diagrams
 
 `share`/`unshare` cascade by default over self-references (a diagram and the diagrams it links to); a direct share sets the level while a cascade only raises an existing grant. Read requires `view`, update requires `edit`; delete stays owner-only and clears the resource's grants. In OAuth deployments `grantee` is an email resolved to the registered user's canonical id (an unregistered email returns 404); with password/SCRAM auth it is the username.
 
+**Child-entity derivation.** Child records (e.g. a diagram's nodes/edges) can inherit access from their parent via `--ownership-derive` (env `MQDB_OWNERSHIP_DERIVE`), a comma-separated map of `child=fk_field>parent_entity` (e.g. `nodes=diagramId>diagrams,edges=diagramId>diagrams`). A derived child's read requires `view` on the parent and create/update/delete require `edit`; the parent reference is immutable on update, so an editor cannot move a child into a diagram they cannot edit. Without a mapping a child entity is unrestricted (default), so derivation is opt-in per deployment.
+
 #### Admin Operations
 
 | Topic | Action |

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.8.5"
+version = "0.8.6"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-agent/src/database/crud.rs
+++ b/crates/mqdb-agent/src/database/crud.rs
@@ -513,6 +513,97 @@ impl Database {
         }
     }
 
+    /// Resolve the parent id a child record references via `fk_field`.
+    ///
+    /// # Errors
+    /// Returns `NotFound` if the child record is missing, or `Validation` if it
+    /// lacks the parent reference field.
+    fn parent_ref(&self, child_entity: &str, child_id: &str, fk_field: &str) -> Result<String> {
+        let key = keys::encode_data_key(child_entity, child_id);
+        let data = self.storage.get(&key)?.ok_or_else(|| Error::NotFound {
+            entity: child_entity.to_string(),
+            id: child_id.to_string(),
+        })?;
+        let entity = Entity::deserialize(child_entity.to_string(), child_id.to_string(), &data)?;
+        entity
+            .data
+            .get(fk_field)
+            .and_then(Value::as_str)
+            .map(String::from)
+            .ok_or_else(|| {
+                Error::Validation(format!(
+                    "child '{child_entity}/{child_id}' is missing parent reference '{fk_field}'"
+                ))
+            })
+    }
+
+    async fn check_parent_access(
+        &self,
+        parent_entity: &str,
+        parent_id: &str,
+        sender: &str,
+        required: AccessLevel,
+        ownership: &OwnershipConfig,
+    ) -> Result<()> {
+        match ownership.owner_field(parent_entity) {
+            Some(owner_field) => {
+                self.check_access(parent_entity, parent_id, owner_field, sender, required)
+                    .await
+            }
+            None => Ok(()),
+        }
+    }
+
+    /// Authorize a child operation by deriving access from its parent record. The
+    /// parent id is read from the existing child via `fk_field`.
+    ///
+    /// # Errors
+    /// Returns `Forbidden` if access is denied, `NotFound` if the child is missing,
+    /// or `Validation` if the parent reference is absent.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn check_derived_access(
+        &self,
+        child_entity: &str,
+        child_id: &str,
+        parent_entity: &str,
+        fk_field: &str,
+        sender: &str,
+        required: AccessLevel,
+        ownership: &OwnershipConfig,
+    ) -> Result<()> {
+        let parent_id = self.parent_ref(child_entity, child_id, fk_field)?;
+        self.check_parent_access(parent_entity, &parent_id, sender, required, ownership)
+            .await
+    }
+
+    /// Authorize a child create by deriving access from the parent referenced in the
+    /// incoming `data` via `fk_field`. A child create requires `Edit` on the parent.
+    ///
+    /// # Errors
+    /// Returns `Forbidden` if access is denied, or `Validation` if `data` lacks the
+    /// parent reference.
+    pub async fn check_derived_create(
+        &self,
+        data: &Value,
+        parent_entity: &str,
+        fk_field: &str,
+        sender: &str,
+        ownership: &OwnershipConfig,
+    ) -> Result<()> {
+        let parent_id = data
+            .get(fk_field)
+            .and_then(Value::as_str)
+            .ok_or_else(|| Error::Validation(format!("missing parent reference '{fk_field}'")))?;
+        self.check_parent_access(
+            parent_entity,
+            parent_id,
+            sender,
+            AccessLevel::Edit,
+            ownership,
+        )
+        .await
+    }
+
     pub(super) fn generate_id(entity_name: &str, data: &[u8]) -> String {
         use std::sync::atomic::{AtomicU16, Ordering};
         static COUNTER: AtomicU16 = AtomicU16::new(0);

--- a/crates/mqdb-agent/src/transport_execute.rs
+++ b/crates/mqdb-agent/src/transport_execute.rs
@@ -59,6 +59,17 @@ impl Database {
         }
         match request {
             Request::Create { entity, data } => {
+                if let OwnershipDecision::Derive {
+                    parent_entity,
+                    fk_field,
+                    sender: uid,
+                } = ownership.evaluate(&entity, sender)
+                    && let Err(e) = self
+                        .check_derived_create(&data, parent_entity, fk_field, uid, ownership)
+                        .await
+                {
+                    return e.into();
+                }
                 let constraint_data = match vault_constraint {
                     Some(VaultConstraintData::Create(cd)) => Some(cd),
                     _ => None,
@@ -84,15 +95,39 @@ impl Database {
                 includes,
                 projection,
             } => {
-                if let OwnershipDecision::Check {
-                    owner_field,
-                    sender: uid,
-                } = ownership.evaluate(&entity, sender)
-                    && let Err(e) = self
-                        .check_access(&entity, &id, owner_field, uid, AccessLevel::View)
-                        .await
-                {
-                    return e.into();
+                match ownership.evaluate(&entity, sender) {
+                    OwnershipDecision::Check {
+                        owner_field,
+                        sender: uid,
+                    } => {
+                        if let Err(e) = self
+                            .check_access(&entity, &id, owner_field, uid, AccessLevel::View)
+                            .await
+                        {
+                            return e.into();
+                        }
+                    }
+                    OwnershipDecision::Derive {
+                        parent_entity,
+                        fk_field,
+                        sender: uid,
+                    } => {
+                        if let Err(e) = self
+                            .check_derived_access(
+                                &entity,
+                                &id,
+                                parent_entity,
+                                fk_field,
+                                uid,
+                                AccessLevel::View,
+                                ownership,
+                            )
+                            .await
+                        {
+                            return e.into();
+                        }
+                    }
+                    OwnershipDecision::Allowed => {}
                 }
                 match self.read(entity, id, includes, projection).await {
                     Ok(v) => Response::ok(v),
@@ -104,20 +139,45 @@ impl Database {
                 id,
                 mut fields,
             } => {
-                if let OwnershipDecision::Check {
-                    owner_field,
-                    sender: uid,
-                } = ownership.evaluate(&entity, sender)
-                {
-                    if let Err(e) = self
-                        .check_access(&entity, &id, owner_field, uid, AccessLevel::Edit)
-                        .await
-                    {
-                        return e.into();
+                match ownership.evaluate(&entity, sender) {
+                    OwnershipDecision::Check {
+                        owner_field,
+                        sender: uid,
+                    } => {
+                        if let Err(e) = self
+                            .check_access(&entity, &id, owner_field, uid, AccessLevel::Edit)
+                            .await
+                        {
+                            return e.into();
+                        }
+                        if let Value::Object(ref mut map) = fields {
+                            map.remove(owner_field);
+                        }
                     }
-                    if let Value::Object(ref mut map) = fields {
-                        map.remove(owner_field);
+                    OwnershipDecision::Derive {
+                        parent_entity,
+                        fk_field,
+                        sender: uid,
+                    } => {
+                        if let Err(e) = self
+                            .check_derived_access(
+                                &entity,
+                                &id,
+                                parent_entity,
+                                fk_field,
+                                uid,
+                                AccessLevel::Edit,
+                                ownership,
+                            )
+                            .await
+                        {
+                            return e.into();
+                        }
+                        if let Value::Object(ref mut map) = fields {
+                            map.remove(fk_field);
+                        }
                     }
+                    OwnershipDecision::Allowed => {}
                 }
                 let update_constraint = match vault_constraint {
                     Some(VaultConstraintData::Update(new_data, old_data)) => {
@@ -139,13 +199,36 @@ impl Database {
                 }
             }
             Request::Delete { entity, id } => {
-                if let OwnershipDecision::Check {
-                    owner_field,
-                    sender: uid,
-                } = ownership.evaluate(&entity, sender)
-                    && let Err(e) = self.check_ownership(&entity, &id, owner_field, uid)
-                {
-                    return e.into();
+                match ownership.evaluate(&entity, sender) {
+                    OwnershipDecision::Check {
+                        owner_field,
+                        sender: uid,
+                    } => {
+                        if let Err(e) = self.check_ownership(&entity, &id, owner_field, uid) {
+                            return e.into();
+                        }
+                    }
+                    OwnershipDecision::Derive {
+                        parent_entity,
+                        fk_field,
+                        sender: uid,
+                    } => {
+                        if let Err(e) = self
+                            .check_derived_access(
+                                &entity,
+                                &id,
+                                parent_entity,
+                                fk_field,
+                                uid,
+                                AccessLevel::Edit,
+                                ownership,
+                            )
+                            .await
+                        {
+                            return e.into();
+                        }
+                    }
+                    OwnershipDecision::Allowed => {}
                 }
                 let id_clone = id.clone();
                 let shareable = ownership.owner_field(&entity).is_some();

--- a/crates/mqdb-agent/tests/integration_test.rs
+++ b/crates/mqdb-agent/tests/integration_test.rs
@@ -2309,6 +2309,344 @@ async fn test_delete_clears_shares_no_inheritance() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn test_child_enforcement_derives_from_parent() {
+    use mqdb_core::{Request, Response};
+
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open_without_background_tasks(tmp.path())
+        .await
+        .unwrap();
+    let ownership = OwnershipConfig::parse("diagrams=userId")
+        .unwrap()
+        .with_derivations("nodes=diagramId>diagrams")
+        .unwrap();
+    let scope = ScopeConfig::default();
+
+    let diagram_id = match db
+        .execute(Request::Create {
+            entity: "diagrams".into(),
+            data: json!({"userId": "alice", "title": "D"}),
+        })
+        .await
+    {
+        Response::Ok { data } => data["id"].as_str().unwrap().to_string(),
+        Response::Error { code, message } => panic!("create diagram failed {code}: {message}"),
+    };
+
+    let create_node = async |sender: &str, diagram: &str| {
+        db.execute_with_sender(
+            Request::Create {
+                entity: "nodes".into(),
+                data: json!({"diagramId": diagram, "label": "n"}),
+            },
+            Some(sender),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+    let node_id = match create_node("alice", &diagram_id).await {
+        Response::Ok { data } => data["id"].as_str().unwrap().to_string(),
+        Response::Error { code, message } => panic!("owner create node failed {code}: {message}"),
+    };
+
+    let read_node = async |sender: &str| {
+        db.execute_with_sender(
+            Request::Read {
+                entity: "nodes".into(),
+                id: node_id.clone(),
+                includes: vec![],
+                projection: None,
+            },
+            Some(sender),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+    let update_node = async |sender: &str| {
+        db.execute_with_sender(
+            Request::Update {
+                entity: "nodes".into(),
+                id: node_id.clone(),
+                fields: json!({"label": "edited"}),
+            },
+            Some(sender),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+    let delete_node = async |sender: &str| {
+        db.execute_with_sender(
+            Request::Delete {
+                entity: "nodes".into(),
+                id: node_id.clone(),
+            },
+            Some(sender),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+    let share = async |permission: &str| {
+        db.execute_with_sender(
+            Request::Share {
+                entity: "diagrams".into(),
+                id: diagram_id.clone(),
+                grantee: "bob".into(),
+                permission: permission.into(),
+                cascade: false,
+            },
+            Some("alice"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    };
+
+    assert!(
+        matches!(read_node("bob").await, Response::Error { code: 403, .. }),
+        "stranger cannot read a child"
+    );
+    assert!(
+        matches!(update_node("bob").await, Response::Error { code: 403, .. }),
+        "stranger cannot update a child"
+    );
+    assert!(
+        matches!(
+            create_node("bob", &diagram_id).await,
+            Response::Error { code: 403, .. }
+        ),
+        "stranger cannot create a child"
+    );
+    assert!(
+        matches!(delete_node("bob").await, Response::Error { code: 403, .. }),
+        "stranger cannot delete a child"
+    );
+
+    share("view").await;
+    assert!(
+        matches!(read_node("bob").await, Response::Ok { .. }),
+        "view grantee reads the child"
+    );
+    assert!(
+        matches!(update_node("bob").await, Response::Error { code: 403, .. }),
+        "view grantee cannot update the child"
+    );
+    assert!(
+        matches!(
+            create_node("bob", &diagram_id).await,
+            Response::Error { code: 403, .. }
+        ),
+        "view grantee cannot create a child"
+    );
+    assert!(
+        matches!(delete_node("bob").await, Response::Error { code: 403, .. }),
+        "view grantee cannot delete the child"
+    );
+
+    share("edit").await;
+    assert!(
+        matches!(read_node("bob").await, Response::Ok { .. }),
+        "edit grantee reads the child"
+    );
+    assert!(
+        matches!(update_node("bob").await, Response::Ok { .. }),
+        "edit grantee updates the child"
+    );
+    assert!(
+        matches!(create_node("bob", &diagram_id).await, Response::Ok { .. }),
+        "edit grantee creates a child"
+    );
+    assert!(
+        matches!(delete_node("bob").await, Response::Ok { .. }),
+        "edit grantee deletes the child"
+    );
+}
+
+#[tokio::test]
+async fn test_child_reparent_blocked() {
+    use mqdb_core::{Request, Response};
+
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open_without_background_tasks(tmp.path())
+        .await
+        .unwrap();
+    let ownership = OwnershipConfig::parse("diagrams=userId")
+        .unwrap()
+        .with_derivations("nodes=diagramId>diagrams")
+        .unwrap();
+    let scope = ScopeConfig::default();
+
+    let mk_diagram = async |user: &str| match db
+        .execute(Request::Create {
+            entity: "diagrams".into(),
+            data: json!({"userId": user, "title": "d"}),
+        })
+        .await
+    {
+        Response::Ok { data } => data["id"].as_str().unwrap().to_string(),
+        Response::Error { code, message } => panic!("create diagram failed {code}: {message}"),
+    };
+    let d1 = mk_diagram("alice").await;
+    let d2 = mk_diagram("carol").await;
+
+    let node_id = match db
+        .execute_with_sender(
+            Request::Create {
+                entity: "nodes".into(),
+                data: json!({"diagramId": d1, "label": "n"}),
+            },
+            Some("alice"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    {
+        Response::Ok { data } => data["id"].as_str().unwrap().to_string(),
+        Response::Error { code, message } => panic!("create node failed {code}: {message}"),
+    };
+
+    db.execute_with_sender(
+        Request::Share {
+            entity: "diagrams".into(),
+            id: d1.clone(),
+            grantee: "bob".into(),
+            permission: "edit".into(),
+            cascade: false,
+        },
+        Some("alice"),
+        None,
+        &ownership,
+        &scope,
+        None,
+    )
+    .await;
+
+    let updated = db
+        .execute_with_sender(
+            Request::Update {
+                entity: "nodes".into(),
+                id: node_id.clone(),
+                fields: json!({"diagramId": d2, "label": "moved"}),
+            },
+            Some("bob"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await;
+    assert!(
+        matches!(updated, Response::Ok { .. }),
+        "edit on the current parent permits the update"
+    );
+
+    match db
+        .execute_with_sender(
+            Request::Read {
+                entity: "nodes".into(),
+                id: node_id.clone(),
+                includes: vec![],
+                projection: None,
+            },
+            Some("alice"),
+            None,
+            &ownership,
+            &scope,
+            None,
+        )
+        .await
+    {
+        Response::Ok { data } => {
+            assert_eq!(
+                data["diagramId"], d1,
+                "parent reference must stay d1 (reparent blocked)"
+            );
+            assert_eq!(data["label"], "moved", "non-parent fields still update");
+        }
+        Response::Error { code, message } => panic!("read failed {code}: {message}"),
+    }
+}
+
+#[tokio::test]
+async fn test_unconfigured_child_unrestricted() {
+    use mqdb_core::{Request, Response};
+
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open_without_background_tasks(tmp.path())
+        .await
+        .unwrap();
+    let ownership = OwnershipConfig::parse("diagrams=userId").unwrap();
+    let scope = ScopeConfig::default();
+
+    let widget_id = match db
+        .execute(Request::Create {
+            entity: "widgets".into(),
+            data: json!({"k": "v"}),
+        })
+        .await
+    {
+        Response::Ok { data } => data["id"].as_str().unwrap().to_string(),
+        Response::Error { code, message } => panic!("create widget failed {code}: {message}"),
+    };
+
+    assert!(
+        matches!(
+            db.execute_with_sender(
+                Request::Read {
+                    entity: "widgets".into(),
+                    id: widget_id.clone(),
+                    includes: vec![],
+                    projection: None,
+                },
+                Some("bob"),
+                None,
+                &ownership,
+                &scope,
+                None,
+            )
+            .await,
+            Response::Ok { .. }
+        ),
+        "unconfigured entity read is unrestricted"
+    );
+    assert!(
+        matches!(
+            db.execute_with_sender(
+                Request::Update {
+                    entity: "widgets".into(),
+                    id: widget_id.clone(),
+                    fields: json!({"k": "v2"}),
+                },
+                Some("bob"),
+                None,
+                &ownership,
+                &scope,
+                None,
+            )
+            .await,
+            Response::Ok { .. }
+        ),
+        "unconfigured entity update is unrestricted"
+    );
+}
+
+#[tokio::test]
 async fn test_ownership_list_with_additional_filter() {
     use mqdb_core::{Request, Response};
 

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.6"
+version = "0.8.7"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cli/src/cli_types/agent.rs
+++ b/crates/mqdb-cli/src/cli_types/agent.rs
@@ -103,6 +103,12 @@ pub(crate) struct AgentStartFields {
     pub(crate) vault_min_passphrase_length: usize,
     #[arg(
         long,
+        env = "MQDB_OWNERSHIP_DERIVE",
+        help = "Child-entity access derivation: child=field>parent pairs (e.g. nodes=diagramId>diagrams)"
+    )]
+    pub(crate) ownership_derive: Option<String>,
+    #[arg(
+        long,
         env = "MQDB_OTLP_ENDPOINT",
         help = "OTLP collector endpoint (enables OpenTelemetry tracing)"
     )]

--- a/crates/mqdb-cli/src/commands/agent.rs
+++ b/crates/mqdb-cli/src/commands/agent.rs
@@ -29,6 +29,7 @@ pub(crate) struct AgentStartArgs {
     pub(crate) ws_bind: Option<SocketAddr>,
     pub(crate) oauth: OAuthArgs,
     pub(crate) ownership: Option<String>,
+    pub(crate) ownership_derive: Option<String>,
     pub(crate) event_scope: Option<String>,
     pub(crate) passphrase_file: Option<PathBuf>,
     pub(crate) passphrase_data: Option<String>,
@@ -133,12 +134,19 @@ pub(crate) async fn cmd_agent_start(
     if let Some(ws_addr) = args.ws_bind {
         agent = agent.with_ws_bind_address(ws_addr);
     }
-    if let Some(ownership_spec) = args.ownership {
+    if args.ownership.is_some() || args.ownership_derive.is_some() {
         let admin_set = args.auth.admin_users.iter().cloned().collect();
-        let ownership = mqdb_core::types::OwnershipConfig::parse(&ownership_spec)
-            .map_err(|e| format!("invalid --ownership: {e}"))?
-            .with_admin_users(admin_set);
-        agent = agent.with_ownership_config(ownership);
+        let mut ownership = match &args.ownership {
+            Some(spec) => mqdb_core::types::OwnershipConfig::parse(spec)
+                .map_err(|e| format!("invalid --ownership: {e}"))?,
+            None => mqdb_core::types::OwnershipConfig::default(),
+        };
+        if let Some(derive_spec) = &args.ownership_derive {
+            ownership = ownership
+                .with_derivations(derive_spec)
+                .map_err(|e| format!("invalid --ownership-derive: {e}"))?;
+        }
+        agent = agent.with_ownership_config(ownership.with_admin_users(admin_set));
     }
 
     if let Some(event_scope_spec) = args.event_scope {

--- a/crates/mqdb-cli/src/main.rs
+++ b/crates/mqdb-cli/src/main.rs
@@ -205,6 +205,7 @@ async fn dispatch_agent(action: AgentAction) -> Result<(), Box<dyn std::error::E
                 license: fields.license,
                 license_data: fields.license_data,
                 vault_min_passphrase_length: fields.vault_min_passphrase_length,
+                ownership_derive: fields.ownership_derive,
                 otlp_endpoint: fields.otlp_endpoint,
                 otel_service_name: fields.otel_service_name,
                 otel_sampling_ratio: fields.otel_sampling_ratio,

--- a/crates/mqdb-core/Cargo.toml
+++ b/crates/mqdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-core"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-core/src/types.rs
+++ b/crates/mqdb-core/src/types.rs
@@ -76,6 +76,7 @@ impl ScopeConfig {
 pub struct OwnershipConfig {
     pub entity_owner_fields: HashMap<String, String>,
     admin_users: HashSet<String>,
+    derivations: HashMap<String, (String, String)>,
 }
 
 impl OwnershipConfig {
@@ -84,6 +85,7 @@ impl OwnershipConfig {
         Self {
             entity_owner_fields,
             admin_users: HashSet::new(),
+            derivations: HashMap::new(),
         }
     }
 
@@ -107,7 +109,44 @@ impl OwnershipConfig {
         Ok(Self {
             entity_owner_fields: fields,
             admin_users: HashSet::new(),
+            derivations: HashMap::new(),
         })
+    }
+
+    /// Parse a child-entity derivation spec and attach it. Format:
+    /// `child=fk_field>parent_entity` pairs, comma-separated
+    /// (e.g. `nodes=diagramId>diagrams,edges=diagramId>diagrams`). A child entity
+    /// with a derivation inherits its access from the referenced parent record.
+    ///
+    /// # Errors
+    /// Returns an error if any pair is not in `child=field>parent` format.
+    pub fn with_derivations(mut self, spec: &str) -> Result<Self, String> {
+        for pair in spec.split(',') {
+            let pair = pair.trim();
+            if pair.is_empty() {
+                continue;
+            }
+            let (child, rest) = pair.split_once('=').ok_or_else(|| {
+                format!("invalid derivation spec '{pair}': expected child=field>parent")
+            })?;
+            let (field, parent) = rest.split_once('>').ok_or_else(|| {
+                format!("invalid derivation spec '{pair}': expected child=field>parent")
+            })?;
+            if child.is_empty() || field.is_empty() || parent.is_empty() {
+                return Err(format!("invalid derivation spec '{pair}': empty component"));
+            }
+            self.derivations
+                .insert(child.to_string(), (field.to_string(), parent.to_string()));
+        }
+        Ok(self)
+    }
+
+    /// The `(fk_field, parent_entity)` a child entity derives its access from.
+    #[must_use]
+    pub fn derivation(&self, entity: &str) -> Option<(&str, &str)> {
+        self.derivations
+            .get(entity)
+            .map(|(field, parent)| (field.as_str(), parent.as_str()))
     }
 
     #[must_use]
@@ -147,9 +186,16 @@ impl OwnershipConfig {
         if self.is_admin(uid) {
             return OwnershipDecision::Allowed;
         }
-        match self.owner_field(entity) {
-            Some(field) => OwnershipDecision::Check {
+        if let Some(field) = self.owner_field(entity) {
+            return OwnershipDecision::Check {
                 owner_field: field,
+                sender: uid,
+            };
+        }
+        match self.derivation(entity) {
+            Some((fk_field, parent_entity)) => OwnershipDecision::Derive {
+                parent_entity,
+                fk_field,
                 sender: uid,
             },
             None => OwnershipDecision::Allowed,
@@ -161,6 +207,11 @@ pub enum OwnershipDecision<'a, 'b> {
     Allowed,
     Check {
         owner_field: &'a str,
+        sender: &'b str,
+    },
+    Derive {
+        parent_entity: &'a str,
+        fk_field: &'a str,
         sender: &'b str,
     },
 }

--- a/crates/mqdb-wasm/Cargo.lock
+++ b/crates/mqdb-wasm/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/specs/DiagramSharing.tla
+++ b/specs/DiagramSharing.tla
@@ -1,7 +1,9 @@
 -------------------------------- MODULE DiagramSharing --------------------------------
 \* Authorization core of the diagram-sharing design (docs/design/diagram-sharing.md).
 \* Verifies the PROPOSED design: named view/edit grants + public grants + pending
-\* grants + child-entity derivation + recipient-scoped event routing.
+\* grants + child-entity derivation + recipient-scoped event routing. The parent
+\* mapping is a VARIABLE here and may be reparented arbitrarily, to test whether
+\* derived child access can leak when a child moves between diagrams.
 \*
 \* Threat model: authenticated users are mutually untrusting tenants.
 \* Assumption NOT modeled (taken as given): mqtt-lib's %u ACL correctly isolates
@@ -17,7 +19,7 @@ Users    == {u1, u2}            \* regular principals: can own and be grantees
 Admins   == {adm}               \* bypass everything
 Diagrams == {d1, d2}            \* ownership-enabled resources
 Children == {c1}                \* derive permission from a parent diagram
-Parent   == (c1 :> d1)          \* c1 belongs to diagram d1
+\* parent is a VARIABLE (see below); initial mapping c1 |-> d1 set in Init
 
 Resources    == Diagrams \cup Children
 Readers      == Users \cup Admins \cup {ANON}
@@ -26,12 +28,12 @@ Levels       == {"view", "edit"}
 LevelOrNone  == {"none", "view", "edit"}
 GrantKeys    == Diagrams \X GranteeSpace
 
-VARIABLES owner, grants
-vars == <<owner, grants>>
+VARIABLES owner, grants, parent
+vars == <<owner, grants, parent>>
 
 GrantOf(d, g) == IF <<d, g>> \in DOMAIN grants THEN grants[<<d, g>>] ELSE "none"
 IsAdmin(u)    == u \in Admins
-DiagramOf(x)  == IF x \in Diagrams THEN x ELSE Parent[x]
+DiagramOf(x)  == IF x \in Diagrams THEN x ELSE parent[x]
 
 \* ---- permission predicates on a diagram ----
 SeeDiagram(u, d) ==
@@ -72,24 +74,34 @@ Delivers(u, x) == (u \in Recipients(x)) \/ (PUBLIC \in Recipients(x))
 Init ==
     /\ owner \in [Diagrams -> Users]
     /\ grants = [k \in GrantKeys |-> "none"]
+    /\ parent = (c1 :> d1)
 
 SetGrant(d, g, l) ==
     /\ grants' = [grants EXCEPT ![<<d, g>>] = l]
-    /\ UNCHANGED owner
+    /\ UNCHANGED <<owner, parent>>
 
 ClearGrant(d, g) ==
     /\ grants' = [grants EXCEPT ![<<d, g>>] = "none"]
-    /\ UNCHANGED owner
+    /\ UNCHANGED <<owner, parent>>
 
 \* ownership transfer changes only the owner field; grants are preserved
 Transfer(d, u) ==
     /\ owner' = [owner EXCEPT ![d] = u]
-    /\ UNCHANGED grants
+    /\ UNCHANGED <<grants, parent>>
+
+\* A child is reparented to a different diagram. Modeled UNRESTRICTED (any child,
+\* any target) to test whether derived child access can leak when the parent moves.
+\* The agent forbids this on update (the parent reference is immutable), so this is
+\* the permissive upper bound the implementation refines.
+Reparent(c, dNew) ==
+    /\ parent' = [parent EXCEPT ![c] = dNew]
+    /\ UNCHANGED <<owner, grants>>
 
 Next ==
     \/ \E d \in Diagrams, g \in GranteeSpace, l \in Levels : SetGrant(d, g, l)
     \/ \E d \in Diagrams, g \in GranteeSpace : ClearGrant(d, g)
     \/ \E d \in Diagrams, u \in Users : Transfer(d, u)
+    \/ \E c \in Children, dNew \in Diagrams : Reparent(c, dNew)
 
 Spec == Init /\ [][Next]_vars
 
@@ -98,6 +110,7 @@ Spec == Init /\ [][Next]_vars
 TypeOK ==
     /\ owner \in [Diagrams -> Users]
     /\ grants \in [GrantKeys -> LevelOrNone]
+    /\ parent \in [Children -> Diagrams]
 
 \* No over-delivery: anyone who receives an event for x can also read x.
 \* Ties the recipient-scoped routing to the CRUD read predicate.
@@ -119,18 +132,18 @@ InvDeleteOwnerOnly ==
 
 \* A child can never be seen/edited by someone who can't see/edit its parent.
 InvChildNeedsParentSee ==
-    \A u \in Readers, x \in Children : CanSee(u, x) => CanSee(u, Parent[x])
+    \A u \in Readers, x \in Children : CanSee(u, x) => CanSee(u, parent[x])
 InvChildNeedsParentEdit ==
-    \A u \in Readers, x \in Children : CanEdit(u, x) => CanEdit(u, Parent[x])
+    \A u \in Readers, x \in Children : CanEdit(u, x) => CanEdit(u, parent[x])
 
 \* A view-only grantee (no other relationship, no public-edit) cannot edit a child.
 \* This is the "view is a lie" property the design must defeat.
 InvViewGranteeCannotEditChild ==
     \A u \in Users, x \in Children :
-        ( u # owner[Parent[x]]
+        ( u # owner[parent[x]]
           /\ ~IsAdmin(u)
-          /\ GrantOf(Parent[x], u) = "view"
-          /\ GrantOf(Parent[x], PUBLIC) # "edit" )
+          /\ GrantOf(parent[x], u) = "view"
+          /\ GrantOf(parent[x], PUBLIC) # "edit" )
         => ~CanEdit(u, x)
 
 \* Anonymous callers reach only public resources, and never edit except public-edit.


### PR DESCRIPTION
Closes #77.

## Summary
- Opt-in `--ownership-derive` (env `MQDB_OWNERSHIP_DERIVE`) maps a child entity to its parent (`child=fk_field>parent_entity`, e.g. `nodes=diagramId>diagrams`). A derived child inherits access from the parent record: read needs `view`, create/update/delete need `edit`.
- Parent reference is immutable on update, so an editor can't reparent a child into a diagram they can't edit. Unconfigured child entities stay unrestricted (opt-in).
- New `mqdb-core` API: `OwnershipConfig::with_derivations`/`derivation` and `OwnershipDecision::Derive`. Agent mode only; cluster parity tracked in #75.
- TLA+: `DiagramSharing.tla` extended with a mutable parent + unrestricted reparent; all 13 invariants hold over 52,488 states (derived access can't leak when a child moves).

## Test plan
- [ ] child matrix: view-grantee reads but can't write; edit-grantee read/create/update/delete; stranger 403
- [ ] reparent blocked: editor can't move a child to a diagram they can't edit
- [ ] unconfigured child entity stays unrestricted
- [ ] `cargo make dev` green