### PR TITLE
filter cluster cascade delete by ownership on remote nodes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,11 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
+      - name: Publish mqdb-wasm
+        run: cargo publish --manifest-path crates/mqdb-wasm/Cargo.toml --no-verify || echo "already published"
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
   build-binaries:
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "base64",
  "bebytes",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cluster"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.11"
+version = "0.8.12"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/Cargo.toml
+++ b/crates/mqdb-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cluster"
-version = "0.3.6"
+version = "0.3.7"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
@@ -945,7 +945,8 @@ impl DbRequestHandler {
             }));
         }
 
-        let all_results = match controller.collect_local_cascade(entity, id, local_results) {
+        let all_results = match controller.collect_local_cascade(entity, id, local_results, sender)
+        {
             Ok(results) => results,
             Err(msg) => return JsonOpResult::Response(Self::json_error(409, &msg)),
         };

--- a/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
@@ -951,7 +951,7 @@ impl DbRequestHandler {
             Err(msg) => return JsonOpResult::Response(Self::json_error(409, &msg)),
         };
         let effects = controller.prepare_fk_side_effects(&all_results);
-        let (cascade, ack_receivers) = controller.execute_fk_side_effects(&effects).await;
+        let (cascade, ack_receivers) = controller.execute_fk_side_effects(&effects, sender).await;
         let ctx = JsonOpContext {
             entity,
             id: Some(id),
@@ -1485,7 +1485,9 @@ impl DbRequestHandler {
                 correlation_data,
             } => {
                 let effects = controller.prepare_fk_side_effects(&side_effects);
-                let (cascade, ack_receivers) = controller.execute_fk_side_effects(&effects).await;
+                let (cascade, ack_receivers) = controller
+                    .execute_fk_side_effects(&effects, sender.as_deref())
+                    .await;
                 let ctx = JsonOpContext {
                     entity: &entity,
                     id: Some(&id),

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -833,7 +833,9 @@ impl<T: ClusterTransport> NodeController<T> {
             Err(msg) => return (Self::json_error(409, &msg), None),
         };
         let effects = self.prepare_fk_side_effects(&all_results);
-        let (cascade, ack_receivers) = self.execute_fk_side_effects(&effects).await;
+        let (cascade, ack_receivers) = self
+            .execute_fk_side_effects(&effects, request.sender.as_deref())
+            .await;
         (
             self.execute_json_delete(entity, id, cascade.as_ref(), ack_receivers)
                 .await,
@@ -968,6 +970,7 @@ impl<T: ClusterTransport> NodeController<T> {
     pub(crate) async fn execute_fk_side_effects(
         &mut self,
         effects: &[CascadeSideEffect],
+        sender: Option<&str>,
     ) -> (Option<CascadeOutboxPayload>, Vec<oneshot::Receiver<bool>>) {
         let now_ms = Self::current_time_ms();
         let mut remote_ops = Vec::new();
@@ -1005,6 +1008,7 @@ impl<T: ClusterTransport> NodeController<T> {
                     remote_ops.push(CascadeRemoteOp::Delete {
                         entity: entity.clone(),
                         id: id.clone(),
+                        sender: sender.map(String::from),
                     });
                 }
                 CascadeSideEffect::RemoteSetNull {
@@ -1051,7 +1055,7 @@ impl<T: ClusterTransport> NodeController<T> {
                                 .await;
                         }
                     } else if let Some(rx) = self
-                        .send_cascade_request(*partition, JsonDbOp::Delete, entity, id, &[])
+                        .send_cascade_request(*partition, JsonDbOp::Delete, entity, id, &[], sender)
                         .await
                     {
                         ack_receivers.push(rx);
@@ -1100,6 +1104,7 @@ impl<T: ClusterTransport> NodeController<T> {
         entity: &str,
         id: &str,
         payload: &[u8],
+        sender: Option<&str>,
     ) -> Option<oneshot::Receiver<bool>> {
         let Some(primary) = self.partition_map.primary(partition) else {
             tracing::debug!(
@@ -1132,7 +1137,7 @@ impl<T: ClusterTransport> NodeController<T> {
             payload: payload.to_vec(),
             response_topic,
             correlation_data: None,
-            sender: None,
+            sender: sender.map(String::from),
         };
         let _ = self
             .transport
@@ -1942,16 +1947,18 @@ impl<T: ClusterTransport> NodeController<T> {
             from,
             entity,
             id,
+            sender,
             response_topic,
             correlation_data,
-            ..
         } = continuation
         else {
             return;
         };
 
         let effects = self.prepare_fk_side_effects(&side_effects);
-        let (cascade, ack_receivers) = self.execute_fk_side_effects(&effects).await;
+        let (cascade, ack_receivers) = self
+            .execute_fk_side_effects(&effects, sender.as_deref())
+            .await;
         let response_payload = self
             .execute_json_delete(&entity, &id, cascade.as_ref(), ack_receivers)
             .await;

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -823,7 +823,12 @@ impl<T: ClusterTransport> NodeController<T> {
             );
         }
 
-        let all_results = match self.collect_local_cascade(entity, id, local_results) {
+        let all_results = match self.collect_local_cascade(
+            entity,
+            id,
+            local_results,
+            request.sender.as_deref(),
+        ) {
             Ok(results) => results,
             Err(msg) => return (Self::json_error(409, &msg), None),
         };

--- a/crates/mqdb-cluster/src/cluster/node_controller/fk.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/fk.rs
@@ -81,14 +81,22 @@ pub async fn await_fk_reverse_lookups(
             tokio::time::Instant::now() + std::time::Duration::from_secs(FK_CHECK_TIMEOUT_SECS);
 
         match tokio::time::timeout_at(deadline, lookup.receiver).await {
-            Ok(Ok(ids)) if !ids.is_empty() => {
+            Ok(Ok(reply)) if !(reply.owned.is_empty() && reply.cross_owned.is_empty()) => {
+                let (referencing_ids, cross_owned_ids) =
+                    if lookup.on_delete == OnDeleteAction::Cascade {
+                        (reply.owned, reply.cross_owned)
+                    } else {
+                        let mut merged = reply.owned;
+                        merged.extend(reply.cross_owned);
+                        (merged, Vec::new())
+                    };
                 results.push(FkReverseLookupResult {
                     constraint_name: lookup.constraint_name,
                     source_entity: lookup.source_entity,
                     source_field: lookup.source_field,
                     on_delete: lookup.on_delete,
-                    referencing_ids: ids,
-                    cross_owned_ids: Vec::new(),
+                    referencing_ids,
+                    cross_owned_ids,
                     target_id: lookup.target_id,
                 });
             }
@@ -342,6 +350,7 @@ impl<T: ClusterTransport> NodeController<T> {
         }
 
         let is_blind = sender.is_none() || sender.is_some_and(|s| self.ownership.is_admin(s));
+        let wire_sender = if is_blind { "" } else { sender.unwrap_or("") };
 
         let mut local_results = Vec::new();
         let mut pending_remote: Vec<PendingFkReverseLookup> = Vec::new();
@@ -405,8 +414,12 @@ impl<T: ClusterTransport> NodeController<T> {
                 target_id: id,
                 target_entity: entity,
             };
-            self.scatter_reverse_lookup_to_remote_nodes(&mut pending_remote, &fk_params)
-                .await;
+            self.scatter_reverse_lookup_to_remote_nodes(
+                &mut pending_remote,
+                &fk_params,
+                wire_sender,
+            )
+            .await;
         }
 
         Ok((local_results, pending_remote))
@@ -449,6 +462,7 @@ impl<T: ClusterTransport> NodeController<T> {
         &mut self,
         pending_remote: &mut Vec<PendingFkReverseLookup>,
         params: &FkLookupParams<'_>,
+        sender: &str,
     ) {
         let constraint_name = params.constraint_name;
         let source_entity = params.source_entity;
@@ -474,6 +488,7 @@ impl<T: ClusterTransport> NodeController<T> {
                 source_field,
                 target_id,
                 target_entity,
+                sender,
             );
             let _ = self
                 .transport
@@ -521,7 +536,15 @@ impl<T: ClusterTransport> NodeController<T> {
             })
             .collect();
 
-        let response = FkReverseLookupResponse::create(req.request_id, &referencing_ids);
+        let sender = req.sender_str();
+        let is_blind = sender.is_empty() || self.ownership.is_admin(sender);
+        let (owned, cross_owned) = if is_blind {
+            (referencing_ids, Vec::new())
+        } else {
+            self.partition_refs_by_ownership(req.source_entity_str(), referencing_ids, sender)
+        };
+
+        let response = FkReverseLookupResponse::create(req.request_id, &owned, &cross_owned);
         let _ = self
             .transport
             .send(from, ClusterMessage::FkReverseLookupResponse(response))

--- a/crates/mqdb-cluster/src/cluster/node_controller/fk.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/fk.rs
@@ -155,7 +155,7 @@ async fn resolve_single_level(
     (None, combined)
 }
 
-fn filter_and_extract_cascade(
+pub(crate) fn filter_and_extract_cascade(
     results: Vec<FkReverseLookupResult>,
     visited: &mut std::collections::HashSet<(String, String)>,
 ) -> (Vec<FkReverseLookupResult>, Vec<(String, String)>) {
@@ -171,7 +171,7 @@ fn filter_and_extract_cascade(
                     false
                 }
             });
-            if r.referencing_ids.is_empty() {
+            if r.referencing_ids.is_empty() && r.cross_owned_ids.is_empty() {
                 continue;
             }
         }
@@ -198,7 +198,10 @@ pub async fn collect_recursive_cascade<T: ClusterTransport>(
     let mut visited = std::collections::HashSet::new();
     visited.insert((deleted_entity.to_string(), deleted_id.to_string()));
     let (filtered, mut queue) = filter_and_extract_cascade(level_results, &mut visited);
-    let mut total_work: usize = filtered.iter().map(|r| r.referencing_ids.len()).sum();
+    let mut total_work: usize = filtered
+        .iter()
+        .map(|r| r.referencing_ids.len() + r.cross_owned_ids.len())
+        .sum();
     if total_work > MAX_CASCADE_WORK_ITEMS {
         return (
             Some(format!(
@@ -250,7 +253,7 @@ pub async fn collect_recursive_cascade<T: ClusterTransport>(
         let (filtered, next_queue) = filter_and_extract_cascade(level_results, &mut visited);
         total_work += filtered
             .iter()
-            .map(|r| r.referencing_ids.len())
+            .map(|r| r.referencing_ids.len() + r.cross_owned_ids.len())
             .sum::<usize>();
         if total_work > MAX_CASCADE_WORK_ITEMS {
             return (

--- a/crates/mqdb-cluster/src/cluster/node_controller/fk.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/fk.rs
@@ -560,11 +560,13 @@ impl<T: ClusterTransport> NodeController<T> {
         deleted_entity: &str,
         deleted_id: &str,
         initial: Vec<FkReverseLookupResult>,
+        sender: Option<&str>,
     ) -> Result<Vec<FkReverseLookupResult>, String> {
         let mut all_results = Vec::new();
         let mut visited = std::collections::HashSet::new();
         visited.insert((deleted_entity.to_string(), deleted_id.to_string()));
         let mut queue: Vec<(String, String)> = Vec::new();
+        let is_blind = sender.is_none() || sender.is_some_and(|s| self.ownership.is_admin(s));
 
         for r in &initial {
             if r.on_delete == OnDeleteAction::Cascade {
@@ -620,8 +622,19 @@ impl<T: ClusterTransport> NodeController<T> {
                         continue;
                     }
 
-                    let filtered_refs: Vec<String> = if on_delete == OnDeleteAction::Cascade {
-                        local_refs
+                    let (owned_refs, cross_owned) =
+                        if is_blind || on_delete != OnDeleteAction::Cascade {
+                            (local_refs, Vec::new())
+                        } else {
+                            self.partition_refs_by_ownership(
+                                source_entity,
+                                local_refs,
+                                sender.unwrap_or(""),
+                            )
+                        };
+
+                    let referencing_ids: Vec<String> = if on_delete == OnDeleteAction::Cascade {
+                        owned_refs
                             .into_iter()
                             .filter(|child_id| {
                                 if visited.insert((source_entity.to_string(), child_id.clone())) {
@@ -633,10 +646,10 @@ impl<T: ClusterTransport> NodeController<T> {
                             })
                             .collect()
                     } else {
-                        local_refs
+                        owned_refs
                     };
 
-                    if filtered_refs.is_empty() {
+                    if referencing_ids.is_empty() && cross_owned.is_empty() {
                         continue;
                     }
 
@@ -645,8 +658,8 @@ impl<T: ClusterTransport> NodeController<T> {
                         source_entity: source_entity.to_string(),
                         source_field: source_field.to_string(),
                         on_delete,
-                        referencing_ids: filtered_refs,
-                        cross_owned_ids: Vec::new(),
+                        referencing_ids,
+                        cross_owned_ids: cross_owned,
                         target_id: id.clone(),
                     });
                 }

--- a/crates/mqdb-cluster/src/cluster/node_controller/fk.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/fk.rs
@@ -352,8 +352,9 @@ impl<T: ClusterTransport> NodeController<T> {
             return Ok((Vec::new(), Vec::new()));
         }
 
-        let is_blind = sender.is_none() || sender.is_some_and(|s| self.ownership.is_admin(s));
-        let wire_sender = if is_blind { "" } else { sender.unwrap_or("") };
+        let sender_str = sender.unwrap_or("");
+        let is_blind = self.is_blind_sender(sender_str);
+        let wire_sender = if is_blind { "" } else { sender_str };
 
         let mut local_results = Vec::new();
         let mut pending_remote: Vec<PendingFkReverseLookup> = Vec::new();
@@ -385,16 +386,8 @@ impl<T: ClusterTransport> NodeController<T> {
             }
 
             if !local_refs.is_empty() {
-                let (owned_refs, cross_owned) = if is_blind || on_delete != OnDeleteAction::Cascade
-                {
-                    (local_refs, Vec::new())
-                } else {
-                    self.partition_refs_by_ownership(
-                        source_entity,
-                        local_refs,
-                        sender.unwrap_or(""),
-                    )
-                };
+                let (owned_refs, cross_owned) =
+                    self.classify_refs(source_entity, local_refs, on_delete, is_blind, sender_str);
 
                 if !owned_refs.is_empty() || !cross_owned.is_empty() {
                     local_results.push(FkReverseLookupResult {
@@ -428,6 +421,25 @@ impl<T: ClusterTransport> NodeController<T> {
         Ok((local_results, pending_remote))
     }
 
+    fn is_blind_sender(&self, sender: &str) -> bool {
+        sender.is_empty() || self.ownership.is_admin(sender)
+    }
+
+    fn classify_refs(
+        &self,
+        source_entity: &str,
+        refs: Vec<String>,
+        on_delete: OnDeleteAction,
+        is_blind: bool,
+        sender: &str,
+    ) -> (Vec<String>, Vec<String>) {
+        if is_blind || on_delete != OnDeleteAction::Cascade {
+            (refs, Vec::new())
+        } else {
+            self.partition_refs_by_ownership(source_entity, refs, sender)
+        }
+    }
+
     fn partition_refs_by_ownership(
         &self,
         source_entity: &str,
@@ -450,7 +462,7 @@ impl<T: ClusterTransport> NodeController<T> {
                         .and_then(|v| v.as_str())
                         .map(String::from)
                 })
-                .is_none_or(|owner| owner == sender);
+                .is_some_and(|owner| owner == sender);
 
             if is_owned {
                 owned.push(ref_id);
@@ -540,7 +552,7 @@ impl<T: ClusterTransport> NodeController<T> {
             .collect();
 
         let sender = req.sender_str();
-        let is_blind = sender.is_empty() || self.ownership.is_admin(sender);
+        let is_blind = self.is_blind_sender(sender);
         let (owned, cross_owned) = if is_blind {
             (referencing_ids, Vec::new())
         } else {
@@ -566,7 +578,8 @@ impl<T: ClusterTransport> NodeController<T> {
         let mut visited = std::collections::HashSet::new();
         visited.insert((deleted_entity.to_string(), deleted_id.to_string()));
         let mut queue: Vec<(String, String)> = Vec::new();
-        let is_blind = sender.is_none() || sender.is_some_and(|s| self.ownership.is_admin(s));
+        let sender_str = sender.unwrap_or("");
+        let is_blind = self.is_blind_sender(sender_str);
 
         for r in &initial {
             if r.on_delete == OnDeleteAction::Cascade {
@@ -622,16 +635,13 @@ impl<T: ClusterTransport> NodeController<T> {
                         continue;
                     }
 
-                    let (owned_refs, cross_owned) =
-                        if is_blind || on_delete != OnDeleteAction::Cascade {
-                            (local_refs, Vec::new())
-                        } else {
-                            self.partition_refs_by_ownership(
-                                source_entity,
-                                local_refs,
-                                sender.unwrap_or(""),
-                            )
-                        };
+                    let (owned_refs, cross_owned) = self.classify_refs(
+                        source_entity,
+                        local_refs,
+                        on_delete,
+                        is_blind,
+                        sender_str,
+                    );
 
                     let referencing_ids: Vec<String> = if on_delete == OnDeleteAction::Cascade {
                         owned_refs

--- a/crates/mqdb-cluster/src/cluster/node_controller/fk.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/fk.rs
@@ -367,15 +367,7 @@ impl<T: ClusterTransport> NodeController<T> {
             let all_refs = self
                 .stores
                 .fk_reverse_lookup(entity, id, source_entity, source_field);
-            let local_refs: Vec<String> = all_refs
-                .into_iter()
-                .filter(|ref_id| {
-                    self.is_primary_for_partition(super::super::db::data_partition(
-                        source_entity,
-                        ref_id,
-                    ))
-                })
-                .collect();
+            let local_refs = self.local_primary_refs(source_entity, all_refs);
 
             if !local_refs.is_empty() && on_delete == OnDeleteAction::Restrict {
                 return Err(format!(
@@ -387,7 +379,7 @@ impl<T: ClusterTransport> NodeController<T> {
 
             if !local_refs.is_empty() {
                 let (owned_refs, cross_owned) =
-                    self.classify_refs(source_entity, local_refs, on_delete, is_blind, sender_str);
+                    self.classify_refs(source_entity, local_refs, on_delete, sender_str);
 
                 if !owned_refs.is_empty() || !cross_owned.is_empty() {
                     local_results.push(FkReverseLookupResult {
@@ -425,18 +417,42 @@ impl<T: ClusterTransport> NodeController<T> {
         sender.is_empty() || self.ownership.is_admin(sender)
     }
 
+    fn local_primary_refs(&self, source_entity: &str, all_refs: Vec<String>) -> Vec<String> {
+        all_refs
+            .into_iter()
+            .filter(|ref_id| {
+                self.is_primary_for_partition(super::super::db::data_partition(
+                    source_entity,
+                    ref_id,
+                ))
+            })
+            .collect()
+    }
+
+    fn classify_refs_by_ownership(
+        &self,
+        source_entity: &str,
+        refs: Vec<String>,
+        sender: &str,
+    ) -> (Vec<String>, Vec<String>) {
+        if self.is_blind_sender(sender) {
+            (refs, Vec::new())
+        } else {
+            self.partition_refs_by_ownership(source_entity, refs, sender)
+        }
+    }
+
     fn classify_refs(
         &self,
         source_entity: &str,
         refs: Vec<String>,
         on_delete: OnDeleteAction,
-        is_blind: bool,
         sender: &str,
     ) -> (Vec<String>, Vec<String>) {
-        if is_blind || on_delete != OnDeleteAction::Cascade {
-            (refs, Vec::new())
+        if on_delete == OnDeleteAction::Cascade {
+            self.classify_refs_by_ownership(source_entity, refs, sender)
         } else {
-            self.partition_refs_by_ownership(source_entity, refs, sender)
+            (refs, Vec::new())
         }
     }
 
@@ -541,23 +557,13 @@ impl<T: ClusterTransport> NodeController<T> {
             req.source_entity_str(),
             req.source_field_str(),
         );
-        let referencing_ids: Vec<String> = all_refs
-            .into_iter()
-            .filter(|ref_id| {
-                self.is_primary_for_partition(super::super::db::data_partition(
-                    req.source_entity_str(),
-                    ref_id,
-                ))
-            })
-            .collect();
+        let referencing_ids = self.local_primary_refs(req.source_entity_str(), all_refs);
 
-        let sender = req.sender_str();
-        let is_blind = self.is_blind_sender(sender);
-        let (owned, cross_owned) = if is_blind {
-            (referencing_ids, Vec::new())
-        } else {
-            self.partition_refs_by_ownership(req.source_entity_str(), referencing_ids, sender)
-        };
+        let (owned, cross_owned) = self.classify_refs_by_ownership(
+            req.source_entity_str(),
+            referencing_ids,
+            req.sender_str(),
+        );
 
         let response = FkReverseLookupResponse::create(req.request_id, &owned, &cross_owned);
         let _ = self
@@ -579,7 +585,6 @@ impl<T: ClusterTransport> NodeController<T> {
         visited.insert((deleted_entity.to_string(), deleted_id.to_string()));
         let mut queue: Vec<(String, String)> = Vec::new();
         let sender_str = sender.unwrap_or("");
-        let is_blind = self.is_blind_sender(sender_str);
 
         for r in &initial {
             if r.on_delete == OnDeleteAction::Cascade {
@@ -613,15 +618,7 @@ impl<T: ClusterTransport> NodeController<T> {
                     let all_refs =
                         self.stores
                             .fk_reverse_lookup(&entity, &id, source_entity, source_field);
-                    let local_refs: Vec<String> = all_refs
-                        .into_iter()
-                        .filter(|ref_id| {
-                            self.is_primary_for_partition(super::super::db::data_partition(
-                                source_entity,
-                                ref_id,
-                            ))
-                        })
-                        .collect();
+                    let local_refs = self.local_primary_refs(source_entity, all_refs);
 
                     if !local_refs.is_empty() && on_delete == OnDeleteAction::Restrict {
                         return Err(format!(
@@ -635,13 +632,8 @@ impl<T: ClusterTransport> NodeController<T> {
                         continue;
                     }
 
-                    let (owned_refs, cross_owned) = self.classify_refs(
-                        source_entity,
-                        local_refs,
-                        on_delete,
-                        is_blind,
-                        sender_str,
-                    );
+                    let (owned_refs, cross_owned) =
+                        self.classify_refs(source_entity, local_refs, on_delete, sender_str);
 
                     let referencing_ids: Vec<String> = if on_delete == OnDeleteAction::Cascade {
                         owned_refs

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -120,13 +120,18 @@ pub struct PendingFkCheck {
     pub receiver: oneshot::Receiver<bool>,
 }
 
+pub struct FkReverseLookupReply {
+    pub owned: Vec<String>,
+    pub cross_owned: Vec<String>,
+}
+
 pub struct PendingFkReverseLookup {
     pub constraint_name: String,
     pub source_entity: String,
     pub source_field: String,
     pub on_delete: super::db::OnDeleteAction,
     pub target_id: String,
-    pub receiver: oneshot::Receiver<Vec<String>>,
+    pub receiver: oneshot::Receiver<FkReverseLookupReply>,
 }
 
 pub struct PendingFkWork {

--- a/crates/mqdb-cluster/src/cluster/node_controller/pending.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/pending.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use super::FkReverseLookupReply;
 use crate::cluster::protocol::{
     FkCheckResponse, FkReverseLookupResponse, UniqueReserveResponse, UniqueReserveStatus,
 };
@@ -13,7 +14,7 @@ use tokio::sync::oneshot;
 pub struct PendingConstraintState {
     unique_requests: Mutex<HashMap<u64, oneshot::Sender<UniqueReserveStatus>>>,
     fk_checks: Mutex<HashMap<u64, oneshot::Sender<bool>>>,
-    fk_lookups: Mutex<HashMap<u64, oneshot::Sender<Vec<String>>>>,
+    fk_lookups: Mutex<HashMap<u64, oneshot::Sender<FkReverseLookupReply>>>,
     cascade_acks: Mutex<HashMap<u64, oneshot::Sender<bool>>>,
     next_unique_id: AtomicU64,
     next_fk_id: AtomicU64,
@@ -66,13 +67,16 @@ impl PendingConstraintState {
         }
     }
 
-    pub fn insert_fk_lookup(&self, id: u64, tx: oneshot::Sender<Vec<String>>) {
+    pub fn insert_fk_lookup(&self, id: u64, tx: oneshot::Sender<FkReverseLookupReply>) {
         self.fk_lookups.lock().unwrap().insert(id, tx);
     }
 
     pub fn resolve_fk_lookup(&self, resp: &FkReverseLookupResponse) {
         if let Some(tx) = self.fk_lookups.lock().unwrap().remove(&resp.request_id) {
-            let _ = tx.send(resp.referencing_ids());
+            let _ = tx.send(FkReverseLookupReply {
+                owned: resp.referencing_ids(),
+                cross_owned: resp.cross_owned_ids(),
+            });
         }
     }
 

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -1415,6 +1415,135 @@ async fn local_cascade_set_nulls_cross_owned_grandchild() {
     );
 }
 
+async fn setup_post_with_owned_and_cross_owned_comments(
+    ctrl: &mut NodeController<MockTransport>,
+    node: NodeId,
+) {
+    use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
+
+    make_all_primary(ctrl, node);
+    ctrl.set_ownership(Arc::new(
+        mqdb_core::types::OwnershipConfig::parse("posts=owner,comments=owner").unwrap(),
+    ));
+
+    let fk_comments = ClusterConstraint::foreign_key(
+        "comments",
+        "comments_post_fk",
+        "post_id",
+        "posts",
+        "id",
+        OnDeleteAction::Cascade,
+    );
+    ctrl.constraint_add(&fk_comments).await.unwrap();
+
+    let post = serde_json::to_vec(&serde_json::json!({
+        "owner": "alice", "id": "post-alice"
+    }))
+    .unwrap();
+    ctrl.db_create("posts", "post-alice", &post, 1000)
+        .await
+        .unwrap();
+    let owned_comment = serde_json::to_vec(&serde_json::json!({
+        "post_id": "post-alice", "owner": "alice", "id": "comment-alice"
+    }))
+    .unwrap();
+    ctrl.db_create("comments", "comment-alice", &owned_comment, 1000)
+        .await
+        .unwrap();
+    let cross_comment = serde_json::to_vec(&serde_json::json!({
+        "post_id": "post-alice", "owner": "carol", "id": "comment-carol"
+    }))
+    .unwrap();
+    ctrl.db_create("comments", "comment-carol", &cross_comment, 1000)
+        .await
+        .unwrap();
+}
+
+fn delete_post_request(sender: Option<&str>) -> crate::cluster::protocol::JsonDbRequest {
+    use crate::cluster::protocol::{JsonDbOp, JsonDbRequest};
+    JsonDbRequest {
+        request_id: 1,
+        op: JsonDbOp::Delete,
+        entity: "posts".to_string(),
+        id: Some("post-alice".to_string()),
+        payload: Vec::new(),
+        response_topic: String::new(),
+        correlation_data: None,
+        sender: sender.map(String::from),
+    }
+}
+
+#[tokio::test]
+async fn owner_aware_delete_request_set_nulls_cross_owned_comment() {
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let transport = MockTransport::new(node1);
+    let mut ctrl = create_test_controller(node1, transport);
+    setup_post_with_owned_and_cross_owned_comments(&mut ctrl, node1).await;
+
+    let partition = crate::cluster::db::data_partition("posts", "post-alice");
+    let req = delete_post_request(Some("alice"));
+    ctrl.handle_json_db_request(node2, partition, &req).await;
+
+    assert!(
+        ctrl.db_get("comments", "comment-carol").is_some(),
+        "carol's cross-owned comment must survive an owner-aware delete"
+    );
+    assert!(
+        ctrl.db_get("comments", "comment-alice").is_none(),
+        "alice's own comment is cascade-deleted"
+    );
+}
+
+#[tokio::test]
+async fn cascade_delete_fan_out_propagates_sender_to_remote_primary() {
+    use crate::cluster::JsonDbOp;
+
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let transport = MockTransport::new(node1);
+    let mut ctrl = create_test_controller(node1, transport);
+
+    let partition = crate::cluster::db::data_partition("comments", "comment-carol");
+    let mut map = PartitionMap::new();
+    map.set(
+        partition,
+        crate::cluster::PartitionAssignment {
+            primary: Some(node2),
+            replicas: vec![],
+            epoch: Epoch::new(1),
+        },
+    );
+    ctrl.update_partition_map(map);
+
+    let _rx = ctrl
+        .send_cascade_request(
+            partition,
+            JsonDbOp::Delete,
+            "comments",
+            "comment-carol",
+            &[],
+            Some("alice"),
+        )
+        .await;
+
+    let req = ctrl
+        .transport
+        .sent_messages()
+        .into_iter()
+        .find_map(|(_, msg)| match msg {
+            ClusterMessage::JsonDbRequest { request, .. } => Some(request),
+            _ => None,
+        })
+        .expect("cascade delete request sent to remote primary");
+    assert_eq!(
+        req.sender.as_deref(),
+        Some("alice"),
+        "cascade delete fan-out must carry the deleter identity so the remote re-cascade stays \
+         owner-aware instead of blindly deleting cross-owned descendants"
+    );
+}
+
 #[tokio::test]
 async fn circular_fk_cascade_terminates() {
     use crate::cluster::db::{ClusterConstraint, OnDeleteAction};

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -1545,6 +1545,114 @@ async fn cascade_delete_fan_out_propagates_sender_to_remote_primary() {
 }
 
 #[tokio::test]
+async fn handle_fk_reverse_lookup_classifies_ownerless_ref_as_cross_owned() {
+    use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
+    use crate::cluster::protocol::FkReverseLookupRequest;
+
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let transport = MockTransport::new(node1);
+    let mut ctrl = create_test_controller(node1, transport);
+
+    make_all_primary(&mut ctrl, node1);
+    ctrl.set_ownership(Arc::new(
+        mqdb_core::types::OwnershipConfig::parse("posts=owner").unwrap(),
+    ));
+    let fk = ClusterConstraint::foreign_key(
+        "posts",
+        "posts_author_fk",
+        "author_id",
+        "users",
+        "id",
+        OnDeleteAction::Cascade,
+    );
+    ctrl.constraint_add(&fk).await.unwrap();
+    let user = serde_json::to_vec(&serde_json::json!({"name": "Alice"})).unwrap();
+    ctrl.db_create("users", "u1", &user, 1000).await.unwrap();
+    let orphan_post = serde_json::to_vec(&serde_json::json!({
+        "author_id": "u1", "id": "post-orphan"
+    }))
+    .unwrap();
+    ctrl.db_create("posts", "post-orphan", &orphan_post, 1000)
+        .await
+        .unwrap();
+
+    let req = FkReverseLookupRequest::create(1, "posts", "author_id", "u1", "users", "alice");
+    ctrl.handle_fk_reverse_lookup_request(node2, &req).await;
+
+    let resp = sent_fk_lookup_response(&ctrl, node2);
+    assert!(
+        resp.referencing_ids().is_empty(),
+        "an ownerless post must NOT be classified as owned/cascade-deletable by a non-owner"
+    );
+    assert_eq!(
+        resp.cross_owned_ids(),
+        vec!["post-orphan".to_string()],
+        "an ownerless post must be cross-owned (set-null'd), matching the direct-delete path \
+         which forbids a non-admin from deleting an ownerless record"
+    );
+}
+
+#[tokio::test]
+async fn owner_aware_delete_request_set_nulls_ownerless_comment() {
+    use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
+
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let transport = MockTransport::new(node1);
+    let mut ctrl = create_test_controller(node1, transport);
+
+    make_all_primary(&mut ctrl, node1);
+    ctrl.set_ownership(Arc::new(
+        mqdb_core::types::OwnershipConfig::parse("posts=owner,comments=owner").unwrap(),
+    ));
+    let fk_comments = ClusterConstraint::foreign_key(
+        "comments",
+        "comments_post_fk",
+        "post_id",
+        "posts",
+        "id",
+        OnDeleteAction::Cascade,
+    );
+    ctrl.constraint_add(&fk_comments).await.unwrap();
+
+    let post = serde_json::to_vec(&serde_json::json!({
+        "owner": "alice", "id": "post-alice"
+    }))
+    .unwrap();
+    ctrl.db_create("posts", "post-alice", &post, 1000)
+        .await
+        .unwrap();
+    let owned_comment = serde_json::to_vec(&serde_json::json!({
+        "post_id": "post-alice", "owner": "alice", "id": "comment-alice"
+    }))
+    .unwrap();
+    ctrl.db_create("comments", "comment-alice", &owned_comment, 1000)
+        .await
+        .unwrap();
+    let orphan_comment = serde_json::to_vec(&serde_json::json!({
+        "post_id": "post-alice", "id": "comment-orphan"
+    }))
+    .unwrap();
+    ctrl.db_create("comments", "comment-orphan", &orphan_comment, 1000)
+        .await
+        .unwrap();
+
+    let partition = crate::cluster::db::data_partition("posts", "post-alice");
+    let req = delete_post_request(Some("alice"));
+    ctrl.handle_json_db_request(node2, partition, &req).await;
+
+    assert!(
+        ctrl.db_get("comments", "comment-orphan").is_some(),
+        "an ownerless comment must survive an owner-aware cascade delete, not be hard-deleted"
+    );
+    assert!(
+        ctrl.db_get("comments", "comment-alice").is_none(),
+        "alice's own comment is still cascade-deleted"
+    );
+}
+
+#[tokio::test]
 async fn circular_fk_cascade_terminates() {
     use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
 

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -1546,29 +1546,14 @@ async fn cascade_delete_fan_out_propagates_sender_to_remote_primary() {
 
 #[tokio::test]
 async fn handle_fk_reverse_lookup_classifies_ownerless_ref_as_cross_owned() {
-    use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
     use crate::cluster::protocol::FkReverseLookupRequest;
 
     let node1 = NodeId::validated(1).unwrap();
     let node2 = NodeId::validated(2).unwrap();
     let transport = MockTransport::new(node1);
     let mut ctrl = create_test_controller(node1, transport);
+    setup_owned_posts_referencing_user(&mut ctrl, node1).await;
 
-    make_all_primary(&mut ctrl, node1);
-    ctrl.set_ownership(Arc::new(
-        mqdb_core::types::OwnershipConfig::parse("posts=owner").unwrap(),
-    ));
-    let fk = ClusterConstraint::foreign_key(
-        "posts",
-        "posts_author_fk",
-        "author_id",
-        "users",
-        "id",
-        OnDeleteAction::Cascade,
-    );
-    ctrl.constraint_add(&fk).await.unwrap();
-    let user = serde_json::to_vec(&serde_json::json!({"name": "Alice"})).unwrap();
-    ctrl.db_create("users", "u1", &user, 1000).await.unwrap();
     let orphan_post = serde_json::to_vec(&serde_json::json!({
         "author_id": "u1", "id": "post-orphan"
     }))
@@ -1581,55 +1566,29 @@ async fn handle_fk_reverse_lookup_classifies_ownerless_ref_as_cross_owned() {
     ctrl.handle_fk_reverse_lookup_request(node2, &req).await;
 
     let resp = sent_fk_lookup_response(&ctrl, node2);
-    assert!(
-        resp.referencing_ids().is_empty(),
-        "an ownerless post must NOT be classified as owned/cascade-deletable by a non-owner"
-    );
     assert_eq!(
-        resp.cross_owned_ids(),
-        vec!["post-orphan".to_string()],
-        "an ownerless post must be cross-owned (set-null'd), matching the direct-delete path \
-         which forbids a non-admin from deleting an ownerless record"
+        resp.referencing_ids(),
+        vec!["post-alice".to_string()],
+        "only alice's own post is owned/cascade-deletable by alice"
+    );
+    let mut cross_owned = resp.cross_owned_ids();
+    cross_owned.sort();
+    assert_eq!(
+        cross_owned,
+        vec!["post-bob".to_string(), "post-orphan".to_string()],
+        "an ownerless post must be cross-owned (set-null'd) just like bob's, matching the \
+         direct-delete path which forbids a non-admin from deleting an ownerless record"
     );
 }
 
 #[tokio::test]
 async fn owner_aware_delete_request_set_nulls_ownerless_comment() {
-    use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
-
     let node1 = NodeId::validated(1).unwrap();
     let node2 = NodeId::validated(2).unwrap();
     let transport = MockTransport::new(node1);
     let mut ctrl = create_test_controller(node1, transport);
+    setup_post_with_owned_and_cross_owned_comments(&mut ctrl, node1).await;
 
-    make_all_primary(&mut ctrl, node1);
-    ctrl.set_ownership(Arc::new(
-        mqdb_core::types::OwnershipConfig::parse("posts=owner,comments=owner").unwrap(),
-    ));
-    let fk_comments = ClusterConstraint::foreign_key(
-        "comments",
-        "comments_post_fk",
-        "post_id",
-        "posts",
-        "id",
-        OnDeleteAction::Cascade,
-    );
-    ctrl.constraint_add(&fk_comments).await.unwrap();
-
-    let post = serde_json::to_vec(&serde_json::json!({
-        "owner": "alice", "id": "post-alice"
-    }))
-    .unwrap();
-    ctrl.db_create("posts", "post-alice", &post, 1000)
-        .await
-        .unwrap();
-    let owned_comment = serde_json::to_vec(&serde_json::json!({
-        "post_id": "post-alice", "owner": "alice", "id": "comment-alice"
-    }))
-    .unwrap();
-    ctrl.db_create("comments", "comment-alice", &owned_comment, 1000)
-        .await
-        .unwrap();
     let orphan_comment = serde_json::to_vec(&serde_json::json!({
         "post_id": "post-alice", "id": "comment-orphan"
     }))

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -1319,6 +1319,103 @@ async fn cascade_set_nulls_cross_owned_ref_with_no_owned_siblings() {
 }
 
 #[tokio::test]
+async fn local_cascade_set_nulls_cross_owned_grandchild() {
+    use super::db_ops::CascadeSideEffect;
+    use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
+
+    let node1 = NodeId::validated(1).unwrap();
+    let transport = MockTransport::new(node1);
+    let mut ctrl = create_test_controller(node1, transport);
+    make_all_primary(&mut ctrl, node1);
+    ctrl.set_ownership(Arc::new(
+        mqdb_core::types::OwnershipConfig::parse("posts=owner,comments=owner").unwrap(),
+    ));
+
+    let fk_posts = ClusterConstraint::foreign_key(
+        "posts",
+        "posts_author_fk",
+        "author_id",
+        "users",
+        "id",
+        OnDeleteAction::Cascade,
+    );
+    ctrl.constraint_add(&fk_posts).await.unwrap();
+    let fk_comments = ClusterConstraint::foreign_key(
+        "comments",
+        "comments_post_fk",
+        "post_id",
+        "posts",
+        "id",
+        OnDeleteAction::Cascade,
+    );
+    ctrl.constraint_add(&fk_comments).await.unwrap();
+
+    let user = serde_json::to_vec(&serde_json::json!({"name": "Alice"})).unwrap();
+    ctrl.db_create("users", "u1", &user, 1000).await.unwrap();
+    let post = serde_json::to_vec(&serde_json::json!({
+        "author_id": "u1", "owner": "alice", "id": "post-alice"
+    }))
+    .unwrap();
+    ctrl.db_create("posts", "post-alice", &post, 1000)
+        .await
+        .unwrap();
+    let owned_comment = serde_json::to_vec(&serde_json::json!({
+        "post_id": "post-alice", "owner": "alice", "id": "comment-alice"
+    }))
+    .unwrap();
+    ctrl.db_create("comments", "comment-alice", &owned_comment, 1000)
+        .await
+        .unwrap();
+    let cross_comment = serde_json::to_vec(&serde_json::json!({
+        "post_id": "post-alice", "owner": "carol", "id": "comment-carol"
+    }))
+    .unwrap();
+    ctrl.db_create("comments", "comment-carol", &cross_comment, 1000)
+        .await
+        .unwrap();
+
+    let (local_results, pending_remote) = ctrl
+        .start_fk_reverse_lookup("users", "u1", Some("alice"))
+        .await
+        .unwrap();
+    assert!(
+        pending_remote.is_empty(),
+        "single-node: collect_local_cascade path"
+    );
+
+    let all = ctrl
+        .collect_local_cascade("users", "u1", local_results, Some("alice"))
+        .unwrap();
+    let effects = ctrl.prepare_fk_side_effects(&all);
+    let has = |pred: &dyn Fn(&CascadeSideEffect) -> bool| effects.iter().any(pred);
+
+    assert!(
+        has(&|e| matches!(
+            e,
+            CascadeSideEffect::LocalSetNull { entity, id, .. } if entity == "comments" && id == "comment-carol"
+        )) && !has(&|e| matches!(
+            e,
+            CascadeSideEffect::LocalDelete { entity, id } if entity == "comments" && id == "comment-carol"
+        )),
+        "carol's cross-owned grandchild must be set-null'd, not deleted, at cascade depth 2"
+    );
+    assert!(
+        has(&|e| matches!(
+            e,
+            CascadeSideEffect::LocalDelete { entity, id } if entity == "comments" && id == "comment-alice"
+        )),
+        "alice's own grandchild is still cascade-deleted"
+    );
+    assert!(
+        has(&|e| matches!(
+            e,
+            CascadeSideEffect::LocalDelete { entity, id } if entity == "posts" && id == "post-alice"
+        )),
+        "alice's own post is still cascade-deleted"
+    );
+}
+
+#[tokio::test]
 async fn circular_fk_cascade_terminates() {
     use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
 
@@ -1356,7 +1453,7 @@ async fn circular_fk_cascade_terminates() {
         .await
         .unwrap();
 
-    let result = ctrl.collect_local_cascade("alpha", "a1", local);
+    let result = ctrl.collect_local_cascade("alpha", "a1", local, None);
     assert!(
         result.is_ok(),
         "circular cascade should terminate via visited set"
@@ -1422,7 +1519,7 @@ async fn three_way_circular_fk_cascade_terminates() {
         .start_fk_reverse_lookup("aaa", "a1", None)
         .await
         .unwrap();
-    let result = ctrl.collect_local_cascade("aaa", "a1", local);
+    let result = ctrl.collect_local_cascade("aaa", "a1", local, None);
     assert!(
         result.is_ok(),
         "3-way circular cascade should terminate: {result:?}"

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -1167,6 +1167,110 @@ async fn fk_reverse_lookup_restrict_blocks_only_on_primary_data() {
     }
 }
 
+async fn setup_owned_posts_referencing_user(
+    ctrl: &mut NodeController<MockTransport>,
+    node: NodeId,
+) {
+    use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
+
+    make_all_primary(ctrl, node);
+    ctrl.set_ownership(Arc::new(
+        mqdb_core::types::OwnershipConfig::parse("posts=owner").unwrap(),
+    ));
+
+    let fk = ClusterConstraint::foreign_key(
+        "posts",
+        "posts_author_fk",
+        "author_id",
+        "users",
+        "id",
+        OnDeleteAction::Cascade,
+    );
+    ctrl.constraint_add(&fk).await.unwrap();
+
+    let user = serde_json::to_vec(&serde_json::json!({"name": "Alice"})).unwrap();
+    ctrl.db_create("users", "u1", &user, 1000).await.unwrap();
+
+    let alice_post = serde_json::to_vec(&serde_json::json!({
+        "author_id": "u1", "owner": "alice", "id": "post-alice"
+    }))
+    .unwrap();
+    ctrl.db_create("posts", "post-alice", &alice_post, 1000)
+        .await
+        .unwrap();
+    let bob_post = serde_json::to_vec(&serde_json::json!({
+        "author_id": "u1", "owner": "bob", "id": "post-bob"
+    }))
+    .unwrap();
+    ctrl.db_create("posts", "post-bob", &bob_post, 1000)
+        .await
+        .unwrap();
+}
+
+fn sent_fk_lookup_response(
+    ctrl: &NodeController<MockTransport>,
+    to: NodeId,
+) -> crate::cluster::protocol::FkReverseLookupResponse {
+    ctrl.transport
+        .sent_messages()
+        .into_iter()
+        .find_map(|(dest, msg)| match msg {
+            ClusterMessage::FkReverseLookupResponse(r) if dest == to => Some(r),
+            _ => None,
+        })
+        .expect("FK reverse lookup response sent to requester")
+}
+
+#[tokio::test]
+async fn handle_fk_reverse_lookup_partitions_cross_owned_by_sender() {
+    use crate::cluster::protocol::FkReverseLookupRequest;
+
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let transport = MockTransport::new(node1);
+    let mut ctrl = create_test_controller(node1, transport);
+    setup_owned_posts_referencing_user(&mut ctrl, node1).await;
+
+    let req = FkReverseLookupRequest::create(1, "posts", "author_id", "u1", "users", "alice");
+    ctrl.handle_fk_reverse_lookup_request(node2, &req).await;
+
+    let resp = sent_fk_lookup_response(&ctrl, node2);
+    assert_eq!(
+        resp.referencing_ids(),
+        vec!["post-alice".to_string()],
+        "alice's own post is owned and cascade-deletable"
+    );
+    assert_eq!(
+        resp.cross_owned_ids(),
+        vec!["post-bob".to_string()],
+        "bob's post is cross-owned and must be set-null'd, not deleted"
+    );
+}
+
+#[tokio::test]
+async fn handle_fk_reverse_lookup_blind_sender_returns_all_owned() {
+    use crate::cluster::protocol::FkReverseLookupRequest;
+
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let transport = MockTransport::new(node1);
+    let mut ctrl = create_test_controller(node1, transport);
+    setup_owned_posts_referencing_user(&mut ctrl, node1).await;
+
+    let req = FkReverseLookupRequest::create(2, "posts", "author_id", "u1", "users", "");
+    ctrl.handle_fk_reverse_lookup_request(node2, &req).await;
+
+    let resp = sent_fk_lookup_response(&ctrl, node2);
+    let mut owned = resp.referencing_ids();
+    owned.sort();
+    assert_eq!(
+        owned,
+        vec!["post-alice".to_string(), "post-bob".to_string()],
+        "a blind (empty) sender treats every ref as owned"
+    );
+    assert!(resp.cross_owned_ids().is_empty());
+}
+
 #[tokio::test]
 async fn circular_fk_cascade_terminates() {
     use crate::cluster::db::{ClusterConstraint, OnDeleteAction};

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -1272,6 +1272,53 @@ async fn handle_fk_reverse_lookup_blind_sender_returns_all_owned() {
 }
 
 #[tokio::test]
+async fn cascade_set_nulls_cross_owned_ref_with_no_owned_siblings() {
+    use super::db_ops::CascadeSideEffect;
+    use super::fk::{FkReverseLookupResult, filter_and_extract_cascade};
+    use crate::cluster::db::OnDeleteAction;
+
+    let node1 = NodeId::validated(1).unwrap();
+    let transport = MockTransport::new(node1);
+    let mut ctrl = create_test_controller(node1, transport);
+    setup_owned_posts_referencing_user(&mut ctrl, node1).await;
+
+    let reply = FkReverseLookupResult {
+        constraint_name: "posts_author_fk".to_string(),
+        source_entity: "posts".to_string(),
+        source_field: "author_id".to_string(),
+        on_delete: OnDeleteAction::Cascade,
+        referencing_ids: Vec::new(),
+        cross_owned_ids: vec!["post-bob".to_string()],
+        target_id: "u1".to_string(),
+    };
+
+    let mut visited = std::collections::HashSet::new();
+    visited.insert(("users".to_string(), "u1".to_string()));
+    let (filtered, _queue) = filter_and_extract_cascade(vec![reply], &mut visited);
+    assert_eq!(
+        filtered.len(),
+        1,
+        "a cross-owned-only cascade result must survive filtering"
+    );
+
+    let effects = ctrl.prepare_fk_side_effects(&filtered);
+    assert!(
+        effects.iter().any(|e| matches!(
+            e,
+            CascadeSideEffect::LocalSetNull { entity, id, .. } if entity == "posts" && id == "post-bob"
+        )),
+        "post-bob is cross-owned and must be set-null'd, not silently dropped"
+    );
+    assert!(
+        !effects.iter().any(|e| matches!(
+            e,
+            CascadeSideEffect::LocalDelete { id, .. } if id == "post-bob"
+        )),
+        "post-bob must never be deleted"
+    );
+}
+
+#[tokio::test]
 async fn circular_fk_cascade_terminates() {
     use crate::cluster::db::{ClusterConstraint, OnDeleteAction};
 

--- a/crates/mqdb-cluster/src/cluster/protocol/fk.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/fk.rs
@@ -98,10 +98,13 @@ pub struct FkReverseLookupRequest {
     pub target_entity_len: u16,
     #[FromField(target_entity_len)]
     pub target_entity: Vec<u8>,
+    pub sender_len: u16,
+    #[FromField(sender_len)]
+    pub sender: Vec<u8>,
 }
 
 impl FkReverseLookupRequest {
-    pub const VERSION: u8 = 1;
+    pub const VERSION: u8 = 2;
 
     #[must_use]
     pub fn create(
@@ -110,6 +113,7 @@ impl FkReverseLookupRequest {
         source_field: &str,
         target_id: &str,
         target_entity: &str,
+        sender: &str,
     ) -> Self {
         assert!(
             u16::try_from(source_entity.len()).is_ok(),
@@ -127,6 +131,10 @@ impl FkReverseLookupRequest {
             u16::try_from(target_entity.len()).is_ok(),
             "target_entity exceeds u16::MAX bytes"
         );
+        assert!(
+            u16::try_from(sender.len()).is_ok(),
+            "sender exceeds u16::MAX bytes"
+        );
         #[allow(clippy::cast_possible_truncation)]
         Self {
             version: Self::VERSION,
@@ -139,6 +147,8 @@ impl FkReverseLookupRequest {
             target_id: target_id.as_bytes().to_vec(),
             target_entity_len: target_entity.len() as u16,
             target_entity: target_entity.as_bytes().to_vec(),
+            sender_len: sender.len() as u16,
+            sender: sender.as_bytes().to_vec(),
         }
     }
 
@@ -181,6 +191,58 @@ impl FkReverseLookupRequest {
             ""
         }
     }
+
+    #[must_use]
+    pub fn sender_str(&self) -> &str {
+        if let Ok(s) = std::str::from_utf8(&self.sender) {
+            s
+        } else {
+            tracing::warn!("invalid UTF-8 in FkReverseLookupRequest sender field");
+            ""
+        }
+    }
+}
+
+fn encode_id_list(ids: &[String]) -> Vec<u8> {
+    let mut data = Vec::new();
+    for id in ids {
+        let bytes = id.as_bytes();
+        assert!(
+            u16::try_from(bytes.len()).is_ok(),
+            "individual id exceeds u16::MAX bytes"
+        );
+        #[allow(clippy::cast_possible_truncation)]
+        data.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
+        data.extend_from_slice(bytes);
+    }
+    assert!(
+        u32::try_from(data.len()).is_ok(),
+        "id list exceeds u32::MAX bytes"
+    );
+    data
+}
+
+fn decode_id_list(data: &[u8]) -> Vec<String> {
+    let mut result = Vec::new();
+    let mut pos = 0;
+    while pos + 2 <= data.len() {
+        let len = u16::from_be_bytes([data[pos], data[pos + 1]]) as usize;
+        pos += 2;
+        if pos + len > data.len() {
+            break;
+        }
+        if let Ok(s) = std::str::from_utf8(&data[pos..pos + len]) {
+            result.push(s.to_string());
+        } else {
+            tracing::warn!(
+                byte_offset = pos,
+                len,
+                "non-UTF-8 ID in FK reverse lookup response, skipping"
+            );
+        }
+        pos += len;
+    }
+    result
 }
 
 #[derive(Debug, Clone, BeBytes)]
@@ -190,59 +252,37 @@ pub struct FkReverseLookupResponse {
     pub ids_data_len: u32,
     #[FromField(ids_data_len)]
     pub ids_data: Vec<u8>,
+    pub cross_owned_data_len: u32,
+    #[FromField(cross_owned_data_len)]
+    pub cross_owned_data: Vec<u8>,
 }
 
 impl FkReverseLookupResponse {
-    pub const VERSION: u8 = 1;
+    pub const VERSION: u8 = 2;
 
     #[must_use]
-    pub fn create(request_id: u64, ids: &[String]) -> Self {
-        let mut ids_data = Vec::new();
-        for id in ids {
-            let bytes = id.as_bytes();
-            assert!(
-                u16::try_from(bytes.len()).is_ok(),
-                "individual id exceeds u16::MAX bytes"
-            );
-            #[allow(clippy::cast_possible_truncation)]
-            ids_data.extend_from_slice(&(bytes.len() as u16).to_be_bytes());
-            ids_data.extend_from_slice(bytes);
-        }
-        assert!(
-            u32::try_from(ids_data.len()).is_ok(),
-            "ids_data exceeds u32::MAX bytes"
-        );
+    pub fn create(request_id: u64, owned_ids: &[String], cross_owned_ids: &[String]) -> Self {
+        let ids_data = encode_id_list(owned_ids);
+        let cross_owned_data = encode_id_list(cross_owned_ids);
         #[allow(clippy::cast_possible_truncation)]
         Self {
             version: Self::VERSION,
             request_id,
             ids_data_len: ids_data.len() as u32,
             ids_data,
+            cross_owned_data_len: cross_owned_data.len() as u32,
+            cross_owned_data,
         }
     }
 
     #[must_use]
     pub fn referencing_ids(&self) -> Vec<String> {
-        let mut result = Vec::new();
-        let mut pos = 0;
-        while pos + 2 <= self.ids_data.len() {
-            let len = u16::from_be_bytes([self.ids_data[pos], self.ids_data[pos + 1]]) as usize;
-            pos += 2;
-            if pos + len > self.ids_data.len() {
-                break;
-            }
-            if let Ok(s) = std::str::from_utf8(&self.ids_data[pos..pos + len]) {
-                result.push(s.to_string());
-            } else {
-                tracing::warn!(
-                    byte_offset = pos,
-                    len,
-                    "non-UTF-8 ID in FK reverse lookup response, skipping"
-                );
-            }
-            pos += len;
-        }
-        result
+        decode_id_list(&self.ids_data)
+    }
+
+    #[must_use]
+    pub fn cross_owned_ids(&self) -> Vec<String> {
+        decode_id_list(&self.cross_owned_data)
     }
 }
 
@@ -276,7 +316,8 @@ mod tests {
 
     #[test]
     fn fk_reverse_lookup_request_roundtrip() {
-        let req = FkReverseLookupRequest::create(99, "posts", "author_id", "user-456", "users");
+        let req =
+            FkReverseLookupRequest::create(99, "posts", "author_id", "user-456", "users", "alice");
         let bytes = req.clone().to_be_bytes();
         let (decoded, _) = FkReverseLookupRequest::try_from_be_bytes(&bytes).unwrap();
         assert_eq!(decoded.request_id, 99);
@@ -284,34 +325,48 @@ mod tests {
         assert_eq!(decoded.source_field_str(), "author_id");
         assert_eq!(decoded.target_id_str(), "user-456");
         assert_eq!(decoded.target_entity_str(), "users");
+        assert_eq!(decoded.sender_str(), "alice");
+        assert_eq!(decoded.version, FkReverseLookupRequest::VERSION);
+    }
+
+    #[test]
+    fn fk_reverse_lookup_request_empty_sender_is_blind() {
+        let req = FkReverseLookupRequest::create(7, "posts", "author_id", "u1", "users", "");
+        let bytes = req.clone().to_be_bytes();
+        let (decoded, _) = FkReverseLookupRequest::try_from_be_bytes(&bytes).unwrap();
+        assert_eq!(decoded.sender_str(), "");
     }
 
     #[test]
     fn fk_reverse_lookup_response_roundtrip() {
-        let ids = vec![
+        let owned = vec![
             "post-1".to_string(),
             "post-2".to_string(),
             "post-3".to_string(),
         ];
-        let resp = FkReverseLookupResponse::create(99, &ids);
+        let cross_owned = vec!["post-9".to_string()];
+        let resp = FkReverseLookupResponse::create(99, &owned, &cross_owned);
         let bytes = resp.clone().to_be_bytes();
         let (decoded, _) = FkReverseLookupResponse::try_from_be_bytes(&bytes).unwrap();
         assert_eq!(decoded.request_id, 99);
-        assert_eq!(decoded.referencing_ids(), ids);
+        assert_eq!(decoded.referencing_ids(), owned);
+        assert_eq!(decoded.cross_owned_ids(), cross_owned);
+        assert_eq!(decoded.version, FkReverseLookupResponse::VERSION);
     }
 
     #[test]
     fn fk_reverse_lookup_response_empty() {
-        let resp = FkReverseLookupResponse::create(1, &[]);
+        let resp = FkReverseLookupResponse::create(1, &[], &[]);
         let bytes = resp.clone().to_be_bytes();
         let (decoded, _) = FkReverseLookupResponse::try_from_be_bytes(&bytes).unwrap();
         assert!(decoded.referencing_ids().is_empty());
+        assert!(decoded.cross_owned_ids().is_empty());
     }
 
     #[test]
     fn ids_data_len_is_byte_length_not_id_count() {
         let ids = vec!["ab".to_string(), "cdef".to_string()];
-        let resp = FkReverseLookupResponse::create(1, &ids);
+        let resp = FkReverseLookupResponse::create(1, &ids, &[]);
         let expected_byte_len: u32 = (2 + 2 + 2 + 4) as u32;
         assert_eq!(resp.ids_data_len, expected_byte_len);
         assert_eq!(resp.referencing_ids().len(), 2);

--- a/crates/mqdb-cluster/src/cluster/store_manager/outbox.rs
+++ b/crates/mqdb-cluster/src/cluster/store_manager/outbox.rs
@@ -92,6 +92,8 @@ pub enum CascadeRemoteOp {
     Delete {
         entity: String,
         id: String,
+        #[serde(default)]
+        sender: Option<String>,
     },
     SetNull {
         entity: String,
@@ -275,6 +277,7 @@ mod tests {
             CascadeRemoteOp::Delete {
                 entity: "orders".to_string(),
                 id: "o-1".to_string(),
+                sender: None,
             },
             CascadeRemoteOp::SetNull {
                 entity: "invoices".to_string(),
@@ -301,6 +304,7 @@ mod tests {
         let ops = vec![CascadeRemoteOp::Delete {
             entity: "items".to_string(),
             id: "i-1".to_string(),
+            sender: None,
         }];
 
         let backend: Arc<dyn StorageBackend> = Arc::new(MemoryBackend::new());
@@ -325,6 +329,7 @@ mod tests {
         let ops = vec![CascadeRemoteOp::Delete {
             entity: "x".to_string(),
             id: "1".to_string(),
+            sender: None,
         }];
         let (ck, cv) = ClusterOutbox::build_cascade_entry("cas-3", &ops);
         backend.insert(&ck, &cv).unwrap();
@@ -338,6 +343,7 @@ mod tests {
         let ops = vec![CascadeRemoteOp::Delete {
             entity: "users".to_string(),
             id: "u-1".to_string(),
+            sender: None,
         }];
         let payload = CascadeOutboxPayload::new("cas-4".to_string(), &ops);
         assert!(payload.key.starts_with(b"_cascade/cas-4"));

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -772,7 +772,7 @@ async fn send_cascade_operations<T: ClusterTransport>(
         let mut local_ops = Vec::new();
         for op in &cascade.operations {
             let partition = match op {
-                crate::cluster::CascadeRemoteOp::Delete { entity, id }
+                crate::cluster::CascadeRemoteOp::Delete { entity, id, .. }
                 | crate::cluster::CascadeRemoteOp::SetNull { entity, id, .. } => {
                     crate::cluster::data_partition(entity, id)
                 }
@@ -782,7 +782,7 @@ async fn send_cascade_operations<T: ClusterTransport>(
                 continue;
             }
             match op {
-                crate::cluster::CascadeRemoteOp::Delete { entity, id } => {
+                crate::cluster::CascadeRemoteOp::Delete { entity, id, sender } => {
                     if let Some(rx) = ctrl
                         .send_cascade_request(
                             partition,
@@ -790,6 +790,7 @@ async fn send_cascade_operations<T: ClusterTransport>(
                             entity,
                             id,
                             &[],
+                            sender.as_deref(),
                         )
                         .await
                     {
@@ -836,7 +837,7 @@ async fn execute_local_cascade_work(
     for item in &work {
         for op in &item.ops {
             match op {
-                crate::cluster::CascadeRemoteOp::Delete { entity, id } => {
+                crate::cluster::CascadeRemoteOp::Delete { entity, id, .. } => {
                     if let Ok((db_entity, write)) = ctrl.db_delete_prepare(entity, id) {
                         let data: serde_json::Value = serde_json::from_slice(&db_entity.data)
                             .unwrap_or(serde_json::Value::Null);

--- a/crates/mqdb-wasm/Cargo.lock
+++ b/crates/mqdb-wasm/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-wasm"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "console_error_panic_hook",
  "futures-channel",

--- a/crates/mqdb-wasm/Cargo.toml
+++ b/crates/mqdb-wasm/Cargo.toml
@@ -6,12 +6,13 @@ license = "Apache-2.0"
 authors = ["LabOverWire"]
 description = "WASM client library for MQDB reactive database"
 repository = "https://github.com/LabOverWire/MQDB"
+exclude = ["examples/pkg"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-mqdb-core = { path = "../mqdb-core", default-features = false }
+mqdb-core = { path = "../mqdb-core", version = "0.7.3", default-features = false }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/crates/mqdb-wasm/Cargo.toml
+++ b/crates/mqdb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-wasm"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["LabOverWire"]

--- a/crates/mqdb-wasm/LICENSE
+++ b/crates/mqdb-wasm/LICENSE
@@ -1,661 +1,202 @@
-                    GNU AFFERO GENERAL PUBLIC LICENSE
-                       Version 3, 19 November 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-                            Preamble
-
-  The GNU Affero General Public License is a free, copyleft license for
-software and other kinds of works, specifically designed to ensure
-cooperation with the community in the case of network server software.
-
-  The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works.  By contrast,
-our General Public Licenses are intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.
-
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
-
-  Developers that use our General Public Licenses protect your rights
-with two steps: (1) assert copyright on the software, and (2) offer
-you this License which gives you legal permission to copy, distribute
-and/or modify the software.
-
-  A secondary benefit of defending all users' freedom is that
-improvements made in alternate versions of the program, if they
-receive widespread use, become available for other developers to
-incorporate.  Many developers of free software are heartened and
-encouraged by the resulting cooperation.  However, in the case of
-software used on network servers, this result may fail to come about.
-The GNU General Public License permits making a modified version and
-letting the public access it on a server without ever releasing its
-source code to the public.
-
-  The GNU Affero General Public License is designed specifically to
-ensure that, in such cases, the modified source code becomes available
-to the community.  It requires the operator of a network server to
-provide the source code of the modified version running there to the
-users of that server.  Therefore, public use of a modified version, on
-a publicly accessible server, gives the public access to the source
-code of the modified version.
-
-  An older license, called the Affero General Public License and
-published by Affero, was designed to accomplish similar goals.  This is
-a different license, not a version of the Affero GPL, but Affero has
-released a new version of the Affero GPL which permits relicensing under
-this license.
-
-  The precise terms and conditions for copying, distribution and
-modification follow.
-
-                       TERMS AND CONDITIONS
-
-  0. Definitions.
-
-  "This License" refers to version 3 of the GNU Affero General Public License.
-
-  "Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
-
-  "The Program" refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as "you".  "Licensees" and
-"recipients" may be individuals or organizations.
-
-  To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
-
-  A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-  To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy.  Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-  To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-  An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License.  If
-the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.
-
-  1. Source Code.
-
-  The "source code" for a work means the preferred form of the work
-for making modifications to it.  "Object code" means any non-source
-form of a work.
-
-  A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
-
-  The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form.  A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
-
-  The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities.  However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work.  For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
-
-  The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
-
-  The Corresponding Source for a work in source code form is that
-same work.
-
-  2. Basic Permissions.
-
-  All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met.  This License explicitly affirms your unlimited
-permission to run the unmodified Program.  The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
-
-  You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force.  You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright.  Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
-
-  Conveying under any other circumstances is permitted solely under
-the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.
-
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
-  No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
-
-  When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
-
-  4. Conveying Verbatim Copies.
-
-  You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.
-
-  You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
-
-  5. Conveying Modified Source Versions.
-
-  You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
-
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
-
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
-
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
-
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
-
-  A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit.  Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
-
-  6. Conveying Non-Source Forms.
-
-  You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
-
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
-
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
-
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
-
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
-
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
-
-  A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
-
-  A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling.  In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product.  A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
-
-  "Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source.  The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
-
-  If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information.  But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
-
-  The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed.  Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
-
-  Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
-
-  7. Additional Terms.
-
-  "Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law.  If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
-
-  When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it.  (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.)  You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
-
-  Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
-
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
-
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
-
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
-
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-  All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10.  If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term.  If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-  If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-  Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-  8. Termination.
-
-  You may not propagate or modify a covered work except as expressly
-provided under this License.  Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-  However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-  Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-  Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License.  If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-  9. Acceptance Not Required for Having Copies.
-
-  You are not required to accept this License in order to receive or
-run a copy of the Program.  Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance.  However,
-nothing other than this License grants you permission to propagate or
-modify any covered work.  These actions infringe copyright if you do
-not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-  10. Automatic Licensing of Downstream Recipients.
-
-  Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.
-
-  An "entity transaction" is a transaction transferring control of an
-organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations.  If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
-
-  You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License.  For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
-
-  11. Patents.
-
-  A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's "contributor version".
-
-  A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
-this License.
-
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
-
-  In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
-
-  If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
-
-  If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
-
-  A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License.  You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
-
-  Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
-
-  12. No Surrender of Others' Freedom.
-
-  If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all.  For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.
-
-  13. Remote Network Interaction; Use with the GNU General Public License.
-
-  Notwithstanding any other provision of this License, if you modify the
-Program, your modified version must prominently offer all users
-interacting with it remotely through a computer network (if your version
-supports such interaction) an opportunity to receive the Corresponding
-Source of your version by providing access to the Corresponding Source
-from a network server at no charge, through some standard or customary
-means of facilitating copying of software.  This Corresponding Source
-shall include the Corresponding Source for any work covered by version 3
-of the GNU General Public License that is incorporated pursuant to the
-following paragraph.
-
-  Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU General Public License into a single
-combined work, and to convey the resulting work.  The terms of this
-License will continue to apply to the part which is the covered work,
-but the work with which it is combined will remain governed by version
-3 of the GNU General Public License.
-
-  14. Revised Versions of this License.
-
-  The Free Software Foundation may publish revised and/or new versions of
-the GNU Affero General Public License from time to time.  Such new versions
-will be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-  Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU Affero General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation.  If the Program does not specify a version number of the
-GNU Affero General Public License, you may choose any version ever published
-by the Free Software Foundation.
-
-  If the Program specifies that a proxy can decide which future
-versions of the GNU Affero General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
-
-  Later license versions may give you additional or different
-permissions.  However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
-
-  15. Disclaimer of Warranty.
-
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-  16. Limitation of Liability.
-
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
-
-  17. Interpretation of Sections 15 and 16.
-
-  If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
-
-                     END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU Affero General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU Affero General Public License for more details.
-
-    You should have received a copy of the GNU Affero General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  If your software can interact with users remotely through a computer
-network, you should also make sure that it provides a way for users to
-get its source.  For example, if your program is a web application, its
-interface could display a "Source" link that leads users to an archive
-of the code.  There are many ways you could offer source, and different
-solutions will be better for different programs; see section 13 for the
-specific requirements.
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU AGPL, see
-<https://www.gnu.org/licenses/>.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.


### PR DESCRIPTION
## Summary

Fixes #22. FK cascade delete ignored ownership on remote nodes and on the local fast-path at cascade depth ≥ 2, so cross-owned records (owned by a third party) were cascade-deleted instead of set-null'd — silent destruction of other users' data.

- Bump `FkReverseLookupRequest`/`Response` to V2: request carries the deleter `sender`, response splits refs into `owned` vs `cross_owned`.
- Remote handler and local cascade partition refs by ownership at every depth — owned children recurse and delete, cross-owned are set-null'd and not recursed. Restrict/SetNull re-merge so Restrict still blocks on cross-owned refs.
- Treat a record with a missing/null owner field as cross-owned (protected), matching the direct-delete path which forbids a non-admin from deleting an ownerless record — previously such records were cascade-deleted by any sender (`is_none_or` → `is_some_and`).
- Thread the deleter identity through the remote cascade fan-out so re-cascades on remote primaries stay owner-aware.
- Dedup the shared reverse-lookup helpers (`local_primary_refs`, `classify_refs`/`classify_refs_by_ownership`, `is_blind_sender`) across the local and remote paths.
- Bump mqdb-cli 0.8.12, mqdb-cluster 0.3.7, mqdb-wasm 0.3.4.

Hard protocol-version bump with no mixed-version interop (matches existing `transport.rs` drop-on-mismatch). During a rolling upgrade, version-mismatched reverse-lookup frames are dropped, so an in-flight FK-cascade delete times out and is rejected (fail-safe) rather than proceeding.

## Test plan

- [x] Protocol V2 round-trips (sender, cross-owned, empty sender)
- [x] Remote handler partitions cross-owned vs owned; blind sender returns all as owned
- [x] Ownerless referencing record is set-null'd, not deleted, by a non-owner (unit + end-to-end)
- [x] Local path set-nulls a cross-owned grandchild at depth 2 while still deleting owned descendants
- [x] Cross-owned-only remote result set-nulls (not drops/deletes) end-to-end
- [x] Circular cascade still terminates
- [x] `cargo make test` — all suites pass, 0 failed
- [x] `cargo make clippy` `-D warnings` gate clean
