### PR TITLE
drop npm publication from release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,94 +45,6 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
-  publish-npm:
-    name: Publish to npm
-    runs-on: ubuntu-latest
-    needs: publish
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Get WASM crate version
-        id: wasm-version
-        run: |
-          VERSION=$(grep '^version' crates/mqdb-wasm/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Check if npm publish needed
-        id: npm-check
-        run: |
-          NPM_VERSION=$(npm view mqdb-wasm version 2>/dev/null || echo "0.0.0")
-          if [ "$NPM_VERSION" = "${{ steps.wasm-version.outputs.version }}" ]; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install Rust
-        if: steps.npm-check.outputs.skip != 'true'
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Cache dependencies
-        if: steps.npm-check.outputs.skip != 'true'
-        uses: Swatinem/rust-cache@v2
-
-      - name: Setup Node.js
-        if: steps.npm-check.outputs.skip != 'true'
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-
-      - name: Build WASM
-        if: steps.npm-check.outputs.skip != 'true'
-        run: cargo build --target wasm32-unknown-unknown --release --manifest-path crates/mqdb-wasm/Cargo.toml
-
-      - name: Install matching wasm-bindgen-cli
-        if: steps.npm-check.outputs.skip != 'true'
-        run: |
-          WB_VERSION=$(cargo metadata --manifest-path crates/mqdb-wasm/Cargo.toml --format-version 1 | python3 -c "import sys,json; pkgs=json.load(sys.stdin)['packages']; print([p['version'] for p in pkgs if p['name']=='wasm-bindgen'][0])")
-          cargo install wasm-bindgen-cli --version "$WB_VERSION"
-
-      - name: Generate bindings
-        if: steps.npm-check.outputs.skip != 'true'
-        run: wasm-bindgen --target web --out-dir pkg crates/mqdb-wasm/target/wasm32-unknown-unknown/release/mqdb_wasm.wasm
-
-      - name: Create package.json
-        if: steps.npm-check.outputs.skip != 'true'
-        run: |
-          cat > pkg/package.json << 'PKGJSON'
-          {
-            "name": "mqdb-wasm",
-            "version": "${{ steps.wasm-version.outputs.version }}",
-            "description": "WASM client library for MQDB reactive database",
-            "license": "Apache-2.0",
-            "repository": {
-              "type": "git",
-              "url": "https://github.com/LabOverWire/MQDB"
-            },
-            "files": [
-              "mqdb_wasm_bg.wasm",
-              "mqdb_wasm.js",
-              "mqdb_wasm.d.ts"
-            ],
-            "main": "mqdb_wasm.js",
-            "types": "mqdb_wasm.d.ts"
-          }
-          PKGJSON
-
-      - name: Copy LICENSE
-        if: steps.npm-check.outputs.skip != 'true'
-        run: cp LICENSE-APACHE pkg/LICENSE
-
-      - name: Publish to npm
-        if: steps.npm-check.outputs.skip != 'true'
-        working-directory: pkg
-        run: npm pkg fix && npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   build-binaries:
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
@@ -186,7 +98,7 @@ jobs:
   create-release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: [publish, publish-npm, build-binaries]
+    needs: [publish, build-binaries]
     steps:
       - uses: actions/checkout@v4
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -258,3 +258,34 @@ wasm-pack test --node
 [tasks.ci-wasm]
 description = "WASM CI: build + test"
 dependencies = ["wasm-build", "wasm-test"]
+
+[tasks.wasm-publish]
+description = "Publish mqdb-wasm to npm (requires npm auth)"
+dependencies = ["wasm-build"]
+script = '''
+set -e
+VERSION=$(grep '^version' crates/mqdb-wasm/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+cat > crates/mqdb-wasm/pkg/package.json <<PKGJSON
+{
+  "name": "mqdb-wasm",
+  "version": "$VERSION",
+  "description": "WASM client library for MQDB reactive database",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LabOverWire/MQDB"
+  },
+  "files": [
+    "mqdb_wasm_bg.wasm",
+    "mqdb_wasm.js",
+    "mqdb_wasm.d.ts"
+  ],
+  "main": "mqdb_wasm.js",
+  "types": "mqdb_wasm.d.ts"
+}
+PKGJSON
+cp LICENSE-APACHE crates/mqdb-wasm/pkg/LICENSE
+cd crates/mqdb-wasm/pkg
+npm pkg fix
+npm publish
+'''

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -34,6 +34,7 @@ echo "WASM:"
 echo "  cargo make wasm-build    Build WASM package (pkg/)"
 echo "  cargo make wasm-test     Run WASM tests (Node.js)"
 echo "  cargo make ci-wasm       WASM CI (build + test)"
+echo "  cargo make wasm-publish  Publish mqdb-wasm to npm (requires auth)"
 echo ""
 echo "Benchmarking:"
 echo "  cargo make bench-pubsub  Run pub/sub benchmark"
@@ -265,6 +266,10 @@ dependencies = ["wasm-build"]
 script = '''
 set -e
 VERSION=$(grep '^version' crates/mqdb-wasm/Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+if npm view "mqdb-wasm@$VERSION" version > /dev/null 2>&1; then
+    echo "mqdb-wasm@$VERSION already published to npm; skipping"
+    exit 0
+fi
 cat > crates/mqdb-wasm/pkg/package.json <<PKGJSON
 {
   "name": "mqdb-wasm",


### PR DESCRIPTION
## Summary
- Remove the `publish-npm` job from `.github/workflows/release.yml` (it 404'd in the `v0.8.9` run because the `mqdb-wasm` package either doesn't exist on npm or the token lacks create-package permission). The `create-release` job's `needs` is updated accordingly.
- Add a `cargo make wasm-publish` task in `Makefile.toml` mirroring the steps the workflow used (wasm-build → write `pkg/package.json` → copy LICENSE → `npm pkg fix && npm publish`) so the publish can be run locally on demand.

## Test plan
- [x] `cargo make --list-all-steps` lists `wasm-publish`
- [x] `release.yml` jobs: `publish`, `build-binaries`, `create-release` (with `needs: [publish, build-binaries]`)