### PR TITLE
patch rustls-webpki and openssl dependabot advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2187,9 +2187,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1384,7 +1384,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "base64",
  "bebytes",

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.12"
+version = "0.8.13"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/publications/vldb-mqtt-as-database/bench/Cargo.lock
+++ b/publications/vldb-mqtt-as-database/bench/Cargo.lock
@@ -1755,9 +1755,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/publications/vldb-mqtt-as-database/bench/rest-pg/Cargo.lock
+++ b/publications/vldb-mqtt-as-database/bench/rest-pg/Cargo.lock
@@ -1048,15 +1048,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1080,9 +1079,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -1376,9 +1375,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary

Clears 15 of 16 open Dependabot alerts. Lockfile bumps + an `mqdb-cli` version bump so the fix is releasable.

- **Product (`Cargo.lock`)**: `rustls-webpki` 0.103.11 → 0.103.13 — patches GHSA-82j2-j2ch-gfr8 (**high**, CRL-panic DoS) plus two low name-constraint advisories. Transitive via `rustls 0.23`; `cargo check --workspace` clean.
- **VLDB benchmark harnesses** (`publications/vldb-mqtt-as-database/bench/`, `.../rest-pg/`, standalone, not shipped): `openssl` 0.10.77 → 0.10.80 (clears the 8-alert openssl cluster) and `rustls-webpki` → 0.103.13.
- **`mqdb-cli` 0.8.12 → 0.8.13** — the shipped binary embeds the lockfile, so it needs a bump to release the fix (tag = `v$mqdb-cli-version`). Library crates are not bumped: `rustls-webpki` is transitive, their manifests are unchanged, and downstream consumers re-resolve it automatically.

### Remaining alert — blocked upstream, cannot fix here

`opentelemetry_sdk` 0.31.0 (medium — unbounded memory in W3C Baggage propagation). First-patched is 0.32.1, but `opentelemetry_sdk = "^0.31"` is **required by `mqtt5`** (git dependency), so cargo refuses 0.32.1 from this repo. The upgrade must land in `mqtt5` first. It is also feature-gated (`--features opentelemetry`), **absent from released binaries** (`--no-default-features --features http-api`), and the vulnerable Baggage propagator is not reachable in MQDB's export-only tracing — so real exposure is low. Recommend tracking against the mqtt5 OTel bump (or dismissing the alert with this rationale).

## Test plan

- [x] `cargo check --workspace` passes after the root bump
- [x] Each lockfile change limited to the targeted advisories (rustls-webpki / openssl)
- [x] `mqdb-cli` bumped so the CVE fix is releasable
