### PR TITLE
docs cleanup, mqtt5/opentelemetry upgrade, and clippy pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-07-06 — mqdb-cli 0.8.14, mqdb-agent 0.8.11, mqdb-cluster 0.3.8, mqdb-vault 0.1.3
+
+### Changed
+
+- Updated mqtt5 to 0.35.1 and opentelemetry to 0.32, moving opentelemetry_sdk to 0.32.1 and clearing the remaining Dependabot advisory (#98).
+
 ## 2026-07-03 — mqdb-cli 0.8.13
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-07-03 — mqdb-cli 0.8.13
+
+### Security
+
+- Patched the `rustls-webpki` and `openssl` dependency advisories flagged by Dependabot (#97).
+
+### Docs
+
+- Documented the owner-aware cascade null-owner protection behavior added in 0.8.12 (#96).
+
+## 2026-07-02 — mqdb-agent 0.8.10, mqdb-cluster 0.3.7, mqdb-wasm 0.3.4, mqdb-cli 0.8.12
+
+### Fixed
+
+- Owner-aware foreign-key cascade delete now filters by ownership at every depth on both the local and remote (cross-node cluster) delete paths, and threads the deleter's identity through the remote cascade fan-out. A cascade only removes child records the deleter owns; cross-owned children are preserved (set-null work on cross-owned references is retained). Records with no owner or a null owner are protected from cascade deletion by a foreign owner (#95).
+
 ## 2026-06-05 — mqdb-vault 0.1.2, mqdb-cli 0.8.11
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Thank you for your interest in contributing to MQDB. This document explains how 
 
 All contributors must sign our [Contributor License Agreement](CLA.md) before any pull request can be merged. This is required even for small changes.
 
-**Why?** The CLA grants LabOverWire the rights needed to distribute MQDB under both the AGPL-3.0 open source license and commercial licenses. Without it, we cannot accept your contribution.
+**Why?** MQDB ships under a per-crate license split: `mqdb-core`, `mqdb-agent`, and `mqdb-wasm` are Apache-2.0, while `mqdb-vault`, `mqdb-cluster`, and `mqdb-cli` are AGPL-3.0-only. The CLA grants LabOverWire the rights needed to distribute your contribution under whichever of these licenses applies, and under commercial licenses. Without it, we cannot accept your contribution.
 
 **How to sign:**
 - First-time contributors: add your name to the signature table in [CLA.md](CLA.md), or

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -185,7 +185,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -195,6 +195,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -211,9 +220,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "portable-atomic",
 ]
@@ -253,6 +262,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "clap"
@@ -337,6 +357,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0095f6103c2a8b44acd6fd15960c801dafebf02e21940360833e0673f48ba7"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -367,6 +393,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -439,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "dashmap"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,9 +517,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -596,12 +651,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -751,15 +800,16 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
+ "rand_core 0.10.1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -795,22 +845,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -818,6 +859,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -890,6 +936,15 @@ checksum = "57a3db5ea5923d99402c94e9feb261dc5ee9b4efa158b0315f788cf549cc200c"
 dependencies = [
  "humantime",
  "serde",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -1051,12 +1106,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,8 +1134,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1149,6 +1196,36 @@ dependencies = [
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1223,12 +1300,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1349,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.8.10"
+version = "0.8.11"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1368,7 +1439,7 @@ dependencies = [
  "mqtt5",
  "opentelemetry",
  "regex",
- "reqwest 0.13.2",
+ "reqwest",
  "ring",
  "serde",
  "serde_json",
@@ -1384,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "base64",
  "bebytes",
@@ -1411,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cluster"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "arc-swap",
  "bebytes",
@@ -1466,7 +1537,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-vault"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64",
  "mqdb-agent",
@@ -1484,8 +1555,8 @@ dependencies = [
 
 [[package]]
 name = "mqtt5"
-version = "0.31.4"
-source = "git+https://github.com/LabOverWire/mqtt-lib.git#f31e9bff215c8354f2baa21a280a76af6493ed26"
+version = "0.35.1"
+source = "git+https://github.com/LabOverWire/mqtt-lib.git#563cc1ce26383b5f89cc289df476aa79aad8da99"
 dependencies = [
  "argon2",
  "base64",
@@ -1494,7 +1565,7 @@ dependencies = [
  "flume",
  "futures",
  "futures-util",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hex",
  "http",
  "http-body-util",
@@ -1508,11 +1579,10 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "quinn",
- "rand",
+ "rand 0.10.2",
  "regex",
  "ring",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1532,12 +1602,12 @@ dependencies = [
 
 [[package]]
 name = "mqtt5-protocol"
-version = "0.12.0"
-source = "git+https://github.com/LabOverWire/mqtt-lib.git#f31e9bff215c8354f2baa21a280a76af6493ed26"
+version = "0.14.1"
+source = "git+https://github.com/LabOverWire/mqtt-lib.git#563cc1ce26383b5f89cc289df476aa79aad8da99"
 dependencies = [
  "bebytes",
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "portable-atomic",
  "portable-atomic-util",
  "serde",
@@ -1609,9 +1679,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1623,22 +1693,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -1646,18 +1716,18 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest",
  "thiserror 2.0.18",
  "tokio",
  "tonic",
- "tracing",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -1668,16 +1738,17 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "portable-atomic",
+ "rand 0.9.3",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
@@ -1799,16 +1870,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1841,6 +1902,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "quick_cache"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,9 +1922,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1872,20 +1942,21 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.7.0",
  "slab",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1939,6 +2010,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1964,6 +2046,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2006,40 +2103,6 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -2047,7 +2110,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2063,7 +2128,7 @@ dependencies = [
  "quinn",
  "rustls",
  "rustls-pki-types",
- "rustls-platform-verifier",
+ "rustls-platform-verifier 0.6.2",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2100,6 +2165,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2114,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -2140,19 +2214,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2166,7 +2231,28 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -2350,19 +2436,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2398,6 +2484,22 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "simple_asn1"
@@ -2519,7 +2621,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2681,9 +2783,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -2710,9 +2812,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.12+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "indexmap",
  "serde_core",
@@ -2720,14 +2822,14 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -2738,7 +2840,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow",
 ]
 
 [[package]]
@@ -2781,6 +2883,17 @@ checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
 dependencies = [
  "bytes",
  "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a875a902255423d34c1f20838ab374126db8eb41625b7947a1d54113b0b7399"
+dependencies = [
+ "prost",
+ "prost-types",
  "tonic",
 ]
 
@@ -2878,9 +2991,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -2918,21 +3031,20 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.3",
  "rustls",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
- "utf-8",
 ]
 
 [[package]]
@@ -2943,9 +3055,9 @@ checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2964,12 +3076,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2996,12 +3102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3019,7 +3119,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3072,15 +3172,6 @@ name = "wasip2"
 version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
@@ -3141,40 +3232,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3205,9 +3262,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3502,12 +3559,6 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-
-[[package]]
-name = "winnow"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
@@ -3517,88 +3568,6 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ zeroize = "1.8.2"
 clap = { version = "4.5", features = ["derive", "env"] }
 comfy-table = "7.2"
 fjall = "3.0"
-mqtt5 = "0.31"
+mqtt5 = "0.35"
 tokio = { version = "1.49", features = ["full"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 lru = "0.16"
@@ -52,8 +52,8 @@ reqwest = { version = "0.13", features = ["form", "json"] }
 base64 = "0.22"
 jsonwebtoken = { version = "10.3", features = ["aws_lc_rs"] }
 
-opentelemetry = { version = "0.31", features = ["trace"] }
-tracing-opentelemetry = "0.32"
+opentelemetry = { version = "0.32", features = ["trace"] }
+tracing-opentelemetry = "0.33"
 
 tempfile = "3.23.0"
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,34 @@
 
 A high-performance reactive database with native MQTT integration, point-to-point delivery, and consumer groups. Built in Rust with support for both native and WASM targets.
 
-MQDB is available in two editions:
+MQDB ships as a single `mqdb` binary. The core is permissively licensed and advanced features are unlocked by a license token — there are no separate editions or downloads:
 
-- **Agent** (open-source): Standalone embedded MQTT broker with full database, authentication, vault encryption, and consumer groups.
-- **Native** (commercial): Everything in Agent plus distributed clustering with Raft consensus, QUIC transport, partition rebalancing, and cross-node replication.
+- **Open-source core (Apache-2.0):** the `mqdb-core`, `mqdb-agent`, and `mqdb-wasm` crates — a standalone embedded MQTT broker with full database, authentication, and consumer groups.
+- **Licensed features:** vault transparent encryption requires a Pro or Enterprise license; distributed clustering (Raft consensus, QUIC transport, partition rebalancing, cross-node replication) requires an Enterprise license. Both run from the same binary once a valid `--license` token is supplied.
+
+See the [License](#license) section for the full per-crate breakdown.
+
+## Table of Contents
+
+- [Features](#features)
+- [Architecture](#architecture)
+- [Quick Start](#quick-start)
+- [Reactive Subscriptions](#reactive-subscriptions)
+- [Point-to-Point Delivery](#point-to-point-delivery)
+- [Secondary Indexes](#secondary-indexes)
+- [Sorting and Pagination](#sorting-and-pagination)
+- [Relationships](#relationships)
+- [Constraints & Data Integrity](#constraints--data-integrity)
+- [TTL (Time-To-Live)](#ttl-time-to-live)
+- [MQTT Agent](#mqtt-agent)
+- [Vault Encryption](#vault-encryption)
+- [Observability](#observability)
+- [Distributed Clustering](#distributed-clustering)
+- [CLI Tool](#cli-tool)
+- [Testing](#testing)
+- [Examples](#examples)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Features
 
@@ -294,15 +318,13 @@ db.add_foreign_key(
 | `OnDeleteAction::Restrict` | Prevent deletion if references exist |
 | `OnDeleteAction::SetNull` | Set foreign key field to null |
 
-When ownership is configured, cascade deletes are owner-aware. Entities owned by the
-deleting user are deleted normally. Cross-owned entities — and entities whose owner field
-is missing or null — are excluded from the cascade and have their FK field set to null
-instead; a missing/null owner is treated as protected, matching the direct delete/update
-path that already forbids a non-owner from removing such a record. Entities in a type with
-no ownership configured are always cascade-deleted. In agent mode, if a to-be-null'd FK
-field carries a NotNull constraint the entire delete is blocked (cluster mode set-nulls
-unconditionally — NotNull is not evaluated during cluster cascade). Admin users, and any
-delete with an empty sender, bypass ownership and perform a full blind cascade.
+When ownership is configured, cascade deletes are owner-aware:
+
+- **Owned entities** (owned by the deleting user) are deleted normally.
+- **Cross-owned entities, and entities whose owner field is missing or null,** are excluded from the cascade and have their FK field set to null instead. A missing/null owner is treated as protected, matching the direct delete/update path that already forbids a non-owner from removing such a record.
+- **Entities in a type with no ownership configured** are always cascade-deleted.
+- **NotNull FK constraint:** in agent mode, if a to-be-null'd FK field carries a NotNull constraint the entire delete is blocked. Cluster mode set-nulls unconditionally — NotNull is not evaluated during cluster cascade.
+- **Admin users, and any delete with an empty sender,** bypass ownership and perform a full blind cascade.
 
 ### Constraint Examples
 
@@ -456,7 +478,7 @@ Entities starting with `_` (e.g., `_sessions`, `_mqtt_subs`) require admin acces
 mqdb agent start --db /path/to/db --admin-users alice,bob
 
 mqdb cluster start --node-id 1 --db /path/to/db --admin-users alice,bob \
-    --quic-cert server.pem --quic-key server.key
+    --quic-cert server.pem --quic-key server.key --license /path/to/license.key
 ```
 
 Admin users have access to `$DB/_admin/*` topics (schema, constraints, backup), `$DB/_oauth_tokens/*` topics, and internal entities (`_sessions`, `_mqtt_subs`, etc.).
@@ -649,7 +671,7 @@ The `database_operation` span links to the W3C `traceparent` from the incoming M
 
 Any OTLP-compatible collector works: Jaeger, Grafana Tempo, Datadog, Honeycomb, AWS X-Ray (via ADOT collector).
 
-## Distributed Clustering (Native Edition)
+## Distributed Clustering
 
 > Clustering requires the `cluster` feature on the `mqdb` CLI (enabled by default). To build without cluster code, use `--no-default-features` (and add `--features http-api` to keep the HTTP server).
 
@@ -664,17 +686,20 @@ MQDB supports distributed clustering with automatic failover and partition rebal
 # Node 1 (first node becomes Raft leader)
 ./target/release/mqdb cluster start --node-id 1 --bind 127.0.0.1:1883 \
     --db /tmp/mqdb-node1 \
-    --quic-cert test_certs/server.pem --quic-key test_certs/server.key --quic-ca test_certs/ca.pem
+    --quic-cert test_certs/server.pem --quic-key test_certs/server.key --quic-ca test_certs/ca.pem \
+    --license /path/to/license.key
 
 # Node 2 (joins via peer)
 ./target/release/mqdb cluster start --node-id 2 --bind 127.0.0.1:1884 \
     --db /tmp/mqdb-node2 --peers "1@127.0.0.1:1883" \
-    --quic-cert test_certs/server.pem --quic-key test_certs/server.key --quic-ca test_certs/ca.pem
+    --quic-cert test_certs/server.pem --quic-key test_certs/server.key --quic-ca test_certs/ca.pem \
+    --license /path/to/license.key
 
 # Node 3 (joins via peer)
 ./target/release/mqdb cluster start --node-id 3 --bind 127.0.0.1:1885 \
     --db /tmp/mqdb-node3 --peers "1@127.0.0.1:1883" \
-    --quic-cert test_certs/server.pem --quic-key test_certs/server.key --quic-ca test_certs/ca.pem
+    --quic-cert test_certs/server.pem --quic-key test_certs/server.key --quic-ca test_certs/ca.pem \
+    --license /path/to/license.key
 ```
 
 ### Cluster CLI Commands
@@ -682,7 +707,7 @@ MQDB supports distributed clustering with automatic failover and partition rebal
 ```bash
 # Start a cluster node
 mqdb cluster start --node-id 1 --bind 0.0.0.0:1883 --db ./data/node1 \
-    --quic-cert server.pem --quic-key server.key
+    --quic-cert server.pem --quic-key server.key --license /path/to/license.key
 
 # Check cluster status
 mqdb cluster status
@@ -733,7 +758,7 @@ When `--quic-ca` is provided, the cluster transport enables mTLS: each node veri
 
 ```bash
 # Start a 3-node cluster with mTLS (QUIC transport is the default)
-mqdb dev start-cluster --nodes 3 --clean
+mqdb dev start-cluster --nodes 3 --clean --license /path/to/license.key
 ```
 
 ### Data Persistence
@@ -804,6 +829,8 @@ Every CLI flag can be set via environment variable. This is the primary configur
 | `MQDB_DURABILITY` | `immediate`, `periodic`, or `none` | `periodic` |
 | `MQDB_DURABILITY_MS` | Fsync interval in ms | `10` |
 | `MQDB_OWNERSHIP` | Ownership config (`entity=field` pairs) | — |
+| `MQDB_OWNERSHIP_DERIVE` | Child-entity access derivation (`child=field>parent` pairs, agent mode only) | — |
+| `MQDB_SCOPED_EVENTS` | Route change events to per-recipient topics for ownership-enabled entities (agent mode only) | `false` |
 | `MQDB_EVENT_SCOPE` | Scope events by entity field | — |
 | `MQDB_WS_BIND` | WebSocket bind address | — |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,19 @@
 # Security Policy
 
+How to report a vulnerability in MQDB and which versions receive fixes.
+
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| 0.1.x   | Yes       |
+Only the latest released version of each crate receives security fixes. Current versions:
+
+| Crate        | Version |
+|--------------|---------|
+| mqdb-cli     | 0.8.13  |
+| mqdb-core    | 0.7.3   |
+| mqdb-cluster | 0.3.7   |
+| mqdb-agent   | 0.8.10  |
+| mqdb-wasm    | 0.3.4   |
+| mqdb-vault   | 0.1.2   |
 
 ## Reporting a Vulnerability
 

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.8.10"
+version = "0.8.11"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-agent/src/agent/tasks.rs
+++ b/crates/mqdb-agent/src/agent/tasks.rs
@@ -18,7 +18,7 @@ impl MqdbAgent {
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         let shutdown_tx = self.shutdown_tx.clone();
         Some(tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(3600));
+            let mut interval = tokio::time::interval(Duration::from_hours(1));
             interval.tick().await;
             loop {
                 tokio::select! {

--- a/crates/mqdb-agent/src/database/crud.rs
+++ b/crates/mqdb-agent/src/database/crud.rs
@@ -719,6 +719,7 @@ mod concurrency_tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_updates_to_distinct_fields_all_converge() {
+        const WRITERS: usize = 16;
         let (_tmp, db) = test_db().await;
         let scope = ScopeConfig::default();
         db.create(
@@ -732,7 +733,6 @@ mod concurrency_tests {
         .await
         .unwrap();
 
-        const WRITERS: usize = 16;
         let mut handles = Vec::with_capacity(WRITERS);
         for i in 0..WRITERS {
             let db = Arc::clone(&db);
@@ -780,13 +780,13 @@ mod concurrency_tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn concurrent_delete_and_update_leave_no_stale_index() {
+        const ROUNDS: usize = 200;
         let (_tmp, db) = test_db().await;
         let scope = ScopeConfig::default();
         db.add_index("item".to_string(), vec!["tag".to_string()])
             .await
             .unwrap();
 
-        const ROUNDS: usize = 200;
         for round in 0..ROUNDS {
             let id = format!("i{round}");
             db.create(

--- a/crates/mqdb-agent/src/http/server.rs
+++ b/crates/mqdb-agent/src/http/server.rs
@@ -426,7 +426,7 @@ async fn spawn_receipt_handler(state: Arc<ServerState>) {
 
 fn spawn_challenge_cleanup(state: Arc<ServerState>) {
     tokio::spawn(async move {
-        let mut interval = tokio::time::interval(std::time::Duration::from_secs(300));
+        let mut interval = tokio::time::interval(std::time::Duration::from_mins(5));
         loop {
             interval.tick().await;
             handlers::cleanup_expired_challenges(&state).await;

--- a/crates/mqdb-agent/tests/integration_test.rs
+++ b/crates/mqdb-agent/tests/integration_test.rs
@@ -2803,13 +2803,11 @@ async fn test_cascade_delete_events_carry_recipients() {
 
     let mut recipients_by_entity: HashMap<String, Vec<String>> = HashMap::new();
     while recipients_by_entity.len() < 2 {
-        let event =
-            match tokio::time::timeout(tokio::time::Duration::from_millis(500), receiver.recv())
-                .await
-            {
-                Ok(Ok(event)) => event,
-                _ => break,
-            };
+        let Ok(Ok(event)) =
+            tokio::time::timeout(tokio::time::Duration::from_millis(500), receiver.recv()).await
+        else {
+            break;
+        };
         if event.entity == "diagrams" || event.entity == "nodes" {
             let mut recipients = event
                 .recipients

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.13"
+version = "0.8.14"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cli/src/commands/bench/db_cascade.rs
+++ b/crates/mqdb-cli/src/commands/bench/db_cascade.rs
@@ -145,9 +145,9 @@ pub(crate) async fn cmd_bench_db_cascade(
             v.push(delete_elapsed);
         }
 
-        let wait_result = tokio::time::timeout(Duration::from_secs(60), done_rx.recv_async()).await;
+        let wait_result = tokio::time::timeout(Duration::from_mins(1), done_rx.recv_async()).await;
         if wait_result.is_err() {
-            let remaining = pending_children.lock().map(|s| s.len()).unwrap_or(0);
+            let remaining = pending_children.lock().map_or(0, |s| s.len());
             total_events_missing.fetch_add(remaining as u64, Ordering::Relaxed);
         }
 

--- a/crates/mqdb-cli/src/commands/dev/tests.rs
+++ b/crates/mqdb-cli/src/commands/dev/tests.rs
@@ -161,7 +161,7 @@ fn run_test_db(nodes: u8, ports: &[u16]) {
         let data = format!(r#"{{"name": "User{node}", "node": {node}}}"#);
         let create_output = mqdb_cmd(&exe, &["create", "test_users", "-d", &data], port);
 
-        let created = create_output.map(|o| o.status.success()).unwrap_or(false);
+        let created = create_output.is_ok_and(|o| o.status.success());
 
         if created {
             println!("  Create via Node {node}: ✓");
@@ -177,12 +177,10 @@ fn run_test_db(nodes: u8, ports: &[u16]) {
         let filter = format!("node={node}");
         let list_output = mqdb_cmd(&exe, &["list", "test_users", "-f", &filter], read_port);
 
-        let can_read = list_output
-            .map(|o| {
-                let stdout = String::from_utf8_lossy(&o.stdout);
-                stdout.contains(&format!("User{node}"))
-            })
-            .unwrap_or(false);
+        let can_read = list_output.is_ok_and(|o| {
+            let stdout = String::from_utf8_lossy(&o.stdout);
+            stdout.contains(&format!("User{node}"))
+        });
 
         if can_read {
             println!("  Read from Node {read_node} (created on {node}): ✓");
@@ -216,10 +214,7 @@ fn run_test_constraints(nodes: u8, ports: &[u16]) {
     let mut passed = 0;
     let mut failed = 0;
 
-    let ts = std::time::UNIX_EPOCH
-        .elapsed()
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
+    let ts = std::time::UNIX_EPOCH.elapsed().map_or(0, |d| d.as_millis());
     let entity = format!("test_products_{ts}");
     let constraint_name = format!("unique_{entity}_sku");
 
@@ -237,13 +232,10 @@ fn run_test_constraints(nodes: u8, ports: &[u16]) {
         ports[0],
     );
 
-    let constraint_added = add_output
-        .as_ref()
-        .map(|o| {
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            stdout.contains("constraint added") || stdout.contains("\"status\":\"ok\"")
-        })
-        .unwrap_or(false);
+    let constraint_added = add_output.as_ref().is_ok_and(|o| {
+        let stdout = String::from_utf8_lossy(&o.stdout);
+        stdout.contains("constraint added") || stdout.contains("\"status\":\"ok\"")
+    });
 
     if constraint_added {
         println!("  Add unique constraint via Node 1: ✓");
@@ -272,7 +264,7 @@ fn run_test_constraints(nodes: u8, ports: &[u16]) {
         ports[0],
     );
 
-    let first_created = create1.map(|o| o.status.success()).unwrap_or(false);
+    let first_created = create1.is_ok_and(|o| o.status.success());
 
     if first_created {
         println!("  Create first product (SKU-001) via Node 1: ✓");
@@ -295,18 +287,16 @@ fn run_test_constraints(nodes: u8, ports: &[u16]) {
         ports[0],
     );
 
-    let dup_rejected = create_dup
-        .map(|o| {
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            let stderr = String::from_utf8_lossy(&o.stderr);
-            let combined = format!("{stdout}{stderr}").to_lowercase();
-            !o.status.success()
-                || combined.contains("unique")
-                || combined.contains("conflict")
-                || combined.contains("duplicate")
-                || combined.contains("constraint")
-        })
-        .unwrap_or(false);
+    let dup_rejected = create_dup.is_ok_and(|o| {
+        let stdout = String::from_utf8_lossy(&o.stdout);
+        let stderr = String::from_utf8_lossy(&o.stderr);
+        let combined = format!("{stdout}{stderr}").to_lowercase();
+        !o.status.success()
+            || combined.contains("unique")
+            || combined.contains("conflict")
+            || combined.contains("duplicate")
+            || combined.contains("constraint")
+    });
 
     if dup_rejected {
         println!("  Duplicate SKU-001 rejected: ✓");
@@ -330,10 +320,7 @@ fn run_test_wildcards(nodes: u8, ports: &[u16]) {
     let src_node = ports.len();
     let dst_node = 1;
 
-    let ts = std::time::UNIX_EPOCH
-        .elapsed()
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
+    let ts = std::time::UNIX_EPOCH.elapsed().map_or(0, |d| d.as_millis());
     let sub_id = format!("wild_sub_{ts}");
     let pub_id = format!("wild_pub_{ts}");
 
@@ -348,10 +335,7 @@ fn run_test_wildcards(nodes: u8, ports: &[u16]) {
         ])
         .output();
 
-    if single_level
-        .map(|o| String::from_utf8_lossy(&o.stdout).contains("single_level_ok"))
-        .unwrap_or(false)
-    {
+    if single_level.is_ok_and(|o| String::from_utf8_lossy(&o.stdout).contains("single_level_ok")) {
         println!("  Single-level (+) Node {src_node} → Node {dst_node}: ✓");
         passed += 1;
     } else {
@@ -372,10 +356,7 @@ fn run_test_wildcards(nodes: u8, ports: &[u16]) {
         ])
         .output();
 
-    if multi_level
-        .map(|o| String::from_utf8_lossy(&o.stdout).contains("multi_level_ok"))
-        .unwrap_or(false)
-    {
+    if multi_level.is_ok_and(|o| String::from_utf8_lossy(&o.stdout).contains("multi_level_ok")) {
         println!("  Multi-level (#) Node {src_node} → Node {dst_node}: ✓");
         passed += 1;
     } else {
@@ -392,10 +373,7 @@ fn run_test_retained(nodes: u8, ports: &[u16]) {
     let mut passed = 0;
     let mut failed = 0;
 
-    let ts = std::time::UNIX_EPOCH
-        .elapsed()
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
+    let ts = std::time::UNIX_EPOCH.elapsed().map_or(0, |d| d.as_millis());
     let topic = format!("retained/test/{ts}");
     let msg = format!("retained_msg_{ts}");
 
@@ -422,7 +400,7 @@ fn run_test_retained(nodes: u8, ports: &[u16]) {
         ])
         .output();
 
-    std::thread::sleep(std::time::Duration::from_millis(1000));
+    std::thread::sleep(std::time::Duration::from_secs(1));
 
     let sub_output = Command::new("timeout")
         .args([
@@ -443,9 +421,7 @@ fn run_test_retained(nodes: u8, ports: &[u16]) {
         ])
         .output();
 
-    let received = sub_output
-        .map(|o| String::from_utf8_lossy(&o.stdout).contains(&msg))
-        .unwrap_or(false);
+    let received = sub_output.is_ok_and(|o| String::from_utf8_lossy(&o.stdout).contains(&msg));
 
     if received {
         println!(
@@ -488,10 +464,7 @@ fn run_test_lwt(nodes: u8, ports: &[u16]) {
     let mut passed = 0;
     let mut failed = 0;
 
-    let ts = std::time::UNIX_EPOCH
-        .elapsed()
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
+    let ts = std::time::UNIX_EPOCH.elapsed().map_or(0, |d| d.as_millis());
     let will_topic = format!("lwt/status/{ts}");
     let will_msg = format!("client_offline_{ts}");
 
@@ -512,9 +485,7 @@ fn run_test_lwt(nodes: u8, ports: &[u16]) {
         ])
         .output();
 
-    let received = lwt_output
-        .map(|o| String::from_utf8_lossy(&o.stdout).contains(&will_msg))
-        .unwrap_or(false);
+    let received = lwt_output.is_ok_and(|o| String::from_utf8_lossy(&o.stdout).contains(&will_msg));
 
     if received {
         println!("  LWT from Node 1 received on Node {}: ✓", ports.len());
@@ -531,8 +502,7 @@ fn run_pubsub_test(pub_port: u16, sub_port: u16, topic: &str, msg: &str) -> bool
     use std::time::{SystemTime, UNIX_EPOCH};
     let ts = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_millis());
     let sub_client_id = format!("sub-{sub_port}-{ts}");
     let pub_client_id = format!("pub-{pub_port}-{ts}");
     let output = Command::new("timeout")
@@ -620,10 +590,7 @@ fn run_test_ownership(nodes: u8, _ports: &[u16], license: Option<&Path>) {
             .output();
     }
 
-    let ts = std::time::UNIX_EPOCH
-        .elapsed()
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
+    let ts = std::time::UNIX_EPOCH.elapsed().map_or(0, |d| d.as_millis());
     let entity = format!("test_owned_{ts}");
     let ownership_spec = format!("{entity}=userId");
 
@@ -990,10 +957,7 @@ fn run_test_stress_constraints(nodes: u8, ports: &[u16]) {
     let mut passed = 0;
     let mut failed = 0;
 
-    let ts = std::time::UNIX_EPOCH
-        .elapsed()
-        .map(|d| d.as_millis())
-        .unwrap_or(0);
+    let ts = std::time::UNIX_EPOCH.elapsed().map_or(0, |d| d.as_millis());
     let entity = format!("stress_products_{ts}");
     let constraint_name = format!("unique_{entity}_sku");
 
@@ -1011,13 +975,10 @@ fn run_test_stress_constraints(nodes: u8, ports: &[u16]) {
         ports[0],
     );
 
-    let constraint_added = add_output
-        .as_ref()
-        .map(|o| {
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            stdout.contains("constraint added") || stdout.contains("\"status\":\"ok\"")
-        })
-        .unwrap_or(false);
+    let constraint_added = add_output.as_ref().is_ok_and(|o| {
+        let stdout = String::from_utf8_lossy(&o.stdout);
+        stdout.contains("constraint added") || stdout.contains("\"status\":\"ok\"")
+    });
 
     if !constraint_added {
         println!("  Add unique constraint: ✗ (aborting stress test)");
@@ -1053,7 +1014,7 @@ fn run_test_stress_constraints(nodes: u8, ports: &[u16]) {
                 let data = format!(r#"{{"name": "Item {sku}", "sku": "{sku}"}}"#);
                 let result = mqdb_cmd(&exe, &["create", &entity, "-d", &data], port);
 
-                if result.map(|o| o.status.success()).unwrap_or(false) {
+                if result.is_ok_and(|o| o.status.success()) {
                     successes += 1;
                 } else {
                     failures += 1;
@@ -1102,7 +1063,7 @@ fn run_test_stress_constraints(nodes: u8, ports: &[u16]) {
         conflict_handles.push(std::thread::spawn(move || {
             let data = format!(r#"{{"name": "Conflict Item {i}", "sku": "{sku}"}}"#);
             let result = mqdb_cmd(&exe, &["create", &entity, "-d", &data], port);
-            result.map(|o| o.status.success()).unwrap_or(false)
+            result.is_ok_and(|o| o.status.success())
         }));
     }
 

--- a/crates/mqdb-cluster/Cargo.toml
+++ b/crates/mqdb-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cluster"
-version = "0.3.7"
+version = "0.3.8"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/src/cluster/client_location.rs
+++ b/crates/mqdb-cluster/src/cluster/client_location.rs
@@ -24,8 +24,7 @@ impl ClientLocationEntry {
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_millis() as u64);
         let client_bytes = client_id.as_bytes().to_vec();
         Self {
             version: 2,

--- a/crates/mqdb-cluster/src/cluster/db/data_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/data_store.rs
@@ -603,7 +603,7 @@ impl FkReverseIndex {
 
 impl std::fmt::Debug for FkReverseIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let count = self.index.lock().map(|m| m.len()).unwrap_or(0);
+        let count = self.index.lock().map_or(0, |m| m.len());
         f.debug_struct("FkReverseIndex")
             .field("entries", &count)
             .finish()

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -1470,8 +1470,7 @@ impl<T: ClusterTransport> NodeController<T> {
         {
             let now = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0);
+                .map_or(0, |d| d.as_secs());
             let expires_at = now + ttl_secs;
             obj.insert(
                 "_expires_at".to_string(),

--- a/crates/mqdb-cluster/src/cluster/protocol/broadcast.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/broadcast.rs
@@ -53,8 +53,7 @@ impl WildcardBroadcast {
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_millis() as u64);
         Self {
             version: Self::VERSION,
             operation: WildcardOp::Subscribe as u8,
@@ -75,8 +74,7 @@ impl WildcardBroadcast {
         use std::time::{SystemTime, UNIX_EPOCH};
         let timestamp_ms = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map(|d| d.as_millis() as u64)
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_millis() as u64);
         Self {
             version: Self::VERSION,
             operation: WildcardOp::Unsubscribe as u8,

--- a/crates/mqdb-cluster/src/cluster/raft_task.rs
+++ b/crates/mqdb-cluster/src/cluster/raft_task.rs
@@ -16,8 +16,7 @@ use super::raft::PartitionUpdate;
 fn current_time_ms() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_millis() as u64)
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_millis() as u64)
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/mqdb-cluster/src/cluster/store_manager/outbox.rs
+++ b/crates/mqdb-cluster/src/cluster/store_manager/outbox.rs
@@ -42,8 +42,7 @@ impl ClusterOutbox {
             user_properties: user_properties.to_vec(),
             created_at: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
+                .map_or(0, |d| d.as_secs()),
         };
         let value = serde_json::to_vec(&stored).unwrap_or_default();
         (key.into_bytes(), value)
@@ -117,8 +116,7 @@ impl ClusterOutbox {
             operations: ops.to_vec(),
             created_at: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
+                .map_or(0, |d| d.as_secs()),
         };
         let value = serde_json::to_vec(&stored).unwrap_or_default();
         (key.into_bytes(), value)

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -76,15 +76,15 @@ impl ClusteredAgent {
         let mut tick_interval = interval(Duration::from_millis(10));
         let mut cleanup_interval = interval(Duration::from_secs(CLEANUP_INTERVAL_SECS));
         let mut ttl_cleanup_interval = interval(Duration::from_secs(TTL_CLEANUP_INTERVAL_SECS));
-        let mut wildcard_reconciliation_interval = interval(Duration::from_secs(60));
-        let mut subscription_reconciliation_interval = interval(Duration::from_secs(300));
+        let mut wildcard_reconciliation_interval = interval(Duration::from_mins(1));
+        let mut subscription_reconciliation_interval = interval(Duration::from_mins(5));
         let mut retained_sync_cleanup_interval =
             interval(Duration::from_secs(RETAINED_SYNC_CLEANUP_INTERVAL_SECS));
         let mut cascade_retry_interval = tokio::time::interval_at(
             tokio::time::Instant::now() + Duration::from_secs(30),
             Duration::from_secs(30),
         );
-        let mut license_check_interval = interval(Duration::from_secs(3600));
+        let mut license_check_interval = interval(Duration::from_hours(1));
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         let tx_tick = self
             .tx_tick
@@ -450,8 +450,7 @@ impl ClusteredAgent {
     async fn handle_ttl_cleanup(&self) {
         let now_secs = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         let ctrl = self.controller.read().await;
         let expired_ttl = ctrl.stores().db_data.cleanup_expired_ttl(now_secs);
         if !expired_ttl.is_empty() {

--- a/crates/mqdb-cluster/tests/mqtt_cluster_test.rs
+++ b/crates/mqdb-cluster/tests/mqtt_cluster_test.rs
@@ -232,7 +232,7 @@ async fn mqtt_lwt_death_detection() {
     dying_node.disconnect_abnormally().await.unwrap();
     drop(dying_node);
 
-    tokio::time::sleep(Duration::from_millis(2000)).await;
+    tokio::time::sleep(Duration::from_secs(2)).await;
 
     assert!(
         death_notice_received.load(Ordering::SeqCst),

--- a/crates/mqdb-core/src/outbox.rs
+++ b/crates/mqdb-core/src/outbox.rs
@@ -46,8 +46,7 @@ impl Outbox {
             retry_count: 0,
             created_at: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_secs())
-                .unwrap_or(0),
+                .map_or(0, |d| d.as_secs()),
             dispatched_count: 0,
         };
         let value = serde_json::to_vec(&stored).unwrap_or_default();

--- a/crates/mqdb-vault/Cargo.toml
+++ b/crates/mqdb-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-vault"
-version = "0.1.2"
+version = "0.1.3"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-vault/tests/backend_integration.rs
+++ b/crates/mqdb-vault/tests/backend_integration.rs
@@ -395,6 +395,26 @@ async fn admin_unlock_skips_re_encrypt_when_records_already_rotated() {
     assert_eq!(decrypted["body"], "secret");
 }
 
+async fn read_decrypted(
+    db: &Database,
+    backend: &VaultBackendImpl,
+    ownership: &OwnershipConfig,
+    id: &str,
+) -> serde_json::Value {
+    let stored = db
+        .read("notes".to_string(), id.to_string(), vec![], None)
+        .await
+        .expect("read");
+    let mut resp = Response::Ok { data: stored };
+    backend
+        .decrypt_response("notes", DbOp::Read, ownership, Some("u1"), &mut resp)
+        .await;
+    let Response::Ok { data } = resp else {
+        panic!("expected Ok");
+    };
+    data
+}
+
 #[tokio::test]
 async fn admin_unlock_resume_strands_unrotated_records_after_mid_batch_crash() {
     use base64::Engine as _;
@@ -478,59 +498,13 @@ async fn admin_unlock_resume_strands_unrotated_records_after_mid_batch_crash() {
         "resume must clear the pending marker"
     );
 
-    let rotated_stored = db
-        .read(
-            "notes".to_string(),
-            "note-rotated".to_string(),
-            vec![],
-            None,
-        )
-        .await
-        .expect("read rotated");
-    let mut rotated_resp = Response::Ok {
-        data: rotated_stored,
-    };
-    backend
-        .decrypt_response(
-            "notes",
-            DbOp::Read,
-            &ownership,
-            Some("u1"),
-            &mut rotated_resp,
-        )
-        .await;
-    let Response::Ok { data: rotated_dec } = rotated_resp else {
-        panic!("expected Ok");
-    };
+    let rotated_dec = read_decrypted(&db, &backend, &ownership, "note-rotated").await;
     assert_eq!(
         rotated_dec["title"], "rotated",
         "already-rotated record must stay readable under the new key, not be double-encrypted"
     );
 
-    let stranded_stored = db
-        .read(
-            "notes".to_string(),
-            "note-stranded".to_string(),
-            vec![],
-            None,
-        )
-        .await
-        .expect("read stranded");
-    let mut stranded_resp = Response::Ok {
-        data: stranded_stored,
-    };
-    backend
-        .decrypt_response(
-            "notes",
-            DbOp::Read,
-            &ownership,
-            Some("u1"),
-            &mut stranded_resp,
-        )
-        .await;
-    let Response::Ok { data: stranded_dec } = stranded_resp else {
-        panic!("expected Ok");
-    };
+    let stranded_dec = read_decrypted(&db, &backend, &ownership, "note-stranded").await;
     assert_ne!(
         stranded_dec["title"], "stranded",
         "records left under the old key by a mid-batch crash are unrecoverable after resume"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -27,6 +27,8 @@ MQDB is a message-oriented reactive database built in Rust that combines:
 
 MQDB prioritizes correctness and simplicity over raw performance and feature count. The architecture reflects this through explicit error handling, clear component boundaries, and incremental feature additions.
 
+This document focuses on the single-node agent architecture; cluster-specific behavior is covered in section 9 and `docs/distributed-design.md`.
+
 ---
 
 ## 2. High-Level Architecture
@@ -57,7 +59,7 @@ MQDB prioritizes correctness and simplicity over raw performance and feature cou
 │  BatchWriter │ Transactions │ Durability        │
 ├─────────────────────────────────────────────────┤
 │    Fjall (Native) │ Memory (WASM/Testing)       │
-│  LSM Persistence  │  In-Memory HashMap          │
+│  LSM Persistence  │  In-Memory BTreeMap         │
 └─────────────────────────────────────────────────┘
 ```
 
@@ -134,7 +136,7 @@ For asynchronous contexts, `AsyncStorageBackend` and `AsyncBatchOperations` trai
 | Backend | Use Case | Persistence | Platform | Internal Implementation |
 |---------|----------|-------------|----------|-------------------------|
 | `FjallBackend` | Production | LSM-based disk | Native | `fjall::Database` with `Keyspace` |
-| `MemoryBackend` | Testing/WASM | In-memory HashMap | All | `std::collections::BTreeMap` |
+| `MemoryBackend` | Testing/WASM | In-memory BTreeMap | All | `std::collections::BTreeMap` |
 
 **Key Features:**
 - `BatchOperations` for atomic multi-key operations
@@ -1143,18 +1145,7 @@ Payload: {"ok": true, "data": {"id": "1", "name": "Alice"}}
 
 **Current Implementation:**
 
-The `StorageBackend` trait enables pluggable persistence:
-
-```rust
-pub trait StorageBackend: Send + Sync {
-    fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>>;
-    fn insert(&self, key: &[u8], value: &[u8]) -> Result<()>;
-    fn remove(&self, key: &[u8]) -> Result<()>;
-    fn prefix_scan(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>>;
-    fn batch(&self) -> Box<dyn BatchWriter>;
-    fn flush(&self) -> Result<()>;
-}
-```
+The `StorageBackend` trait enables pluggable persistence. See section 3.1 for the full trait definition, including the scan variants (`prefix_scan_keys`, `prefix_scan_batch`, `range_scan`) and `BatchOperations`.
 
 **Available Backends:**
 
@@ -1227,7 +1218,7 @@ In cluster mode, the `StorageBackend` trait is used by multiple subsystems:
 - Uses `DurabilityMode::Immediate` for consensus safety
 - Path: `{db_path}/raft/`
 
-**Cluster Stores** (`crates/mqdb-cluster/src/cluster/store_manager.rs`):
+**Cluster Stores** (`crates/mqdb-cluster/src/cluster/store_manager/`):
 - Manages 17 distinct stores for MQTT and database state
 - Uses configurable durability (default: `PeriodicMs(10)`)
 - Path: `{db_path}/stores/`
@@ -1296,7 +1287,7 @@ $DB/{entity}/create → ClusteredAgent → NodeController → Partition primary 
 
 The `$DB/` topic prefix is handled by both modes, ensuring client applications work transparently.
 
-For detailed cluster architecture, see `DISTRIBUTED_DESIGN.md`.
+For detailed cluster architecture, see `docs/distributed-design.md`.
 
 ---
 
@@ -1311,7 +1302,7 @@ For detailed cluster architecture, see `DISTRIBUTED_DESIGN.md`.
 | Updates   | 191k/s     | 0.00ms      | 0.01ms      | 0.01ms      |
 | List/Scan | 91/s       | 10.96ms     | -           | -           |
 
-Note: These benchmarks are for single-node agent mode. For cluster mode performance characteristics, see `DISTRIBUTED_DESIGN.md` section A6.
+Note: These benchmarks are for single-node agent mode. For cluster mode performance characteristics, see `docs/distributed-design.md` section A6.
 
 ### Bottlenecks
 
@@ -1380,6 +1371,8 @@ pub enum Error {
     ForeignKeyRestrict { entity, id, referencing_entity },
     NotNullViolation { entity, field },
     InvalidForeignKey,            // FK value not a string
+    Forbidden(String),            // Ownership/authorization denial
+    CascadeBlocked(Box<CascadeBlockedInfo>), // Cross-owned entity has non-nullable FK
 }
 ```
 
@@ -1483,20 +1476,15 @@ DatabaseConfig::new("db")
 
 ## 13. Testing Strategy
 
-### Test Coverage: 683+ Tests
+### Test Coverage
+
+Run `cargo make test` for the current, authoritative counts across all suites.
 
 **Major Test Suites:**
-- 472 unit tests (library components including cluster modules)
-- 68 protocol/encoding tests
-- 49 subscription/topic tests
-- Integration tests:
-  - 25 constraint tests
-  - 17 CRUD + features
-  - 13 crash recovery
-  - 7 point-to-point delivery
-  - 6 transaction tests
-  - 4 concurrency tests
-  - 4 cluster integration tests
+- Unit tests (library components including cluster modules)
+- Protocol/encoding tests
+- Subscription/topic tests
+- Integration tests: constraints, CRUD + features, crash recovery, point-to-point delivery, transactions, concurrency, cluster integration
 
 ### Test Categories
 
@@ -1517,13 +1505,13 @@ DatabaseConfig::new("db")
 - `durability_test.rs`: Fsync behavior, crash simulation
 - `point_to_point_test.rs`: Shared subscriptions, consumer groups, heartbeat
 
-**3. Constraint Tests (25 tests):**
-- NOT NULL: 4 tests (create/update violations, success)
-- Unique: 6 tests (single, composite, concurrent, update)
-- Foreign Key: 8 tests (valid, invalid, null, CASCADE, RESTRICT, SET_NULL, multilevel)
-- Schema: 3 tests (type validation, required, defaults)
-- Persistence: 4 tests (survive restart)
-- Combined: 1 test (all constraints together)
+**3. Constraint Tests (`constraint_test.rs`):**
+- NOT NULL (create/update violations, success)
+- Unique (single, composite, concurrent, update)
+- Foreign Key (valid, invalid, null, CASCADE, RESTRICT, SET_NULL, multilevel)
+- Schema (type validation, required, defaults)
+- Persistence (survive restart)
+- Combined (all constraints together)
 
 ### Test Patterns
 
@@ -1699,7 +1687,7 @@ Located in `crates/mqdb-agent/src/topic_rules.rs`:
 | `$DB/_unique/#` | BlockAll | Unique constraint enforcement |
 | `$DB/_fk/#` | BlockAll | Foreign key validation |
 | `$DB/_query/#` | BlockAll | Query execution internals |
-| `$DB/p+/#` | BlockAll | Partition-specific topics (p0, p1, ..., p63) |
+| `$DB/p+/#` | BlockAll | Partition-specific topics (p0, p1, ..., p255) |
 | `$SYS/#` | ReadOnly | Broker statistics, monitoring |
 | `$DB/_admin/#` | AdminRequired | Schema, constraints, backup operations |
 | `$DB/_oauth_tokens/#` | AdminRequired | OAuth token storage |
@@ -1939,7 +1927,7 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for development guidelines.
 
 ## Related Documentation
 
-- **DISTRIBUTED_DESIGN.md** - Detailed cluster architecture and design decisions
-- **IMPLEMENTATION_PLAN.md** - Milestone plan (all M1-M10 complete)
-- **COMPLETE_MATRIX_DOC.md** - Benchmark specification
+- **docs/distributed-design.md** - Detailed cluster architecture and design decisions
+- **docs/implementation-plan.md** - Milestone plan (all M1-M10 complete)
+- **docs/benchmarks/matrix-spec.md** - Benchmark specification
 - **README.md** - User-facing documentation with examples

--- a/docs/benchmarks/issue-11.15-bridge-overhead.md
+++ b/docs/benchmarks/issue-11.15-bridge-overhead.md
@@ -1,0 +1,97 @@
+# Investigation: Issue 11.15 - Bridge Overhead Root Cause Analysis
+
+### Summary
+
+**Original Hypothesis**: RwLock contention causes 3-4x slowdown on nodes with 2 bridges.
+
+**Conclusion**: RwLock contention hypothesis **DISPROVEN**. The actual root cause is **CPU contention from cluster message processing competing with client request handling on the main runtime**.
+
+### Evidence
+
+#### Lock Wait Times (t_lock) Are NOT the Bottleneck
+
+| Node | Bridges | Throughput | Avg t_lock | Avg t_handle |
+|------|---------|------------|------------|--------------|
+| Node 1 | 2 | 1353 ops/s | 0.23 µs | 55.68 µs |
+| Node 2 | 1 | - | 1.24 µs | 57.17 µs |
+| Node 3 | 0 | 4222 ops/s | 1.82 µs | 54.26 µs |
+
+**Node 3 (fastest) has the HIGHEST t_lock!** This disproves lock contention as the cause.
+
+#### Cluster Message Volume IS the Differentiator
+
+| Node | Bridges | Total Cluster Msgs | DB Operations | Ratio |
+|------|---------|-------------------|---------------|-------|
+| Node 1 | 2 | 42,685 | 23,076 | 1.85:1 |
+| Node 3 | 0 | 14,233 | 148,051 | 0.096:1 |
+
+Node 1 processes **3x more cluster messages** and performs **6x fewer DB operations**.
+
+#### Message Type Distribution
+
+Node 1 (leader, 2 bridges):
+- Write: 13,393 (sends replication to replicas)
+- Ack: 23,094 (receives acks from replicas)
+- Heartbeat: 3,618
+- Raft: 1,216
+
+Node 3 (0 bridges):
+- Write: 28 (almost none)
+- Ack: 10,825
+- Heartbeat: 1,465
+- Raft: 1,426
+
+#### Queue Depth (No Backlog)
+
+| Node | Avg Queue Depth | Max Queue Depth |
+|------|-----------------|-----------------|
+| Node 1 | 1.30 | 25 |
+| Node 2 | 1.00 | 4 |
+| Node 3 | 1.02 | 15 |
+
+Messages are processed quickly - the issue is CPU time spent processing them.
+
+### Current Architecture
+
+1. **DedicatedExecutor** handles bridge network I/O (read/write from QUIC connections)
+2. Bridge callbacks invoke `route_message_local_only()` which publishes to local broker
+3. **Main runtime** handles:
+   - Local broker message routing
+   - `process_messages()` loop consuming from flume channel
+   - Client request handling (DB operations)
+4. All post-receive processing runs on main runtime, competing for CPU
+
+### Hypotheses Evaluated
+
+| # | Hypothesis | Evidence For | Evidence Against | Conclusion |
+|---|------------|--------------|------------------|------------|
+| H1 | Split the lock | None | t_lock avg < 2µs on ALL nodes; Node 3 (fastest) has highest t_lock | **REJECTED** |
+| H2 | Message batching | None | Processing time per message is similar across nodes | **REJECTED** |
+| H3 | Defer bridge processing | Queue depth low (avg ~1) | No message backlog building up | **REJECTED** |
+| H4 | Read lock for reads | Not tested (DEBUG level) | t_lock is already minimal | **UNLIKELY** |
+
+### Recommended Fix Approaches
+
+1. **Separate cluster message consumer** (RECOMMENDED)
+   - Move `process_messages()` to dedicated executor
+   - Use flume channel for cross-runtime communication (already in place)
+   - Clean separation of cluster traffic from client request handling
+
+2. **Batch replication writes**
+   - Combine multiple DB writes into single replication message
+   - Reduces message count and serialization overhead
+   - Increases write latency
+
+### What NOT to Do
+
+Based on the data, these approaches would NOT help:
+- Splitting the RwLock (lock times already sub-microsecond)
+- Using read locks for reads (lock contention is not the issue)
+- Deferring bridge processing (queue depth already low)
+- Reducing batch size (processing efficiency is already good)
+
+### QoS Considerations
+
+- Cluster Write/Ack messages use QoS 0 (`AtMostOnce`)
+- QoS 0 is single-trip (no PUBACK)
+- QoS level doesn't significantly affect DB operation overhead

--- a/docs/benchmarks/matrix-results.md
+++ b/docs/benchmarks/matrix-results.md
@@ -1,6 +1,8 @@
 # MQDB Benchmark Results - 2026-03-20
 
 **Date:** 2026-03-20
+**MQDB version / commit:** <record at run time — exact git commit not captured for this run>
+**Build features:** default (cluster, http-api)
 **Transport:** Direct QUIC (mTLS)
 **Methodology:** Triplicate runs per experiment, mean +/- stdev reported
 **Platform:** macOS (Darwin 25.3.0), local loopback
@@ -361,6 +363,8 @@ Coefficient of variation (stdev/mean) across nodes within each topology, for asy
 | Parameter | Value |
 |-----------|-------|
 | Date | 2026-03-20 |
+| MQDB version / commit | <record at run time — exact git commit not captured for this run> |
+| Build features | default (cluster, http-api) |
 | Platform | macOS (Darwin 25.3.0) |
 | Network | Local loopback (127.0.0.1) |
 | Transport | Direct QUIC with mTLS |

--- a/docs/benchmarks/matrix-spec.md
+++ b/docs/benchmarks/matrix-spec.md
@@ -1,6 +1,6 @@
 # Complete Benchmark Matrix Specification
 
-This document defines the complete benchmark matrix for measuring MQDB cluster performance with the DedicatedExecutor.
+This document defines the complete benchmark matrix for measuring MQDB performance across four configurations: standalone Agent mode and three cluster topologies (Partial, Upper, and Full mesh). Every experiment is run three times (triplicates) so that mean throughput and standard deviation can be reported. Recorded results live in [matrix-results.md](matrix-results.md); a companion root-cause analysis of bridge overhead lives in [issue-11.15-bridge-overhead.md](issue-11.15-bridge-overhead.md).
 
 ---
 
@@ -318,104 +318,10 @@ Final analysis should include:
 
 1. **Async list excluded** - Performance depends on DB size (56x degradation with 80K records)
 2. **Cross-node pubsub ~1000 msg/s limit** - QoS 0 saturation, expected behavior
-3. **Full mesh B15, B17 lower throughput** - Some routes through node 1 show degradation (808, 688 msg/s)
+3. **Full mesh B13, B14 lower throughput** - Some full-mesh routes show intermittent degradation (B13 mean 886, B14 mean 936 msg/s; single-run dips to 655 and 803). See "Notable Anomalies" in matrix-results.md
 
 ---
 
 ## Investigation: Issue 11.15 - Bridge Overhead Root Cause Analysis
 
-### Summary
-
-**Original Hypothesis**: RwLock contention causes 3-4x slowdown on nodes with 2 bridges.
-
-**Conclusion**: RwLock contention hypothesis **DISPROVEN**. The actual root cause is **CPU contention from cluster message processing competing with client request handling on the main runtime**.
-
-### Evidence
-
-#### Lock Wait Times (t_lock) Are NOT the Bottleneck
-
-| Node | Bridges | Throughput | Avg t_lock | Avg t_handle |
-|------|---------|------------|------------|--------------|
-| Node 1 | 2 | 1353 ops/s | 0.23 µs | 55.68 µs |
-| Node 2 | 1 | - | 1.24 µs | 57.17 µs |
-| Node 3 | 0 | 4222 ops/s | 1.82 µs | 54.26 µs |
-
-**Node 3 (fastest) has the HIGHEST t_lock!** This disproves lock contention as the cause.
-
-#### Cluster Message Volume IS the Differentiator
-
-| Node | Bridges | Total Cluster Msgs | DB Operations | Ratio |
-|------|---------|-------------------|---------------|-------|
-| Node 1 | 2 | 42,685 | 23,076 | 1.85:1 |
-| Node 3 | 0 | 14,233 | 148,051 | 0.096:1 |
-
-Node 1 processes **3x more cluster messages** and performs **6x fewer DB operations**.
-
-#### Message Type Distribution
-
-Node 1 (leader, 2 bridges):
-- Write: 13,393 (sends replication to replicas)
-- Ack: 23,094 (receives acks from replicas)
-- Heartbeat: 3,618
-- Raft: 1,216
-
-Node 3 (0 bridges):
-- Write: 28 (almost none)
-- Ack: 10,825
-- Heartbeat: 1,465
-- Raft: 1,426
-
-#### Queue Depth (No Backlog)
-
-| Node | Avg Queue Depth | Max Queue Depth |
-|------|-----------------|-----------------|
-| Node 1 | 1.30 | 25 |
-| Node 2 | 1.00 | 4 |
-| Node 3 | 1.02 | 15 |
-
-Messages are processed quickly - the issue is CPU time spent processing them.
-
-### Current Architecture
-
-1. **DedicatedExecutor** handles bridge network I/O (read/write from QUIC connections)
-2. Bridge callbacks invoke `route_message_local_only()` which publishes to local broker
-3. **Main runtime** handles:
-   - Local broker message routing
-   - `process_messages()` loop consuming from flume channel
-   - Client request handling (DB operations)
-4. All post-receive processing runs on main runtime, competing for CPU
-
-### Hypotheses Evaluated
-
-| # | Hypothesis | Evidence For | Evidence Against | Conclusion |
-|---|------------|--------------|------------------|------------|
-| H1 | Split the lock | None | t_lock avg < 2µs on ALL nodes; Node 3 (fastest) has highest t_lock | **REJECTED** |
-| H2 | Message batching | None | Processing time per message is similar across nodes | **REJECTED** |
-| H3 | Defer bridge processing | Queue depth low (avg ~1) | No message backlog building up | **REJECTED** |
-| H4 | Read lock for reads | Not tested (DEBUG level) | t_lock is already minimal | **UNLIKELY** |
-
-### Recommended Fix Approaches
-
-1. **Separate cluster message consumer** (RECOMMENDED)
-   - Move `process_messages()` to dedicated executor
-   - Use flume channel for cross-runtime communication (already in place)
-   - Clean separation of cluster traffic from client request handling
-
-2. **Batch replication writes**
-   - Combine multiple DB writes into single replication message
-   - Reduces message count and serialization overhead
-   - Increases write latency
-
-### What NOT to Do
-
-Based on the data, these approaches would NOT help:
-- Splitting the RwLock (lock times already sub-microsecond)
-- Using read locks for reads (lock contention is not the issue)
-- Deferring bridge processing (queue depth already low)
-- Reducing batch size (processing efficiency is already good)
-
-### QoS Considerations
-
-- Cluster Write/Ack messages use QoS 0 (`AtMostOnce`)
-- QoS 0 is single-trip (no PUBACK)
-- QoS level doesn't significantly affect DB operation overhead
+Moved to [issue-11.15-bridge-overhead.md](issue-11.15-bridge-overhead.md).

--- a/docs/design/cross-partition-transactions.md
+++ b/docs/design/cross-partition-transactions.md
@@ -1,5 +1,7 @@
 # Cross-partition batch atomicity in MQDB — implementation answer
 
+> **STATUS: PROPOSAL — not implemented.** No 2PC / commit-log-as-entity transaction layer exists in the code. This document explores design options only.
+
 ## The picture
 
 You have three realistic builds. Cost goes up left-to-right; correctness goes from "application-level" to "ACID-shaped."

--- a/docs/design/diagram-sharing-phase1-plan.md
+++ b/docs/design/diagram-sharing-phase1-plan.md
@@ -1,5 +1,7 @@
 # Diagram Sharing — Phase 1 Implementation Plan
 
+> **STATUS: IMPLEMENTED (historical plan).** This phase shipped in agent mode (`_shares` entity, `AccessLevel`, share-aware `check_access`). Retained for historical reference.
+
 Phase 1 of `diagram-sharing.md`: the **grants + access core**. Delivers a complete
 agent-mode vertical slice — share a diagram view/edit with a named user, grantee
 reads/updates, owner-only delete, revoke, transitive cascade — plus cluster parity

--- a/docs/design/diagram-sharing.md
+++ b/docs/design/diagram-sharing.md
@@ -1,13 +1,14 @@
 # Diagram Sharing
 
+> **STATUS: Phases 1-3 IMPLEMENTED (agent mode); Phase 4 (public/anon) and cluster parity PENDING.** The `_shares` entity, `AccessLevel`, and share-aware `check_access` live in `crates/mqdb-agent`. No public/anonymous sharing and no cluster-mode implementation exist yet.
+
 Let a diagram owner grant other users **view** or **edit** access to a diagram and
 the diagrams it references, share a diagram **publicly** by link, and have all of
 this hold consistently across CRUD, child entities (nodes/edges/topics), and the
 live event stream — under a threat model where authenticated users are **mutually
 untrusting tenants** (Alice must not see Bob's data).
 
-This supersedes the "Sharing (future)" note in `frontend-ownership.md` and also
-corrects several stale claims in that doc (flagged inline). It is designed
+This supersedes the "Sharing (future)" note in `frontend-ownership.md`. It is designed
 generically for any ownership-enabled entity, with `diagrams` as the running
 example.
 
@@ -42,7 +43,7 @@ this work.
 | Area | Reality in code | Source |
 |------|-----------------|--------|
 | Ownership config | per-entity `--ownership diagrams=userId`, single owner field | `mqdb-core/src/types.rs:75` |
-| Read | **ownership-enforced** (403 for non-owner) — *`frontend-ownership.md:29` wrongly says unrestricted* | `transport_execute.rs:72-79` |
+| Read | **ownership-enforced** (403 for non-owner) | `transport_execute.rs:72-79` |
 | Update | owner-checked; owner field stripped from payload | `transport_execute.rs:90-101` |
 | Delete | owner-checked | `transport_execute.rs:122-129` |
 | List | injects mandatory `owner_field = sender` (single AND filter; no OR/contains) | `transport_execute.rs:156-166` |

--- a/docs/design/frontend-ownership.md
+++ b/docs/design/frontend-ownership.md
@@ -21,7 +21,7 @@ The original discussion proposed **user-scoped topic namespacing** (`$DB/u/{user
 
 ## How It Works
 
-When a user authenticates via MQTT CONNECT (password, SCRAM, JWT, or OAuth), the broker injects their identity as `x-mqtt-sender` (username) and `x-mqtt-client-id` (MQTT client ID) user properties on every PUBLISH they send. These are anti-spoof: the broker strips any client-supplied values before injecting the real ones. The database layer reads `x-mqtt-sender` for ownership enforcement and `x-mqtt-client-id` for echo suppression in change events (see `ARCHITECTURE.md` Section 16 for the full property flow). The ownership layer uses `x-mqtt-sender` to:
+When a user authenticates via MQTT CONNECT (password, SCRAM, JWT, or OAuth), the broker injects their identity as `x-mqtt-sender` (username) and `x-mqtt-client-id` (MQTT client ID) user properties on every PUBLISH they send. These are anti-spoof: the broker strips any client-supplied values before injecting the real ones. The database layer reads `x-mqtt-sender` for ownership enforcement and `x-mqtt-client-id` for echo suppression in change events (see `../architecture.md` Section 16 for the full property flow). The ownership layer uses `x-mqtt-sender` to:
 
 - **List operations**: Automatically injects a mandatory filter `userId = {authenticated_user}`. Alice only sees her own diagrams. Bob only sees his.
 - **Read/Update/Delete operations**: Reads the existing record and checks `data.userId == sender`. If mismatch, returns a 403 Forbidden error. Read is enforced the same as Update/Delete (`transport_execute.rs` → `check_access` with `AccessLevel::View`); it is **not** unrestricted.
@@ -162,11 +162,7 @@ Admin users (specified via `--admin-users`) bypass all ownership restrictions:
 
 ## Event Subscriptions
 
-Event subscriptions (`$DB/diagrams/events/#`) are NOT filtered by ownership. All authenticated users receive events for all diagrams. This is intentional:
-
-- The frontend already filters locally based on which diagrams it loaded
-- Events for diagrams the user doesn't own are harmless (they won't have local state for those IDs)
-- Future: ACL rules can restrict event subscriptions if needed (`%u` substitution is available)
+Recipient-scoped events shipped. For ownership-enabled entities, change events are routed to per-recipient topics `$DB/u/{user}/events/{entity}/{id}` (see `events.rs` `recipients` and `agent/tasks.rs`), enabled via the `--scoped-events` flag (`MQDB_SCOPED_EVENTS`). Each subscriber subscribes to its own `$DB/u/{user}/events/#` namespace, and the `%u`-based topic protection prevents subscribing to another user's namespace. The legacy shared `$DB/diagrams/events/#` topic remains for non-ownership entities.
 
 ---
 
@@ -213,5 +209,5 @@ mqdb dev test --ownership --nodes 3
 | Authentication | Required — anonymous mode incompatible |
 | Child entity isolation | Inherited through `diagramId` FK — no `userId` needed |
 | Admin access | `--admin-users` flag, bypasses all ownership |
-| Event filtering | Not server-filtered — frontend filters locally |
-| Sharing (future) | Can be added later by making ownership check look at a `sharedWith` array |
+| Event filtering | Recipient-scoped events available via `--scoped-events` (`$DB/u/{user}/events/#`) |
+| Sharing | Largely implemented (agent mode) — see [diagram-sharing.md](diagram-sharing.md) |

--- a/docs/design/oauth-vault-future.md
+++ b/docs/design/oauth-vault-future.md
@@ -2,13 +2,11 @@
 
 Architectural issues identified during PR #13 review that require deeper design work.
 
-## Batch Vault Operations Are Not Atomic
+## Batch Vault Operations Are Not Atomic — RESOLVED
 
-`batch_vault_operation` in `handlers.rs` iterates over all user entities and encrypts/decrypts records one by one. If the process crashes mid-batch, some records are encrypted and some are plaintext. The `vault_check` token on the identity record indicates the vault *should* be enabled, but the data is in a mixed state.
+**Status: RESOLVED.** The proposed `vault_migration_status` state machine shipped in `crates/mqdb-vault`. `batch_vault_operation` now writes `vault_migration_status: "pending"` (with `vault_migration_mode` of `encrypt`/`decrypt`/`re_encrypt`) before mutating records, then flips it to `"complete"` after (`backend.rs`). On unlock, `resume_pending_migration` (`ops.rs:130`) detects a `pending` status and re-runs the batch, making enable/disable/change crash-recoverable.
 
-**Impact**: Data corruption after crash during vault enable/disable/change.
-**Mitigation**: The write fence prevents concurrent modifications during batch, but doesn't help with crash recovery.
-**Potential fix**: Store a `vault_migration_status` field on the identity (e.g., `pending`, `complete`). On next unlock, if status is `pending`, re-run the batch. Alternatively, use a WAL-style approach where the batch operation is logged before execution.
+Original issue: `batch_vault_operation` iterated over all user entities and encrypted/decrypted records one by one; a crash mid-batch left records in a mixed state while the `vault_check` token said the vault should be enabled.
 
 ## vault_pre_update TOCTOU in Agent Handlers
 

--- a/docs/design/ownership-transfer.md
+++ b/docs/design/ownership-transfer.md
@@ -1,5 +1,7 @@
 # Ownership Transfer
 
+> **STATUS: DESIGN ONLY — not implemented.** No `Transfer` `DbOp`, no `transfer_ownership`, and no `$DB/{entity}/{id}/transfer` topic exist in the code.
+
 Transfer ownership of an entity from one user to another.
 
 ## Topic

--- a/docs/design/queue-design.md
+++ b/docs/design/queue-design.md
@@ -1,5 +1,7 @@
 # Work Queue Design
 
+> **STATUS: ON HOLD — no implementation.** No queue entity, visibility-timeout, or ACK state machine exists in the code. Superseded by `queue-ideation.md` where the two conflict.
+
 ## Overview
 
 MQDB work queues provide durable, push-based message processing built on top of the existing entity storage system. Queues are entities with special consumption semantics: messages persist until consumed, and the broker distributes them across competing consumers.

--- a/docs/design/queue-ideation.md
+++ b/docs/design/queue-ideation.md
@@ -1,5 +1,7 @@
 # Queue Feature — Ideation Document
 
+> **STATUS: ON HOLD — no implementation.** No queue entity or visibility-timeout code exists. This document supersedes `queue-design.md` where decisions conflict.
+
 This document captures the design thinking for MQDB's queue feature. It supersedes the earlier QUEUE_DESIGN.md where decisions conflict. Use this as the reference during planning and implementation.
 
 ## The Core Idea

--- a/docs/distributed-design.md
+++ b/docs/distributed-design.md
@@ -2,7 +2,7 @@
 
 > **Living Document** - Updated iteratively with code verification.
 > Every claim has file:line references. When in doubt, verify against code.
-> Last verified: January 2026 (all milestones M1-M10 complete, Direct QUIC transport added)
+> Last verified: 2026-07 (all milestones M1-M11 complete, Direct QUIC transport is the default)
 >
 > **Note:** Clustering requires the `cluster` feature on the `mqdb` CLI (enabled by default; see `crates/mqdb-cli/Cargo.toml`). Builds with `--no-default-features` exclude all cluster code. Shared types (partitions, IDs) live in `crates/mqdb-core/src/partition/` and compile unconditionally.
 
@@ -346,9 +346,11 @@ Retained Message Queries:
 
 ## A6: Transport Layer Design
 
-### A6.1 Why MQTT Bridges?
+> **Deprecation banner**: Sections A6.1–A6.4 describe the legacy MQTT-bridge transport, which is deprecated. The actual default transport is **Direct QUIC**, documented in A6.5. Read A6.5 first; A6.1–A6.4 are retained for historical reference only.
 
-MQDB uses MQTT as the cluster communication substrate rather than custom RPC:
+### A6.1 Why MQTT Bridges? (deprecated)
+
+MQDB originally used MQTT as the cluster communication substrate rather than custom RPC:
 
 - **Reuses existing infrastructure**: The embedded MQTT broker already handles messaging
 - **Topic-based routing**: Natural fit for partition-specific traffic
@@ -376,17 +378,17 @@ All callers properly `await` transport operations. No fire-and-forget spawning�
 
 ### A6.2 Topic Namespaces
 
-Five topic namespaces structure MQDB communication:
+Seven topic namespaces structure MQDB communication:
 
-| Prefix | Purpose | QoS | Bridged |
-|--------|---------|-----|---------|
-| `_mqdb/cluster/` | Control messages, heartbeats, Raft | 1 | Yes |
-| `_mqdb/repl/` | Partition replication | 1 | Yes |
-| `_mqdb/forward/` | Message forwarding to subscribers | 1 | Yes |
-| `_mqdb/scatter/` | Distributed query scatter responses | 1 | Yes |
-| `_mqdb/http_resp/` | HTTP handler request-response | 1 | No (local) |
-| `$DB/` | Database operations | 2 | Yes |
-| `$SYS/` | Admin operations (rebalance, status) | 1 | No (local, AdminRequired for `$SYS/mqdb/cluster/#`) |
+| Prefix | Purpose | QoS |
+|--------|---------|-----|
+| `_mqdb/cluster/` | Control messages, heartbeats, Raft | 1 |
+| `_mqdb/repl/` | Partition replication | 1 |
+| `_mqdb/forward/` | Message forwarding to subscribers | 1 |
+| `_mqdb/scatter/` | Distributed query scatter responses | 1 |
+| `_mqdb/http_resp/` | HTTP handler request-response (local) | 1 |
+| `$DB/` | Database operations | 2 |
+| `$SYS/` | Admin operations (rebalance, status; AdminRequired for `$SYS/mqdb/cluster/#`) | 1 |
 
 **Detailed topic patterns** (`mqtt_transport.rs:107-163`):
 
@@ -435,7 +437,7 @@ Five topic namespaces structure MQDB communication:
 | `$DB/_sub/{sub_id}/heartbeat` | Keep subscription alive |
 | `$DB/_sub/{sub_id}/unsubscribe` | Remove subscription |
 
-*Admin patterns* (`bin/mqdb.rs`):
+*Admin patterns* (`crates/mqdb-cli/src/main.rs`):
 
 | Pattern | Purpose |
 |---------|---------|
@@ -466,7 +468,7 @@ Each node creates N-1 outbound bridges (one per peer). Messages flow bidirection
 - `clean_start = false`: Preserve session across reconnects
 - Topics: `_mqdb/cluster/#`, `_mqdb/forward/#`, `_mqdb/repl/#`, `$DB/#`
 
-**QUIC stream caching** (`quic_stream_manager.rs`): With `DataPerTopic` strategy, streams are cached per topic for reuse. When cache reaches 100 streams (hardcoded default), LRU eviction closes the oldest stream. This is a **performance optimization**, not a limit—unlimited topics are supported, they just share cached streams via eviction.
+**QUIC stream caching**: With `DataPerTopic` strategy, streams are cached per topic for reuse. When cache reaches 100 streams (hardcoded default), LRU eviction closes the oldest stream. This is a **performance optimization**, not a limit—unlimited topics are supported, they just share cached streams via eviction.
 
 **Bridge Overhead Trade-off**: Each bridge creates bidirectional MQTT connections that share the broker's event loop with client connections. More bridges enable direct routing (e.g., Node 2 → Node 3) but degrade local DB performance:
 
@@ -974,10 +976,9 @@ Each node can be:
 
 ### 1.6 Inter-Node Communication
 
-- **MQTT Bridges** connect nodes (not direct TCP sockets)
-- Bridges subscribe to cluster topics on remote nodes
-- All cluster messages flow through MQTT publish/subscribe
-- Topic prefixes (`crates/mqdb-cluster/src/cluster/mqtt_transport.rs:19-21`):
+- **Direct QUIC** is the default transport: nodes exchange cluster messages over dedicated QUIC streams, bypassing the MQTT broker (see A6.5).
+- **MQTT bridges** are deprecated/legacy and retained only for historical reference.
+- Legacy bridge topic prefixes (`crates/mqdb-cluster/src/cluster/mqtt_transport.rs:19-21`):
   ```rust
   const CLUSTER_TOPIC_PREFIX: &str = "_mqdb/cluster";
   const REPLICATION_TOPIC_PREFIX: &str = "_mqdb/repl";
@@ -2359,8 +2360,6 @@ The following are implemented but documented in other files:
 
 The following sections may need documentation:
 
-- Performance tuning and benchmarks
-- Security model and authentication
 - Monitoring and observability
 - Operational runbooks
 - Capacity planning guidelines
@@ -2383,32 +2382,31 @@ The following sections may need documentation:
 | `crates/mqdb-cluster/src/cluster/store_manager/constraint_ops.rs` | FK reverse index integration, rebuild on constraint add |
 | `crates/mqdb-cluster/src/cluster/store_manager/outbox.rs` | CascadeOutboxPayload, CascadeRemoteOp, _cascade/ prefix |
 | `crates/mqdb-cluster/src/cluster/db/data_store.rs` | FkReverseIndex in-memory data structure |
-| `crates/mqdb-cluster/src/cluster/node_controller.rs` | Main cluster controller, message handling |
+| `crates/mqdb-cluster/src/cluster/node_controller/mod.rs` | Main cluster controller, message handling |
 | `crates/mqdb-cluster/src/cluster/heartbeat.rs` | Heartbeat management, node status |
-| `crates/mqdb-cluster/src/cluster/partition_map.rs` | Partition assignments |
+| `crates/mqdb-core/src/partition/map.rs` | Partition assignments (`PartitionMap`) |
 | `crates/mqdb-cluster/src/cluster/mqtt_transport.rs` | MQTT-based cluster transport |
 | `crates/mqdb-cluster/src/cluster/quic_transport.rs` | Direct QUIC transport (bypasses MQTT bridges) |
 | `crates/mqdb-cluster/src/cluster/message_processor.rs` | Message classification and heartbeat offloading |
 | `crates/mqdb-cluster/src/cluster/dedicated_executor.rs` | Isolated Tokio runtime for blocking tasks |
-| `crates/mqdb-cluster/src/cluster/raft/coordinator.rs` | Raft consensus coordinator |
+| `crates/mqdb-cluster/src/cluster/raft/coordinator/mod.rs` | Raft consensus coordinator |
 | `crates/mqdb-cluster/src/cluster/raft/node.rs` | Raft node state machine |
 | `crates/mqdb-cluster/src/cluster/raft/state.rs` | Raft state and commands |
 | `crates/mqdb-cluster/src/cluster/topic_index.rs` | Topic → subscriber mapping |
 | `crates/mqdb-cluster/src/cluster/topic_trie.rs` | Wildcard subscription trie |
 | `crates/mqdb-cluster/src/cluster/wildcard_store.rs` | Wildcard store wrapper |
 | `crates/mqdb-cluster/src/cluster/client_location.rs` | Client → connected node mapping |
-| `crates/mqdb-cluster/src/cluster/event_handler.rs` | MQTT event hooks for cluster |
+| `crates/mqdb-cluster/src/cluster/event_handler/mod.rs` | MQTT event hooks for cluster |
 | `crates/mqdb-cluster/src/cluster/session.rs` | SessionData structure and store |
-| `crates/mqdb-cluster/src/cluster/store_manager.rs` | All entity stores coordination |
-| `crates/mqdb-cluster/src/cluster/protocol.rs` | Message definitions (BeBytes) |
+| `crates/mqdb-cluster/src/cluster/store_manager/mod.rs` | All entity stores coordination |
+| `crates/mqdb-cluster/src/cluster/protocol/mod.rs` | Message definitions (BeBytes) |
 | `crates/mqdb-cluster/src/cluster/snapshot.rs` | Snapshot transfer protocol |
 | `crates/mqdb-cluster/src/cluster/inflight_store.rs` | QoS 1 inflight tracking |
 | `crates/mqdb-cluster/src/cluster/qos2_store.rs` | QoS 2 state machine |
 | `crates/mqdb-cluster/src/cluster/retained_store.rs` | Retained message store |
 | `crates/mqdb-cluster/src/cluster/entity.rs` | Entity name constants |
-| `crates/mqdb-cluster/src/cluster/node.rs` | NodeId type |
-| `crates/mqdb-cluster/src/cluster/partition.rs` | PartitionId type, NUM_PARTITIONS |
-| `crates/mqdb-cluster/src/cluster/epoch.rs` | Epoch type |
+| `crates/mqdb-core/src/partition/types.rs` | NodeId, Epoch, PartitionId types, NUM_PARTITIONS |
+| `crates/mqdb-core/src/partition/functions.rs` | Partition hashing functions |
 | `crates/mqdb-cluster/src/cluster_agent/mod.rs` | Cluster node startup |
 | `crates/mqdb-cli/src/main.rs` | CLI entry point |
 

--- a/docs/encryption-architecture.md
+++ b/docs/encryption-architecture.md
@@ -16,18 +16,18 @@ Encrypts user-owned entity records with a user-provided passphrase. Keys exist o
 
 | Parameter | Value | Source |
 |-----------|-------|--------|
-| Algorithm | PBKDF2-HMAC-SHA256 | `vault_crypto.rs:29` |
-| Iterations | 600,000 | `vault_crypto.rs:16` |
-| Salt | 32 bytes, random, per-user | `vault_crypto.rs:14` |
-| Output | 256-bit AES-256-GCM key | `vault_crypto.rs:13,42` |
+| Algorithm | PBKDF2-HMAC-SHA256 | `crypto.rs:29` |
+| Iterations | 600,000 | `crypto.rs:16` |
+| Salt | 32 bytes, random, per-user | `crypto.rs:14` |
+| Output | 256-bit AES-256-GCM key | `crypto.rs:13,43` |
 
 The derived key is stored in a `VaultKeyStore` as `Zeroizing<Vec<u8>>` — memory is overwritten with zeros on drop. No key material is ever written to disk.
 
 ### Passphrase Verification
 
-A check token is created by encrypting the constant `b"mqdb-vault-check-v1"` with the derived key (`vault_crypto.rs:17,87-88`). On unlock, the system re-derives the key and attempts to decrypt the stored check token. If the plaintext matches, the passphrase is correct. No plaintext passphrase or hash is stored.
+A check token is created by encrypting the constant `b"mqdb-vault-check-v1"` with the derived key (`crypto.rs:17,87-88`). On unlock, the system re-derives the key and attempts to decrypt the stored check token. If the plaintext matches, the passphrase is correct. No plaintext passphrase or hash is stored.
 
-Unlock attempts are rate-limited to 5 per user per minute (`agent.rs:330`, `rate_limiter.rs:9`).
+Unlock attempts are rate-limited to 5 per user per minute, shared across both the MQTT and HTTP paths (`crates/mqdb-vault/src/backend.rs`, `crates/mqdb-cli/src/commands/agent.rs`).
 
 ### Field-Level Encryption
 
@@ -35,20 +35,20 @@ Vault encryption operates at the JSON field level, recursively encrypting every 
 
 **Per-field encryption:**
 
-1. Generate a random 12-byte nonce (`vault_crypto.rs:209-212`)
-2. For non-string values (numbers, booleans, null), prepend `\x01` before encryption (`vault_crypto.rs:146-151`). On decryption, the prefix signals that the plaintext should be parsed back to its original JSON type (`vault_crypto.rs:176-180`)
-3. Construct AAD as `"{entity}:{record_id}"` (`vault_crypto.rs:216-217`). This binds ciphertext to a specific record, preventing copy-paste attacks between records
+1. Generate a random 12-byte nonce (`crypto.rs:210-213`)
+2. For non-string values (numbers, booleans, null), prepend `\x01` before encryption (`crypto.rs:147`). On decryption, the prefix signals that the plaintext should be parsed back to its original JSON type (`crypto.rs:176`)
+3. Construct AAD as `"{entity}:{record_id}"` (`crypto.rs:216-217`). This binds ciphertext to a specific record, preventing copy-paste attacks between records
 4. Encrypt with AES-256-GCM, producing ciphertext + 16-byte authentication tag
-5. Store as `base64(nonce || ciphertext || tag)` (`vault_crypto.rs:218-229`)
+5. Store as `base64(nonce || ciphertext || tag)` (`crypto.rs:225-226`)
 
-**Recursive traversal** (`vault_transform.rs:59-89`):
+**Recursive traversal** (`transform.rs`):
 
 - String leaf values: encrypted
 - Number/bool/null leaf values: encrypted with `\x01` type prefix
 - Objects: recurse into each field
 - Arrays: recurse into each element
 
-**Skipped fields** (`vault_transform.rs:14-25`):
+**Skipped fields** (`transform.rs:14-24`):
 
 - `id` (top-level): needed for routing
 - Owner field (top-level): needed for access control
@@ -105,10 +105,10 @@ For passphrase changes, the old salt and old check token are persisted as `vault
 
 ### Write Fences
 
-Batch operations must not interleave with concurrent MQTT operations on the same user's data. A per-user `RwLock` fence prevents this (`vault_keys.rs:58-83`):
+Batch operations must not interleave with concurrent MQTT operations on the same user's data. A per-user `RwLock` fence prevents this (`key_store.rs:50-80`):
 
 - Batch operations acquire an **exclusive write fence** (`acquire_fence`)
-- MQTT handlers acquire a **shared read fence** (`read_fence`) before processing vault-eligible requests (`handlers.rs:102-104`)
+- MQTT handlers acquire a **shared read fence** (`read_fence`) before processing vault-eligible requests
 - While a batch holds the write fence, all MQTT operations for that user block until the batch completes
 
 This guarantees clients never observe a mixed state (some fields encrypted, others plaintext).
@@ -239,10 +239,10 @@ With 600,000 PBKDF2 iterations (~5 guesses/second/core):
 
 | Component | File |
 |-----------|------|
-| Vault crypto primitives | `crates/mqdb-agent/src/http/vault_crypto.rs` |
-| Field encrypt/decrypt helpers | `crates/mqdb-agent/src/vault_transform.rs` |
+| Vault crypto primitives | `crates/mqdb-vault/src/crypto.rs` |
+| Field encrypt/decrypt helpers | `crates/mqdb-vault/src/transform.rs` |
 | Identity crypto | `crates/mqdb-agent/src/http/identity_crypto.rs` |
-| Key store (memory + fences) | `crates/mqdb-core/src/vault_keys.rs` |
+| Key store (memory + fences) | `crates/mqdb-vault/src/key_store.rs` |
 | Agent MQTT handler integration | `crates/mqdb-agent/src/agent/handlers.rs` |
 | Agent HTTP vault endpoints | `crates/mqdb-agent/src/http/handlers.rs` |
 | Cluster field encryption | `crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs` |

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,5 +1,9 @@
 # MQDB Distributed Implementation Plan
 
+> **Archived — historical record.** All milestones (M1-M11) are complete; this
+> document is preserved as the milestone plan of record and is no longer a live
+> task list. MQTT bridge transport is deprecated (QUIC is the default).
+
 > **Status: ALL MILESTONES COMPLETE (M1-M11)**
 > Last verified: March 2026
 
@@ -25,7 +29,7 @@
 
 ### Components
 - `NodeId` - Node identifier (u16)
-- `PartitionId` - Partition identifier (0-63)
+- `PartitionId` - Partition identifier (0-255, 256 fixed partitions)
 - `Epoch` - Monotonic version for partition assignments
 - `PartitionMap` - Mapping of partitions to primaries/replicas
 - `PartitionAssignment` - Per-partition ownership info
@@ -354,17 +358,17 @@ Per-user transparent encryption at rest for owned entities, in both agent and cl
 - Cookie-based session authentication required
 - Rate-limited unlock attempts
 
-**Cryptography** (`crates/mqdb-agent/src/http/vault_crypto.rs`):
+**Cryptography** (`crates/mqdb-vault/src/crypto.rs`):
 - `VaultCrypto` struct wraps AES-256-GCM key derived via PBKDF2-HMAC-SHA256
-- Per-record nonce derived from entity + record ID (deterministic, no nonce storage)
+- Random 12-byte nonce generated per encryption and stored prepended to the ciphertext (`base64(nonce || ciphertext || tag)`)
 - Recursive field-level encryption: each string leaf value encrypted independently at any JSON depth
 
-**Transform layer** (`crates/mqdb-agent/src/vault_transform.rs`):
+**Transform layer** (`crates/mqdb-vault/src/transform.rs`):
 - `vault_encrypt_fields` / `vault_decrypt_fields` for record-level operations
 - `is_vault_eligible` gates encryption to owned, non-system entities
 - `build_vault_skip_fields` excludes `id` and ownership field from encryption
 
-**Key storage** (`crates/mqdb-core/src/vault_keys.rs`):
+**Key storage** (`crates/mqdb-vault/src/key_store.rs`):
 - `VaultKeyStore` maps canonical_id → `VaultCrypto` (in-memory only)
 - Keys never persisted — user must unlock after each server restart
 
@@ -374,10 +378,10 @@ Per-user transparent encryption at rest for owned entities, in both agent and cl
 - Constraint validation operates on plaintext (decrypt before validate, re-encrypt after)
 
 ### Files
-- `crates/mqdb-agent/src/http/vault_crypto.rs`
+- `crates/mqdb-vault/src/crypto.rs`
+- `crates/mqdb-vault/src/transform.rs`
+- `crates/mqdb-vault/src/key_store.rs`
 - `crates/mqdb-agent/src/http/handlers.rs`
-- `crates/mqdb-agent/src/vault_transform.rs`
-- `crates/mqdb-core/src/vault_keys.rs`
 - `examples/vault-mqtt/` (single-node demo)
 - `examples/vault-cluster/` (multi-node E2E test, 70 tests)
 
@@ -402,26 +406,3 @@ Per-user transparent encryption at rest for owned entities, in both agent and cl
 - Real multi-process cluster
 - Network partition simulation
 - Performance benchmarks
-
----
-
-## Dependencies
-
-### mqtt-lib Fixes Needed
-
-1. **PUBACK Timeout Fix** (was committed as `ac885a6`, may be lost)
-   - Bridge forwarding must be non-blocking
-   - Don't await PUBACK when forwarding to remote broker
-   - File: `mqtt5/src/broker/bridge/connection.rs`
-
-```rust
-// In handle_remote_message():
-// Change from:
-let _ = local_client.publish_qos(...).await;  // BLOCKS!
-
-// To:
-let client = local_client.clone();
-tokio::spawn(async move {
-    let _ = client.publish_qos(...).await;
-});
-```

--- a/docs/integration/frontend-agent.md
+++ b/docs/integration/frontend-agent.md
@@ -1,341 +1,174 @@
-# Frontend Agent: MQDB Integration Tasks
+# Frontend Integration Reference
 
-## ⚠️ CORRECTION: Server Assumptions Changed
+Purpose: how a browser frontend performs CRUD and consumes change events over MQDB's MQTT-over-WebSocket API. Audience: frontend developers building the diagramming client on top of MQDB.
 
-**The original plan incorrectly promised server-side features that will NOT be implemented.** MQDB is generic infrastructure and will not have diagram-specific logic.
+## Status: current
 
-### What the Server Will NOT Provide
+MQDB is generic infrastructure. It stores and syncs data but has no diagram-specific logic. Sequence/version tracking for the sync protocol is the frontend's responsibility.
 
-| Feature | Status | Reason |
-|---------|--------|--------|
-| `diagrams/{id}/mutations` topic | ❌ NOT PROVIDED | Diagram-specific logic doesn't belong in MQDB |
-| `seq` field in mutations | ❌ NOT PROVIDED | Server doesn't track diagram sequences |
-| `author_client_id` in mutations | ❌ NOT PROVIDED | Server doesn't inject this |
-| `up_to_seq` in list responses | ❌ NOT PROVIDED | Server doesn't track diagram sequences |
+### What the Server Provides
 
-### What the Server DOES Provide
+| Feature | Topic / Usage |
+|---------|---------------|
+| WebSocket endpoint | `ws://host:8080/mqtt` |
+| Create | `$DB/{entity}/create` |
+| Read | `$DB/{entity}/{id}` |
+| Update | `$DB/{entity}/{id}/update` |
+| Delete | `$DB/{entity}/{id}/delete` |
+| List with filters | `$DB/{entity}/list` with `{"filter": "diagramId=xyz"}` |
+| Change events | `$DB/{entity}/events/#` — notifies on any change to that entity type |
 
-| Feature | Status | Topic/Usage |
-|---------|--------|-------------|
-| WebSocket endpoint | ✅ | `ws://host:8080/mqtt` |
-| CRUD operations | ✅ | `$DB/create/{entity}`, `$DB/read/{entity}/{id}`, `$DB/update/{entity}/{id}`, `$DB/delete/{entity}/{id}` |
-| List with filters | ✅ | `$DB/list/{entity}` with `{"filter": "diagramId=xyz"}` |
-| Entity watch | ✅ | `$DB/watch/{entity}` - notifies on any change to entity type |
+The server does not provide diagram-specific mutation topics, `seq`/`up_to_seq` fields, or `author_client_id`. Echo suppression uses the `operation_id` present in each event.
 
 ---
 
-## Revised Sync Protocol: Frontend-Managed Sequences
+## Change Event Format
 
-The TLA+ bugs are still real. The fixes must be implemented **entirely in the frontend** using existing MQDB features.
+The broker publishes a serialized `ChangeEvent` to `$DB/{entity}/events/{id}` on every write. Subscribe with `$DB/{entity}/events/#`.
 
-### The Key Insight
+```json
+{
+  "sequence": 42,
+  "entity": "nodes",
+  "id": "node-123",
+  "operation": "Create",
+  "data": { "diagramId": "d1", "type": "broker" }
+}
+```
 
-Your schema already has `diagrams.version`. Use it:
+- `operation`: `"Create"`, `"Update"`, or `"Delete"` (capitalized)
+- `data`: present on Create/Update, absent on Delete
+- Filter events by `data.diagramId` to route to the correct open diagram
 
-1. **`diagrams.version` IS the sequence number**
-2. **Frontend increments it** when mutating child entities
-3. **Frontend reads it** when fetching initial state
-4. **Frontend filters by it** to prevent duplicate application
+---
 
-### Revised SyncClient
+## Sync Protocol: Frontend-Managed Versions
+
+Your schema already has `diagrams.version`. Use it as the sequence number:
+
+1. **`diagrams.version` IS the sequence** — frontend increments it on every child mutation.
+2. **On initial open** — fetch the diagram (reads `version`) and its child entities, then record the version.
+3. **Buffer events during fetch** — hold incoming events until initial state is applied to avoid state regression.
+4. **Idempotent apply** — since the server does not inject a per-event sequence, design local applies to be safe if applied twice.
+
+### Bug fixes this protocol addresses
+
+- **Stale-diagram events**: ignore events whose `data.diagramId` is not currently subscribed.
+- **State regression during sync**: buffer events until the fetched state is applied, then drain the buffer.
+
+---
+
+## SyncClient (concise)
 
 ```typescript
-// src/services/mqdb/SyncClient.ts
-
-interface Mutation {
-  op: 'insert' | 'update' | 'delete';
+interface ChangeEvent {
+  sequence: number;
   entity: string;
   id: string;
-  data: Record<string, unknown> | null;
+  operation: 'Create' | 'Update' | 'Delete';
+  data?: Record<string, unknown>;
 }
 
 export class SyncClient {
   private mqtt: MqttClient | null = null;
-  private clientId: string;
-
-  // Bug #1 fix: Track subscribed diagrams
-  private subscribedDiagrams = new Set<string>();
-
-  // Bug #2 fix: Track applied versions PER DIAGRAM
+  private subscribed = new Set<string>();
+  private awaiting = new Set<string>();
+  private buffered = new Map<string, ChangeEvent[]>();
   private appliedVersion = new Map<string, number>();
+  private onEvent: ((diagramId: string, ev: ChangeEvent) => void) | null = null;
 
-  // Bug #2 fix: Buffer mutations while awaiting state
-  private buffered = new Map<string, Mutation[]>();
-  private awaitingState = new Set<string>();
+  constructor(private clientId: string) {}
 
-  private onMutation: ((diagramId: string, mutation: Mutation) => void) | null = null;
-
-  constructor(clientId: string) {
-    this.clientId = clientId;
+  async connect(url: string): Promise<void> {
+    this.mqtt = await MqttClient.connect({ url, clientId: this.clientId, cleanSession: true });
+    this.mqtt.onMessage((topic, payload) => this.handleMessage(topic, payload));
   }
 
-  async connect(serverUrl: string): Promise<void> {
-    this.mqtt = await MqttClient.connect({
-      url: serverUrl,
-      clientId: this.clientId,
-      cleanSession: true,
-    });
-
-    this.mqtt.onMessage((topic, payload) => {
-      this.handleMessage(topic, payload);
-    });
-
-    this.mqtt.onDisconnect(() => {
-      this.subscribedDiagrams.clear();
-      this.appliedVersion.clear();
-      this.buffered.clear();
-      this.awaitingState.clear();
-    });
+  setEventHandler(h: (diagramId: string, ev: ChangeEvent) => void): void {
+    this.onEvent = h;
   }
-
-  setMutationHandler(handler: (diagramId: string, mutation: Mutation) => void): void {
-    this.onMutation = handler;
-  }
-
-  // ─────────────────────────────────────────────────────────────
-  // Diagram Lifecycle (REVISED)
-  // ─────────────────────────────────────────────────────────────
 
   async openDiagram(diagramId: string): Promise<void> {
     if (!this.mqtt) throw new Error('Not connected');
-
-    // 1. Mark as awaiting state (mutations will be buffered)
-    this.awaitingState.add(diagramId);
+    this.awaiting.add(diagramId);
     this.buffered.set(diagramId, []);
+    this.subscribed.add(diagramId);
 
-    // 2. Subscribe to entity watches (NOT diagram-specific mutation topic)
-    this.subscribedDiagrams.add(diagramId);
-    await this.mqtt.subscribe('$DB/watch/nodes', { qos: 1 });
-    await this.mqtt.subscribe('$DB/watch/edges', { qos: 1 });
-    await this.mqtt.subscribe('$DB/watch/topics', { qos: 1 });
-    await this.mqtt.subscribe('$DB/watch/schemas', { qos: 1 });
-    await this.mqtt.subscribe('$DB/watch/variables', { qos: 1 });
-
-    // 3. Fetch diagram (includes version) and all child entities
-    const diagram = await this.fetchOne('diagrams', diagramId);
-    const [nodes, edges, topics, schemas, variables] = await Promise.all([
-      this.fetchList('nodes', `diagramId=${diagramId}`),
-      this.fetchList('edges', `diagramId=${diagramId}`),
-      this.fetchList('topics', `diagramId=${diagramId}`),
-      this.fetchList('schemas', `diagramId=${diagramId}`),
-      this.fetchList('variables', `diagramId=${diagramId}`),
-    ]);
-
-    // 4. Record the version we've synced to
-    const version = diagram?.data?.version || 0;
-    this.appliedVersion.set(diagramId, version);
-
-    // 5. Apply state to local DB (handled by caller)
-    // ... caller applies nodes, edges, etc. to local DB ...
-
-    // 6. Process any buffered mutations
-    // Note: Without server-side seq, we can't perfectly dedupe.
-    // We rely on idempotent operations and version comparison.
-    const buffer = this.buffered.get(diagramId) || [];
-    for (const mutation of buffer) {
-      // Only apply if mutation is for our diagram
-      const mutationDiagramId = mutation.data?.diagramId;
-      if (mutationDiagramId === diagramId) {
-        this.applyMutation(diagramId, mutation);
-      }
+    for (const e of ['nodes', 'edges', 'topics', 'schemas', 'variables']) {
+      await this.mqtt.subscribe(`$DB/${e}/events/#`, { qos: 1 });
     }
 
-    // 7. Clear buffer, mark as ready
-    this.buffered.delete(diagramId);
-    this.awaitingState.delete(diagramId);
-  }
+    const diagram = await this.request(`$DB/diagrams/${diagramId}`, {});
+    this.appliedVersion.set(diagramId, diagram?.data?.version ?? 0);
+    // caller applies fetched child entities to local state here
 
-  async closeDiagram(diagramId: string): Promise<void> {
-    this.subscribedDiagrams.delete(diagramId);
-    this.buffered.delete(diagramId);
-    this.awaitingState.delete(diagramId);
-    this.appliedVersion.delete(diagramId);
-
-    // Unsubscribe only if no other diagrams open
-    if (this.subscribedDiagrams.size === 0) {
-      await this.mqtt?.unsubscribe('$DB/watch/nodes');
-      await this.mqtt?.unsubscribe('$DB/watch/edges');
-      await this.mqtt?.unsubscribe('$DB/watch/topics');
-      await this.mqtt?.unsubscribe('$DB/watch/schemas');
-      await this.mqtt?.unsubscribe('$DB/watch/variables');
+    for (const ev of this.buffered.get(diagramId) ?? []) {
+      if (ev.data?.diagramId === diagramId) this.onEvent?.(diagramId, ev);
     }
+    this.buffered.delete(diagramId);
+    this.awaiting.delete(diagramId);
   }
-
-  // ─────────────────────────────────────────────────────────────
-  // Mutation Handling (REVISED)
-  // ─────────────────────────────────────────────────────────────
 
   private handleMessage(topic: string, payload: Uint8Array): void {
-    // Parse $DB/watch/{entity} messages
-    const match = topic.match(/^\$DB\/watch\/(\w+)$/);
-    if (!match) return;
-
-    const entity = match[1];
-    const mutation = JSON.parse(new TextDecoder().decode(payload)) as Mutation;
-
-    // Extract diagramId from mutation data
-    const diagramId = mutation.data?.diagramId as string | undefined;
-    if (!diagramId) return; // Not a diagram-scoped entity
-
-    // ═══════════════════════════════════════════════════════════
-    // BUG #1 FIX: Ignore mutations for unsubscribed diagrams
-    // ═══════════════════════════════════════════════════════════
-    if (!this.subscribedDiagrams.has(diagramId)) {
+    if (!/^\$DB\/\w+\/events\//.test(topic)) return;
+    const ev = JSON.parse(new TextDecoder().decode(payload)) as ChangeEvent;
+    const diagramId = ev.data?.diagramId as string | undefined;
+    if (!diagramId || !this.subscribed.has(diagramId)) return;
+    if (this.awaiting.has(diagramId)) {
+      this.buffered.get(diagramId)?.push(ev);
       return;
     }
-
-    // If awaiting initial state, buffer the mutation
-    if (this.awaitingState.has(diagramId)) {
-      this.buffered.get(diagramId)?.push(mutation);
-      return;
-    }
-
-    // Apply the mutation
-    this.applyMutation(diagramId, mutation);
+    this.onEvent?.(diagramId, ev);
   }
-
-  private applyMutation(diagramId: string, mutation: Mutation): void {
-    this.onMutation?.(diagramId, mutation);
-  }
-
-  // ─────────────────────────────────────────────────────────────
-  // CRUD Operations - Frontend MUST bump diagram.version
-  // ─────────────────────────────────────────────────────────────
 
   async createNode(diagramId: string, data: Record<string, unknown>): Promise<string> {
-    // 1. Create the node
-    const nodeData = { ...data, diagramId };
-    const response = await this.request('$DB/create/nodes', nodeData);
-    const nodeId = response.id;
-
-    // 2. Bump diagram version (CRITICAL for sync protocol)
-    await this.bumpDiagramVersion(diagramId);
-
-    return nodeId;
+    const res = await this.request('$DB/nodes/create', { ...data, diagramId });
+    await this.bumpVersion(diagramId);
+    return res.id;
   }
 
   async updateNode(diagramId: string, id: string, data: Record<string, unknown>): Promise<void> {
-    await this.request(`$DB/update/nodes/${id}`, data);
-    await this.bumpDiagramVersion(diagramId);
+    await this.request(`$DB/nodes/${id}/update`, data);
+    await this.bumpVersion(diagramId);
   }
 
   async deleteNode(diagramId: string, id: string): Promise<void> {
-    await this.request(`$DB/delete/nodes/${id}`, {});
-    await this.bumpDiagramVersion(diagramId);
+    await this.request(`$DB/nodes/${id}/delete`, {});
+    await this.bumpVersion(diagramId);
   }
 
-  // Similar for edges, topics, schemas, variables...
-
-  private async bumpDiagramVersion(diagramId: string): Promise<void> {
-    // Fetch current version
-    const diagram = await this.fetchOne('diagrams', diagramId);
-    const currentVersion = diagram?.data?.version || 0;
-    const newVersion = currentVersion + 1;
-
-    // Update diagram with incremented version
-    await this.request(`$DB/update/diagrams/${diagramId}`, { version: newVersion });
-
-    // Update local tracking
-    this.appliedVersion.set(diagramId, newVersion);
-  }
-
-  // ─────────────────────────────────────────────────────────────
-  // Helpers
-  // ─────────────────────────────────────────────────────────────
-
-  private async fetchOne(entity: string, id: string): Promise<any> {
-    return this.request(`$DB/read/${entity}/${id}`, {});
-  }
-
-  private async fetchList(entity: string, filter: string): Promise<any[]> {
-    const response = await this.request(`$DB/list/${entity}`, { filter });
-    return response.data || [];
+  private async bumpVersion(diagramId: string): Promise<void> {
+    const next = (this.appliedVersion.get(diagramId) ?? 0) + 1;
+    await this.request(`$DB/diagrams/${diagramId}/update`, { version: next });
+    this.appliedVersion.set(diagramId, next);
   }
 
   private async request(topic: string, payload: unknown): Promise<any> {
     const responseTopic = `responses/${this.clientId}/${Date.now()}`;
     await this.mqtt!.subscribe(responseTopic, { qos: 1 });
-
-    await this.mqtt!.publish(topic, JSON.stringify(payload), {
-      qos: 1,
-      properties: { responseTopic },
-    });
-
+    await this.mqtt!.publish(topic, JSON.stringify(payload), { qos: 1, properties: { responseTopic } });
     return new Promise((resolve, reject) => {
-      const timeout = setTimeout(() => reject(new Error('Request timeout')), 10000);
-
-      const handler = (topic: string, payload: Uint8Array) => {
-        if (topic === responseTopic) {
-          clearTimeout(timeout);
-          this.mqtt!.unsubscribe(responseTopic);
-          resolve(JSON.parse(new TextDecoder().decode(payload)));
-        }
-      };
-
-      this.mqtt!.onMessage(handler);
+      const timer = setTimeout(() => reject(new Error('Request timeout')), 10000);
+      this.mqtt!.onMessage((t, p) => {
+        if (t !== responseTopic) return;
+        clearTimeout(timer);
+        this.mqtt!.unsubscribe(responseTopic);
+        resolve(JSON.parse(new TextDecoder().decode(p)));
+      });
     });
   }
 }
 ```
 
----
-
-## Key Changes from Original Plan
-
-| Original Plan | Revised Approach |
-|---------------|------------------|
-| Subscribe to `diagrams/{id}/mutations` | Subscribe to `$DB/watch/nodes`, `$DB/watch/edges`, etc. |
-| Server provides `seq` in mutations | Frontend uses `diagram.version` as the sequence |
-| Server provides `up_to_seq` in list responses | Frontend reads `diagram.version` separately |
-| Server provides `author_client_id` | Not needed - see note below |
-
-### About `author_client_id`
-
-The original plan used `author_client_id` to skip applying your own mutations. Without server support, you have two options:
-
-1. **Optimistic updates with local tracking**: Track IDs of entities you've created/modified locally, skip applying watch notifications for those IDs for a short window
-2. **Idempotent operations**: Design your local state updates to be idempotent (applying the same mutation twice has no additional effect)
+List with a filter uses `$DB/{entity}/list` and a `{ "filter": "diagramId=..." }` payload; the response `data` array holds the matching records.
 
 ---
 
-## Bug #2 Fix: Revised Approach
+## Definition of Done
 
-Without server-side sequence numbers, Bug #2 (state regression during initial sync) is harder to fix perfectly. The revised approach:
-
-1. **Buffer mutations while fetching state** (same as before)
-2. **Read `diagram.version` from fetched state**
-3. **After applying state, apply buffered mutations**
-4. **Accept that some mutations may be applied twice** - design for idempotency
-
-The `diagram.version` bump on each child mutation provides ordering, but since the server doesn't inject it into watch notifications, you can't filter precisely. The key protection is:
-- Buffering prevents mutations from being applied before state
-- Idempotent local operations prevent corruption from double-apply
-
----
-
-## Watch Notification Format
-
-The `$DB/watch/{entity}` topics publish notifications in this format:
-
-```json
-{
-  "op": "insert",
-  "entity": "nodes",
-  "id": "node-123",
-  "data": { "diagramId": "d1", "type": "broker", "positionX": 100, "positionY": 200 }
-}
-```
-
-Note: No `seq`, no `author_client_id`. Filter by `data.diagramId`.
-
----
-
-## Definition of Done (Revised)
-
-- [ ] SyncClient subscribes to `$DB/watch/{entity}` (not `diagrams/{id}/mutations`)
-- [ ] SyncClient filters by `data.diagramId` to route to correct diagram
-- [ ] SyncClient implements Bug #1 fix (ignore unsubscribed diagrams)
-- [ ] SyncClient buffers mutations during initial state fetch
-- [ ] CRUD operations bump `diagram.version` after each mutation
-- [ ] Local operations are idempotent (safe to apply twice)
-- [ ] All tests in checklist pass
+- [ ] CRUD uses entity-first topics (`$DB/{entity}/create`, `$DB/{entity}/{id}/update`, ...)
+- [ ] SyncClient subscribes to `$DB/{entity}/events/#` and routes by `data.diagramId`
+- [ ] Events for unsubscribed diagrams are ignored
+- [ ] Events are buffered during initial state fetch, then drained
+- [ ] CRUD bumps `diagram.version` after each mutation
+- [ ] Local applies are idempotent

--- a/docs/integration/mqdb-agent.md
+++ b/docs/integration/mqdb-agent.md
@@ -1,8 +1,8 @@
-# MQDB Agent: Frontend Integration Tasks
+# MQDB Agent Integration Reference
 
-## Status: ✅ COMPLETE
+Purpose: MQTT topics, event format, and startup flags a frontend uses to talk to the MQDB agent. MQDB provides generic infrastructure; application-specific sync logic lives in the frontend.
 
-MQDB provides generic infrastructure. Application-specific sync logic is handled by the frontend.
+## Status: current
 
 ---
 
@@ -12,7 +12,7 @@ MQDB provides generic infrastructure. Application-specific sync logic is handled
 |---------|--------|-------|
 | WebSocket listener | ✅ | `--ws-bind 0.0.0.0:8080` |
 | MQTT over WebSocket | ✅ | Browser connects to `ws://host:8080/mqtt` |
-| CRUD operations | ✅ | `$DB/create/{entity}`, `$DB/read/{entity}/{id}`, etc. |
+| CRUD operations | ✅ | `$DB/{entity}/create`, `$DB/{entity}/{id}`, `$DB/{entity}/{id}/update`, `$DB/{entity}/{id}/delete`, `$DB/{entity}/list` |
 | Real-time events | ✅ | `$DB/{entity}/events/#` for change notifications |
 | Change-only delivery | ✅ | Duplicate payloads suppressed on `$DB/+/events/#` |
 | Foreign keys | ✅ | CASCADE delete supported |
@@ -73,8 +73,10 @@ MQDB has no concept of "diagrams" or parent-child versioning. It's just a databa
 ### Starting the broker
 
 ```bash
-mqdb agent start --db /path --bind 0.0.0.0:1883 --ws-bind 0.0.0.0:8080 --anonymous
+mqdb agent start --db /path --bind 0.0.0.0:1883 --ws-bind 0.0.0.0:8080 --passwd passwd.txt
 ```
+
+`--anonymous` is available only when built with the `dev-insecure` feature; use `--passwd` (or another auth source) otherwise.
 
 ### Browser connection
 

--- a/docs/integration/mqtt-lib-agent.md
+++ b/docs/integration/mqtt-lib-agent.md
@@ -1,8 +1,10 @@
-# mqtt-lib Agent: Frontend Integration Tasks
+# mqtt-lib Integration Reference
 
-## Status: ✅ COMPLETE
+Purpose: how MQDB configures MQTT-over-WebSocket in the `mqtt5` broker library, for browser clients.
 
-WebSocket support is **fully implemented** in the mqtt5 broker. No additional work needed.
+## Status: implemented
+
+WebSocket support is available in the `mqtt5` broker via `WebSocketConfig`.
 
 ---
 
@@ -27,19 +29,11 @@ broker.run().await?;
 
 | Method | Description |
 |--------|-------------|
-| `with_bind_address(addr)` | Address to listen on (required) |
-| `with_path(path)` | WebSocket endpoint path (default: `/`) |
-| `with_tls(tls_config)` | Enable TLS (WSS) |
+| `with_bind_address(addr)` | Address to listen on |
+| `with_path(path)` | WebSocket endpoint path (default: `/mqtt`) |
+| `with_tls(use_tls: bool)` | Enable TLS (WSS) |
 
----
-
-## Integration Summary
-
-| Item | Status | Consumer |
-|------|--------|----------|
-| WebSocket listener API | ✅ Documented | MQDB agent |
-| `mqtt` subprotocol | ✅ Handled internally | Browser clients |
-| Binary frame handling | ✅ Handled internally | MQTT codec |
+The `mqtt` subprotocol and binary frame handling are managed internally by the codec.
 
 ---
 
@@ -56,13 +50,4 @@ ws.onopen = () => console.log('Connected');
 ws.onmessage = (e) => console.log('Received:', e.data);
 ```
 
----
-
-## Original Context
-
-MQDB is being integrated with a frontend diagramming application. Browser clients connect to the MQDB broker via MQTT over WebSocket.
-
-- **Client-side (browser):** `mqtt5-wasm` crate
-- **Server-side (broker):** `mqtt5` crate with `WebSocketConfig`
-
-This documentation was requested to confirm WebSocket support exists. It does. The MQDB agent document has been updated with these API details.
+Browser clients use the `mqtt5-wasm` crate; the server uses `mqtt5` with `WebSocketConfig`.

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,70 +1,38 @@
 # MQDB Release Guide
 
+How maintainers cut and publish an MQDB release.
+
 ## Prerequisites
 
 - All tests pass: `cargo make test`
 - All lints pass: `cargo make clippy`
-- Changelog updated (if applicable)
 
-## mqtt-lib Dependency Patches
+## Process
 
-The `Cargo.toml` contains local path patches for rapid development iteration:
+Releases are triggered by pushing a `v*` tag. The tag **must** equal the
+`mqdb-cli` version — `.github/workflows/release.yml` verifies that
+`TAG == mqdb-cli version` and fails the run otherwise. Bump `mqdb-cli` first,
+even if only another crate changed.
 
-```toml
-[patch.crates-io]
-mqtt5 = { path = "../mqtt-lib/crates/mqtt5" }
-mqtt5-protocol = { path = "../mqtt-lib/crates/mqtt5-protocol" }
-```
+1. [ ] Bump the version in `crates/mqdb-cli/Cargo.toml` **first**. Bump any other
+       crates being released (`mqdb-core`, `mqdb-agent`, `mqdb-wasm`) as needed.
+2. [ ] Add a dated `CHANGELOG.md` heading listing the released crate versions:
+       `## YYYY-MM-DD — mqdb-cli <ver>[, mqdb-core <ver>, ...]`. The heading must
+       list `mqdb-cli <tag>` — CI anchors the release notes on it.
+3. [ ] Run `cargo make ci` (format-check + clippy + test).
+4. [ ] Commit, then create and push the tag: `git tag v<mqdb-cli-version>` and
+       `git push origin v<mqdb-cli-version>`.
 
-These patches override the crates.io dependencies with local copies, which is useful during development but prevents reproducible builds.
+## What CI does
 
-### For Reproducible Release Builds
+On the pushed `v*` tag, `release.yml` runs three jobs:
 
-**Option 1: Comment out patches (recommended)**
-
-```toml
-# [patch.crates-io]
-# mqtt5 = { path = "../mqtt-lib/crates/mqtt5" }
-# mqtt5-protocol = { path = "../mqtt-lib/crates/mqtt5-protocol" }
-```
-
-**Option 2: Remove patches entirely**
-
-Delete the `[patch.crates-io]` section from Cargo.toml.
-
-After either option, run:
-```bash
-cargo update -p mqtt5 -p mqtt5-protocol
-cargo make ci
-```
-
-### Version Pinning
-
-For strict version control in releases, use exact versions:
-
-```toml
-mqtt5 = { version = "=0.22.0", optional = true }
-```
-
-## Release Checklist
-
-1. [ ] Update version in `Cargo.toml`
-2. [ ] Remove or comment out `[patch.crates-io]` section
-3. [ ] Run `cargo update -p mqtt5 -p mqtt5-protocol`
-4. [ ] Run `cargo make ci` (format-check + clippy + test)
-5. [ ] Build release binary: `cargo make build-release`
-6. [ ] Test release binary manually
-7. [ ] Create git tag: `git tag -a v0.X.Y -m "Release 0.X.Y"`
-8. [ ] Push tag: `git push origin v0.X.Y`
-9. [ ] Restore patches for continued development (if desired)
-
-## Published Crate Versions
-
-The mqtt-lib crates are published to crates.io:
-
-| Crate | Version | Published |
-|-------|---------|-----------|
-| mqtt5 | 0.22.0 | March 2025 |
-| mqtt5-protocol | 0.9.4 | March 2025 |
-
-These are the versions that will be used when patches are removed.
+1. **Publish to crates.io** — verifies the tag matches the `mqdb-cli` version,
+   then publishes `mqdb-core`, `mqdb-agent`, and `mqdb-wasm` (each
+   `|| echo "already published"`, so re-runs are safe).
+2. **Build binaries** — cross-builds four platform binaries with
+   `cargo build --profile dist --package mqdb-cli --no-default-features
+   --features http-api`: linux-amd64, macos-amd64, macos-arm64, windows-amd64.
+3. **Create GitHub release** — extracts the release body from `CHANGELOG.md` by
+   matching the dated heading that lists `mqdb-cli <tag>`, then attaches the four
+   binaries to the release.

--- a/docs/testing/01-setup.md
+++ b/docs/testing/01-setup.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for building the CLI, starting an agent, error handling, and troubleshooting. Start here — the other guides assume an agent started as shown below.
+
 ## Prerequisites
 
 ### Build the CLI

--- a/docs/testing/02-crud.md
+++ b/docs/testing/02-crud.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for basic CRUD operations and output formats. Assumes an agent started per 01-setup.
+
 ## 2. Basic CRUD Operations
 
 > **Note:** These examples assume the agent started in Section 1 with `--passwd`. All commands

--- a/docs/testing/03-queries.md
+++ b/docs/testing/03-queries.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for filtering, sorting, pagination, limits, edge cases, and MQTT-only query features. Assumes an agent started per 01-setup.
+
 ## 3. List and Filtering
 
 ### Setup Test Data
@@ -146,6 +148,7 @@ MQDB enforces hard limits on query complexity: `MAX_FILTERS=16`, `MAX_SORT_FIELD
 ### Setup
 
 ```bash
+mqdb passwd admin -b admin123 -f /tmp/passwd.txt
 mqdb agent start --db /tmp/mqdb-limits-test --bind 127.0.0.1:1883 --passwd /tmp/passwd.txt --admin-users admin
 ```
 
@@ -249,6 +252,7 @@ mqdb list products \
 ### Setup
 
 ```bash
+mqdb passwd admin -b admin123 -f /tmp/passwd.txt
 mqdb agent start --db /tmp/mqdb-sort-test --bind 127.0.0.1:1883 --passwd /tmp/passwd.txt --admin-users admin
 ```
 
@@ -344,6 +348,7 @@ mqdb list nullsort --sort 'missing_field:asc' --user admin --pass admin123
 ### Setup
 
 ```bash
+mqdb passwd admin -b admin123 -f /tmp/passwd.txt
 mqdb agent start --db /tmp/mqdb-filter-test --bind 127.0.0.1:1883 --passwd /tmp/passwd.txt --admin-users admin
 ```
 
@@ -467,6 +472,7 @@ These features are accessible only via MQTT payloads, not through CLI `--filter`
 ### Setup
 
 ```bash
+mqdb passwd admin -b admin123 -f /tmp/passwd.txt
 mqdb agent start --db /tmp/mqdb-mqtt-query-test --bind 127.0.0.1:1883 --passwd /tmp/passwd.txt --admin-users admin
 ```
 

--- a/docs/testing/04-schema.md
+++ b/docs/testing/04-schema.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for schema management and constraints (unique, foreign key, not-null, cascade). Assumes an agent started per 01-setup.
+
 ## 4. Schema Management
 
 ### Create Schema File

--- a/docs/testing/05-indexes.md
+++ b/docs/testing/05-indexes.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for index management, range queries, projection, and backfill. Assumes an agent started per 01-setup.
+
 ## 5b. Index Management
 
 Indexes optimize range filter queries (`>`, `>=`, `<`, `<=`) by avoiding full table scans.
@@ -473,6 +475,7 @@ mqdb dev kill
 ### Setup
 
 ```bash
+mqdb passwd admin -b admin123 -f /tmp/passwd.txt
 mqdb agent start --db /tmp/mqdb-index-test --bind 127.0.0.1:1883 --passwd /tmp/passwd.txt --admin-users admin
 ```
 

--- a/docs/testing/06-subscriptions.md
+++ b/docs/testing/06-subscriptions.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for reactive subscriptions and consumer groups. Assumes an agent started per 01-setup.
+
 ## 6. Reactive Subscriptions
 
 ### Watch Command (Broadcast)
@@ -18,7 +20,7 @@ mqdb create users --data '{"name": "Watcher Test"}'
 
 **Expected in Terminal 3:**
 ```json
-{"type": "create", "entity": "users", "id": "...", "data": {"name": "Watcher Test"}}
+{"sequence": 0, "entity": "users", "id": "...", "operation": "Create", "data": {"name": "Watcher Test"}}
 ```
 
 ### Subscribe with Consumer Group (Load-Balanced)

--- a/docs/testing/07-auth.md
+++ b/docs/testing/07-auth.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for password, SCRAM, and JWT authentication, ACLs, topic protection, and ownership. Assumes an agent started per 01-setup.
+
 ## 9. Authentication
 
 ### Create Password File

--- a/docs/testing/08-vault.md
+++ b/docs/testing/08-vault.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for vault transparent encryption. Assumes an agent started per 01-setup and an Enterprise license.
+
 ## 25. Vault Encryption Testing
 
 ### Prerequisites

--- a/docs/testing/09-backup.md
+++ b/docs/testing/09-backup.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for backup creation and restore. Assumes an agent started per 01-setup.
+
 ## 8. Backup and Restore
 
 ### Create Backup
@@ -11,7 +13,13 @@ mqdb backup create
 mqdb backup create --name my-snapshot
 ```
 
-The `--name` flag is optional (default: `backup`).
+The `--name` flag is optional (default: `backup`). The backup is written to a directory named
+exactly `<name>` (no timestamp is appended).
+
+**Expected output:**
+```
+backup created: my-snapshot
+```
 
 ### List Backups
 
@@ -19,12 +27,31 @@ The `--name` flag is optional (default: `backup`).
 mqdb backup list
 ```
 
-### Restore from Backup
-
-Restore sends a restore command to the running broker via MQTT. The agent handles the restore internally — no restart required.
-
-```bash
-mqdb restore --name backup_20241208_143022
+**Expected output:**
+```
+Available backups:
+  backup
+  my-snapshot
 ```
 
+An empty backup directory prints `No backups found`.
+
+### Restore from Backup
+
+```bash
+mqdb restore --name my-snapshot
+```
+
+> **Note:** In agent mode the `$DB/_admin/restore` endpoint is not handled online — it returns
+> `Error: restore requires agent restart - use CLI with --restore flag`. Restore a snapshot by
+> stopping the agent and starting it against the restored data directory.
+
 All backup/restore commands connect to the broker (support `--broker`, `--user`, `--pass`, `--insecure` flags).
+
+### Verification Checklist
+
+- [ ] `mqdb backup create --name my-snapshot` prints `backup created: my-snapshot`
+- [ ] A `my-snapshot` directory exists under the agent's backup directory
+- [ ] `mqdb backup list` includes `my-snapshot`
+- [ ] `mqdb backup list` on a fresh agent prints `No backups found`
+- [ ] `mqdb restore --name my-snapshot` reports the restart-required error in agent mode

--- a/docs/testing/10-cluster.md
+++ b/docs/testing/10-cluster.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for cluster-mode setup, dev commands, and multi-node operation. Assumes generated TLS certs and an Enterprise license.
+
 ## 11. Cluster Mode
 
 Cluster mode runs a distributed MQDB with Raft consensus for partition management.
@@ -31,7 +33,8 @@ mqdb cluster start --node-id 1 --bind 127.0.0.1:1883 --db /tmp/mqdb-node1 \
 - Becomes Raft leader immediately (single-node quorum)
 - Assigns all 256 partitions to itself
 
-> **Tip:** For quick testing without TLS, use `--no-quic` to fall back to TCP bridges.
+> **Tip:** `--no-quic` disables QUIC and falls back to the deprecated TCP bridge transport.
+> QUIC is the default and only recommended transport; use `--no-quic` only for legacy debugging.
 
 ### Starting a Multi-Node Cluster (Manual)
 
@@ -136,18 +139,28 @@ mqdb cluster start --node-id 1 --bind 127.0.0.1:1883 --db /tmp/mqdb-test \
 mqdb cluster status --broker 127.0.0.1:1883
 ```
 
-**Expected output:**
-```json
-{
-  "leader": 1,
-  "nodes": [
-    {"id": 1, "name": "node-1", "status": "alive"},
-    {"id": 2, "name": "node-2", "status": "alive"},
-    {"id": 3, "name": "node-3", "status": "alive"}
-  ],
-  "partitions": 256
-}
+**Expected output** (the CLI prints a formatted summary, not JSON):
 ```
+┌─────────────────────────────────────────┐
+│             CLUSTER STATUS              │
+├─────────────────────────────────────────┤
+│ Node:     node-1 (id=1)                 │
+│ Role:     Leader                        │
+│ Term:     1                             │
+├─────────────────────────────────────────┤
+│ Nodes:    3 total (1 + [2, 3])          │
+├─────────────────────────────────────────┤
+│ Partitions: 256 total                   │
+│   Node 1: 86 primary                    │
+│   Node 2: 85 primary                    │
+│   Node 3: 85 primary                    │
+│   Replicated: 256/256                   │
+└─────────────────────────────────────────┘
+```
+
+The CLI reads the `$SYS/mqdb/cluster/status` endpoint, whose `data` payload carries
+`node_id`, `node_name`, `is_raft_leader`, `raft_term`, `alive_nodes`, `partition_count`,
+and `partitions` as an array of `{"id", "primary", "replicas", "epoch"}` objects.
 
 ### Trigger Rebalance
 

--- a/docs/testing/11-cluster-tests.md
+++ b/docs/testing/11-cluster-tests.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for cluster resilience, MQTT protocol behavior, cluster constraints, DB features, and scatter-gather queries. Assumes a running cluster per 10-cluster.
+
 > **License:** All cluster tests require an Enterprise license. Pass `--license /path/to/license.key`
 > to every `mqdb dev start-cluster` and `mqdb cluster start` command. Examples below omit `--license`
 > for brevity — add it to every cluster start invocation.

--- a/docs/testing/12-benchmarks.md
+++ b/docs/testing/12-benchmarks.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for the pub/sub and database benchmark harness and the health endpoint. Assumes an agent or cluster started per 01-setup or 10-cluster.
+
 ## 15. Benchmarking
 
 The `mqdb bench` commands measure performance.
@@ -52,7 +54,7 @@ mqdb bench db \
 |--------|-------------|---------|
 | `--operations` | Number of operations | `1000` |
 | `--entity` | Entity name to use | `bench_entity` |
-| `--op` | Operation type: `insert`, `get`, `update`, `delete`, `list`, `mixed` | `mixed` |
+| `--op` | Operation type: `insert`, `get`, `update`, `delete`, `list`, `mixed`, `changefeed`, `unique`, `cascade` | `mixed` |
 | `--concurrency` | Number of concurrent clients | `1` |
 | `--fields` | Fields per record | `5` |
 | `--field-size` | Size of each field value in bytes | `100` |
@@ -62,8 +64,16 @@ mqdb bench db \
 | `--no-latency` | Disable latency tracking for pure throughput | `false` |
 | `--async` | Use pipelined mode (fire all ops, collect responses) | `false` |
 | `--qos` | MQTT QoS level for async mode | `1` |
-| `--duration` | Duration in seconds (async mode only, overrides `--operations`) | (none) |
+| `--duration` | Duration in seconds (async mode / `changefeed`, overrides `--operations`) | (none) |
+| `--write-rate` | Write rate in ops/sec (`changefeed` op only) | `500` |
+| `--attempts-per-client` | Attempts per client on the contested field (`unique` op only) | `100` |
+| `--children` | Children per parent (`cascade` op only) | `100` |
+| `--runs` | Cascade iterations (`cascade` op only) | `5` |
 | `--format` | Output format: `json`, `table`, `csv` | `table` |
+
+> **Extended ops:** `changefeed` measures live event-delivery latency (drives writes with `--write-rate`
+> for `--duration`); `unique` stress-tests unique-constraint contention (`--attempts-per-client`);
+> `cascade` measures cascade-delete fan-out (`--children` per parent over `--runs` iterations).
 
 > **QoS Warning:** Async mode defaults to QoS 1 because QoS 0 causes connection resets at
 > ~5000 ops/s due to lack of flow control. QoS 1's PUBACK provides natural backpressure.

--- a/docs/testing/13-http-api.md
+++ b/docs/testing/13-http-api.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for OAuth/identity HTTP endpoints, email verification, and admin MQTT endpoints. Assumes an agent started per 01-setup with `--http-bind` and OAuth configured.
+
 ## 26. OAuth/Identity HTTP Endpoints
 
 The HTTP server provides OAuth 2.0 login, session management, and identity linking.

--- a/docs/testing/14-checklists.md
+++ b/docs/testing/14-checklists.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual test checklists covering quick verification, complete verification, and additions. Assumes an agent started per 01-setup.
+
 ## Quick Test Checklist
 
 Run through these commands to validate core functionality.

--- a/docs/testing/15-license.md
+++ b/docs/testing/15-license.md
@@ -2,6 +2,8 @@
 
 [Back to index](README.md)
 
+Manual tests for license key verification and feature enforcement. Assumes a built CLI per 01-setup.
+
 ## Overview
 
 MQDB uses ECDSA P-256 signed license tokens to gate commercial features (vault encryption, clustering). Tokens are generated externally and verified by the MQDB binary using an embedded public key.

--- a/docs/vault.md
+++ b/docs/vault.md
@@ -117,7 +117,7 @@ Vault operations are also available over MQTT 5.0 request-response. Set the `res
 
 Responses follow the standard MQDB response envelope: `{"status": "ok", "data": {...}}` on success, `{"status": "error", "code": N, "message": "..."}` on failure.
 
-Unlock attempts are rate-limited per user per minute (MQTT path: 10, HTTP path: 5). Wrong passphrase returns error code 401 (Unauthorized), rate limiting returns error code 429 (RateLimited).
+Unlock attempts are rate-limited to 5 per user per minute (both MQTT and HTTP paths share the same limiter). Wrong passphrase returns error code 401 (Unauthorized), rate limiting returns error code 429 (RateLimited).
 
 The `$DB/_vault/*` topics are exempt from internal entity topic protection, so any authenticated user can publish to them without admin privileges.
 
@@ -216,7 +216,7 @@ This recovers exactly one failure: the batch had already finished and only the `
 
 ## Security considerations
 
-**Rate limiting.** Unlock attempts are rate-limited per user per minute (HTTP: 5, MQTT: 10). This prevents online brute-force attacks through the API but does not protect against offline attacks on stolen database files.
+**Rate limiting.** Unlock attempts are rate-limited to 5 per user per minute (both MQTT and HTTP paths share the same limiter). This prevents online brute-force attacks through the API but does not protect against offline attacks on stolen database files.
 
 **Passphrase length enforcement.** Use `--vault-min-passphrase-length N` to reject short passphrases on enable and change operations. This is a defense-in-depth measure against weak passphrases. It does not apply to unlock or disable (which verify an existing passphrase, not set a new one).
 


### PR DESCRIPTION
## Summary

Documentation audit cleanup, a dependency upgrade, and a clippy pass.

Docs (39 files):
- Fixed stale source paths, partition range (p0-p255), missing error-enum variants, a wrong deterministic-nonce claim, and the vault rate limit in the reference docs; reframed transport sections to QUIC-default with bridges deprecated.
- Corrected integration-doc topics to entity-first and replaced the nonexistent $DB/watch with $DB/{entity}/events/#.
- Added implemented/planned/on-hold status markers to the design docs.
- Rewrote release.md around release.yml; refreshed CHANGELOG, SECURITY, and CONTRIBUTING; fixed the README intro and added a table of contents.
- Added a one-line intro to testing guides 01-15 and corrected stale watch/op/cluster-status examples.
- Corrected benchmark anomaly IDs and extracted the bridge-overhead investigation to its own file.

Dependencies:
- Updated mqtt5 to 0.35.1 and opentelemetry to 0.32, moving opentelemetry_sdk to 0.32.1 and clearing the last Dependabot advisory.
- Bumped mqdb-cli 0.8.14, mqdb-agent 0.8.11, mqdb-cluster 0.3.8, mqdb-vault 0.1.3.
- Cleared the pre-existing pedantic clippy warnings across the workspace.

## Test plan

- [ ] cargo make dev passes (format, clippy -D warnings, full test suite)
- [ ] TOC anchors and relative links resolve
- [ ] Docs claims verified against code
