### PR TITLE
document owner-aware cascade null-owner protection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Per-entity atomicity with constraint enforcement and correlation ID dedup.
 - Schemas with type validation, required fields, and default values
 - Unique constraints (single and composite), not-null constraints
 - Foreign keys with CASCADE, RESTRICT, and SET NULL delete policies
-- Owner-aware cascade: cross-owned entities survive deletion with FK set to null
+- Owner-aware cascade: cross-owned and ownerless entities survive deletion with FK set to null
 
 Secondary indexes accelerate equality lookups. Ten filter operators cover the rest.
 
@@ -295,9 +295,14 @@ db.add_foreign_key(
 | `OnDeleteAction::SetNull` | Set foreign key field to null |
 
 When ownership is configured, cascade deletes are owner-aware. Entities owned by the
-deleting user are deleted normally. Cross-owned entities are excluded from the cascade — their
-FK field is set to null instead. If the FK field has a NotNull constraint, the entire delete
-is blocked. Admin users bypass ownership and perform a full blind cascade.
+deleting user are deleted normally. Cross-owned entities — and entities whose owner field
+is missing or null — are excluded from the cascade and have their FK field set to null
+instead; a missing/null owner is treated as protected, matching the direct delete/update
+path that already forbids a non-owner from removing such a record. Entities in a type with
+no ownership configured are always cascade-deleted. In agent mode, if a to-be-null'd FK
+field carries a NotNull constraint the entire delete is blocked (cluster mode set-nulls
+unconditionally — NotNull is not evaluated during cluster cascade). Admin users, and any
+delete with an empty sender, bypass ownership and perform a full blind cascade.
 
 ### Constraint Examples
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -311,9 +311,16 @@ let schema = Schema::new("users")
 - Reference integrity between entities
 - Validates referenced entity exists
 - Three deletion policies:
-  - `CASCADE`: Recursively delete referencing entities
+  - `CASCADE`: Recursively delete referencing entities (owner-aware — see below)
   - `RESTRICT`: Prevent deletion if references exist
   - `SET_NULL`: Set FK field to null when referenced entity deleted
+- When ownership is configured, only `CASCADE` filters by owner: a referencing record
+  is deleted only if the deleter (`sender`) owns it. Cross-owned records, and records
+  whose owner field is missing/null, are set to null instead of deleted (and not
+  recursed into) — a missing/null owner is protected, matching the direct-delete path.
+  Records in a type with no owner field configured are always cascade-deleted. An admin
+  or empty `sender` performs a full blind cascade. Agent mode additionally blocks the
+  whole delete if a to-be-null'd field carries NOT NULL; cluster mode does not.
 
 **Validation Timing (Agent Mode):**
 
@@ -345,7 +352,11 @@ Find all FK constraints targeting users
     ↓
 For each CASCADE constraint:
     Find referencing entities (posts where author_id=123)
-    Recursively collect cascade deletions (comments on those posts)
+    Split by ownership against the deleter (sender):
+        owned          → recurse + delete (comments on those posts)
+        cross-owned    → set FK to null, do not recurse
+        missing/null owner → set FK to null (protected), do not recurse
+    (no owner field configured for the entity → all owned; admin/empty sender → all owned)
     ↓
 For each RESTRICT constraint:
     Validate no references exist (fail if found)
@@ -603,9 +614,10 @@ Read entity to delete
     ↓
 Find FK constraints referencing this entity
     ↓
-Collect cascade operations (recursive DFS)
+Collect cascade operations (recursive DFS, owner-aware for CASCADE)
     ├─ CASCADE: posts where author_id=123
-    │   └─ CASCADE: comments where post_id in posts
+    │   ├─ owned by deleter        → delete + recurse (comments where post_id in posts)
+    │   └─ cross-owned / null owner → set FK null (protected), no recurse
     ├─ RESTRICT: verify no references
     └─ SET_NULL: update categories.owner_id=null
     ↓

--- a/docs/design/frontend-ownership.md
+++ b/docs/design/frontend-ownership.md
@@ -24,10 +24,10 @@ The original discussion proposed **user-scoped topic namespacing** (`$DB/u/{user
 When a user authenticates via MQTT CONNECT (password, SCRAM, JWT, or OAuth), the broker injects their identity as `x-mqtt-sender` (username) and `x-mqtt-client-id` (MQTT client ID) user properties on every PUBLISH they send. These are anti-spoof: the broker strips any client-supplied values before injecting the real ones. The database layer reads `x-mqtt-sender` for ownership enforcement and `x-mqtt-client-id` for echo suppression in change events (see `ARCHITECTURE.md` Section 16 for the full property flow). The ownership layer uses `x-mqtt-sender` to:
 
 - **List operations**: Automatically injects a mandatory filter `userId = {authenticated_user}`. Alice only sees her own diagrams. Bob only sees his.
-- **Update/Delete operations**: Reads the existing record, checks `data.userId == sender`. If mismatch, returns a 403 Forbidden error.
+- **Read/Update/Delete operations**: Reads the existing record and checks `data.userId == sender`. If mismatch, returns a 403 Forbidden error. Read is enforced the same as Update/Delete (`transport_execute.rs` → `check_access` with `AccessLevel::View`); it is **not** unrestricted.
+- **Missing/null owner**: A record whose owner field is absent or null is **protected** — `None == Some(sender)` is false, so any non-admin gets 403. This holds uniformly: the direct Read/Update/Delete path and the FK cascade path both treat a null/missing owner as not-owned (cascade set-nulls it instead of deleting). See [distributed-design.md → Owner-Aware Cascade](../distributed-design.md).
 - **Create operations**: No restriction. The frontend sets `userId` in the data payload.
-- **Read operations**: No restriction. IDs are UUIDs, not guessable.
-- **Admin users**: Bypass all ownership checks. Admins see all records and can update/delete anything.
+- **Admin users**: Bypass all ownership checks. Admins see all records and can read/update/delete anything.
 - **Internal operations**: When `sender` is absent (replication, outbox, internal handlers), all checks are bypassed.
 
 ### MQTT Topic Structure (Unchanged)
@@ -153,7 +153,7 @@ Admin users (specified via `--admin-users`) bypass all ownership restrictions:
 | Operation | Regular User | Admin User |
 |-----------|-------------|------------|
 | List diagrams | Only own diagrams | All diagrams |
-| Read diagram | Allowed (by UUID) | Allowed |
+| Read diagram | Only own diagrams (403 otherwise) | Any diagram |
 | Create diagram | Allowed | Allowed |
 | Update diagram | Only own diagrams (403 otherwise) | Any diagram |
 | Delete diagram | Only own diagrams (403 otherwise) | Any diagram |

--- a/docs/distributed-design.md
+++ b/docs/distributed-design.md
@@ -2288,10 +2288,39 @@ index to find all records that reference it. Depending on the constraint's
 
 - **Restrict**: The delete is rejected if any references exist.
 - **Cascade**: Referencing records are deleted recursively (depth limit: 16,
-  work-item limit: 16,000).
+  work-item limit: 16,000), subject to the owner-aware filter below.
 - **SetNull**: The FK field on referencing records is set to null. A CAS guard
   (`__mqdb_fk_expected`) ensures the field still holds the expected value at
   write time, preventing overwrites of concurrent updates.
+
+#### Owner-Aware Cascade
+
+Cascade is the only action that filters by ownership; Restrict and SetNull do not.
+The delete request carries the deleter's identity (`sender`), and each node that is
+primary for a referencing record's partition classifies that record against its own
+`OwnershipConfig`:
+
+- If the referencing entity has **no owner field configured**, every reference is
+  treated as owned and cascade-deleted (recursively).
+- If the entity **is** ownership-configured, a reference is **owned** only when its
+  owner field equals `sender`. Owned children are cascade-deleted and recursed into.
+- **Cross-owned** references (owner field present but not equal to `sender`) and
+  references whose **owner field is missing or null** are **set to null**, not
+  deleted, and are not recursed into. A missing/null owner is treated as protected —
+  the same record the direct delete/update path forbids a non-owner from removing
+  (`403`), so cascade and direct paths agree.
+- A **blind** deleter — an admin `sender`, or an empty `sender` — bypasses the filter
+  entirely: every reference is treated as owned and cascade-deleted.
+
+Because classification happens on the partition primary that holds each referencing
+record, ownership is enforced consistently across nodes. The reverse-lookup RPC
+(`FkReverseLookupRequest`/`Response`, wire version 2) carries `sender` on the request
+and returns the split as separate `owned` and `cross_owned` id lists on the response.
+
+> **Cluster vs agent:** the single-node agent additionally aborts the whole delete
+> (`CascadeBlocked`) when a cross-owned/ownerless child would be set to null on a
+> field carrying a NOT NULL constraint. Cluster mode does not evaluate NOT NULL
+> during cascade, so it set-nulls unconditionally.
 
 `CascadeSideEffect` partitions effects into local (same batch) and remote
 (transport request). Cascade and set-null operations on remote partitions are

--- a/docs/testing/04-schema.md
+++ b/docs/testing/04-schema.md
@@ -350,10 +350,12 @@ mqdb list tasks --user admin --pass admin
 
 **Expected:** All tasks are deleted (both alice's and bob's). Admin cascade is blind.
 
-### Unowned Entity Always Cascades
+### Unowned Entity Type Always Cascades
 
-If the referencing entity has no ownership configured, it is always included in the cascade
-regardless of the sender. Start a broker with ownership only on projects (not tasks):
+This is about an **entity type that is not listed in `--ownership`** — distinct from a record
+whose owner *field* is missing (covered in the next scenario). If the referencing entity has no
+owner field configured at all, every reference is treated as owned and is always included in the
+cascade regardless of the sender. Start a broker with ownership only on projects (not tasks):
 
 ```bash
 mqdb agent start --db /tmp/mqdb-cascade-unowned --bind 127.0.0.1:1883 \
@@ -373,7 +375,39 @@ mqdb delete projects <pid> --user alice --pass alice
 mqdb list tasks --user admin --pass admin
 ```
 
-**Expected:** Task is deleted. Entities without ownership config are always cascade-eligible.
+**Expected:** Task is deleted. Entity types without ownership config are always cascade-eligible.
+
+### Missing/Null Owner Field Is Protected
+
+When the referencing entity **is** ownership-configured but a specific record has **no owner
+field** (or a null one) — legacy data, an internal/admin insert, or a client that omitted it —
+that record is treated as not-owned: it is set-null'd, not deleted. This matches the direct
+delete/update path, which returns 403 when a non-admin targets a record with a missing/null
+owner. Fresh broker with ownership on both projects and tasks:
+
+```bash
+mqdb agent start --db /tmp/mqdb-cascade-nullowner --bind 127.0.0.1:1883 \
+    --passwd /tmp/cascade-passwd \
+    --ownership "projects=userId,tasks=userId" \
+    --admin-users admin
+
+mqdb constraint add tasks --fk "projectId:projects:id:cascade" \
+    --user admin --pass admin
+mqdb create projects --data '{"name": "P1", "userId": "alice"}' \
+    --user alice --pass alice
+# Note project ID → <pid>
+
+# A task in the ownership-configured `tasks` entity, but with NO userId field
+mqdb create tasks --data '{"name": "Ownerless Task", "projectId": "<pid>"}' \
+    --user admin --pass admin
+# Note ownerless task ID → <otid>
+
+mqdb delete projects <pid> --user alice --pass alice
+mqdb read tasks <otid> --user admin --pass admin
+```
+
+**Expected:** The ownerless task survives with `projectId: null` and `_version: 2` — it is
+set-null'd, not deleted, even though alice (a non-owner) triggered the cascade.
 
 ### Verification Checklist
 
@@ -381,5 +415,6 @@ mqdb list tasks --user admin --pass admin
 - [ ] Cross-owner cascade: entities owned by other users survive with FK set to null
 - [ ] Cross-owner + NotNull: delete is blocked with 409
 - [ ] Admin cascade: blind (deletes all regardless of owner)
-- [ ] Unowned entity: always included in cascade
+- [ ] Unowned entity type: always included in cascade
+- [ ] Missing/null owner field (configured entity): protected — set-null'd, not deleted
 - [ ] ChangeEvents: cross-owner survivors emit Update events (FK nulled), not Delete events

--- a/docs/testing/07-auth.md
+++ b/docs/testing/07-auth.md
@@ -527,13 +527,14 @@ mqdb dev start-cluster --nodes 3 --clean \
 
 **Cascade delete + ownership:**
 - [ ] Cross-owner cascade: referencing entity owned by different user survives with FK set to null
+- [ ] Missing/null owner field (configured entity): protected — survives with FK set to null, not deleted
 - [ ] Cross-owner + NotNull FK: delete is blocked (409)
 - [ ] Admin cascade bypasses ownership (blind cascade)
 - [ ] See [04-schema.md § Owner-Aware Cascade Delete](04-schema.md#6-owner-aware-cascade-delete) for full scenarios
 
 **Edge cases:**
-- [ ] Entity without ownership config allows all operations
-- [ ] Record missing the owner field allows all operations (no crash)
+- [ ] Entity type without ownership config allows all operations
+- [ ] Record missing the owner field (in a configured entity) is protected: non-admin read/update/delete returns 403, and cascade set-nulls it instead of deleting
 
 ---
 

--- a/docs/testing/11-cluster-tests.md
+++ b/docs/testing/11-cluster-tests.md
@@ -555,6 +555,40 @@ mqdb list posts --broker 127.0.0.1:1883 --user admin --pass admin
 
 **Expected:** Posts still exist with `author_id: null` and `_version: 2`.
 
+### Owner-Aware Cascade Across Nodes
+
+Exercises the remote-node ownership filter. Requires the cluster started with
+`--ownership "posts=userId"` and non-admin users (`alice`, `bob`) in the passwd file. Each
+node classifies the referencing records it is primary for against the deleter's identity, so
+cross-owned and ownerless posts on any node are set-null'd rather than deleted.
+
+```bash
+# authors is NOT ownership-configured; posts=userId. Cascade FK posts.author_id -> authors.id
+mqdb constraint add posts --fk "author_id:authors:id:cascade" \
+  --broker 127.0.0.1:1883 --user admin --pass admin
+mqdb create authors --data '{"name": "Shared"}' --broker 127.0.0.1:1883 --user admin --pass admin
+# Note the ID → <author-id>
+
+# alice's own post (owned), on a remote node
+mqdb create posts --data '{"title": "Alice Post", "userId": "alice", "author_id": "<author-id>"}' \
+  --broker 127.0.0.1:1884 --user alice --pass alice
+# bob's post (cross-owned), on another node
+mqdb create posts --data '{"title": "Bob Post", "userId": "bob", "author_id": "<author-id>"}' \
+  --broker 127.0.0.1:1885 --user bob --pass bob
+# ownerless post (no userId field), on node 1
+mqdb create posts --data '{"title": "Orphan Post", "author_id": "<author-id>"}' \
+  --broker 127.0.0.1:1883 --user admin --pass admin
+
+# alice deletes the shared parent (authors is unowned, so the delete itself is allowed)
+mqdb delete authors <author-id> --broker 127.0.0.1:1883 --user alice --pass alice
+
+mqdb list posts --broker 127.0.0.1:1883 --user admin --pass admin
+```
+
+**Expected:** Alice's own post is deleted. Bob's cross-owned post and the ownerless post survive
+on their respective nodes with `author_id: null` — remote nodes filter by ownership instead of
+blindly deleting. Re-running with `--user admin` (blind cascade) deletes all three.
+
 ---
 
 ## 20. Cluster Database Features


### PR DESCRIPTION
## Summary

- Document that owner-aware FK cascade **set-nulls (protects)** cross-owned *and* ownerless/null-owner records — kept distinct from an entity *type* with no `--ownership` config, which still always cascades. Updated `distributed-design.md`, `architecture.md`, and `README.md`.
- Add E2E scenarios: null-owner protection (`04-schema.md`) and cross-node owner-aware cascade (`11-cluster-tests.md`); fix the stale `07-auth.md` checklist that claimed a missing owner field "allows all operations".
- Correct stale `frontend-ownership.md`: Read is ownership-enforced (`AccessLevel::View`), not unrestricted.

Follows up #95 (owner-aware cascade). Documentation only — no code changes.

## Test plan

- [x] Every claim verified against code (`fk.rs`, `db_ops.rs`, `constraint.rs`, `transport_execute.rs`, `crud.rs`)
- [x] NotNull-blocks-cascade scoped to agent mode (cluster has no such check)
- [x] Two "ownerless" cases documented distinctly (unconfigured entity type vs null owner field)
