### PR TITLE
align mqdb-agent version with v0.8.10 tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1349,7 +1349,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.8.9"
+version = "0.8.10"
 dependencies = [
  "arc-swap",
  "argon2",

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.8.9"
+version = "0.8.10"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true


### PR DESCRIPTION
## Summary
- Bumps `mqdb-agent` 0.8.9 → 0.8.10 so the crate version matches the latest release tag.

## Test plan
- [x] `cargo make dev` (format + clippy + tests)