### PR TITLE
close unique-constraint oversell in agent and cluster modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-07-11 — mqdb-cli 0.8.15, mqdb-cluster 0.4.0, mqdb-agent 0.8.12, mqdb-core 0.7.4
+
+### Fixed
+
+- **Unique-constraint oversell (agent mode).** `Database::create`/`update` could commit two records for the same unique value under concurrency because the check across the constraint reservation and the record write was not atomic. Unique enforcement is now an id-free compare-and-swap: a `uniq/{entity}/{field}/{value}` guard key is written under a new `expect_absent` storage precondition, so the guard claim and the record write commit or fail together. New `mqdb-core` API: an `expect_absent` precondition on the backend batch commit (in-memory, fjall, and encrypted backends). Verified in TLA+ (`specs/UniqueGuard.tla`) and by in-process barrier tests — 200 concurrent creates of the same value that previously all oversold now yield exactly one winner.
+
+- **Unique-constraint oversell (cluster mode).** The distributed unique reservation was a fragile per-node in-memory lock, decoupled from the durable+replicated record, that could oversell through durability/TTL loss, the promotion gap, dual-primary failover, and dropped commits. The cluster unique path is now an epoch-fenced, quorum-durable, seal-on-promotion protocol (Option C, modelled and verified in `specs/ClusterUniqueQuorum.tla`):
+  - reserve/commit/release are persisted, fsync'd, and replicated to a fixed quorum group (the registered cluster membership), decoupled from data replication factor;
+  - a reserve returns success only after a **majority** of the group holds it, fail-closed on timeout, on both the primary MQTT create path and the forwarded (cross-node) create/update path — the latter now runs its majority-await outside the controller lock via the pending-work path (a prior inline await would have deadlocked, and also removed a latent up-to-5s stall);
+  - on promotion a new primary **seals** the partition: it promises its epoch at a majority (fencing a superseded primary, whose stale-epoch group writes are then rejected so its reserves can't reach a majority) and **learns** any reservation it missed from the read quorum, so it cannot re-grant an already-held value; it refuses to serve reserves until sealed;
+  - a member never reassigns a **committed** value to a different record;
+  - a record-driven reconciler (leader-driven, periodic) repairs a reservation lost to failover/restart or a lost commit from the durable record, reclaims abandoned claims by TTL only when the record is absent, and surfaces any detected oversell.
+
+  These mechanisms are individually load-bearing and jointly close the dual-primary oversell, verified in TLA+: `specs/ClusterUniqueMonotonic.tla` shows that dropping the seal's reservation-learning step reintroduces oversell (a promoted primary that missed an *uncommitted* reservation re-grants the value), so the seal-learning is required — the implementation now matches the verified `ClusterUniqueQuorum` model. A not-yet-durable reserve (partition unsealed, no primary, or quorum timeout) now returns a retryable `503` instead of a misleading `409 unique constraint violation`.
+
+- `mqdb-cli`: replaced an `if let … else { return None }` with the `?` operator in license verification to satisfy a newer clippy `question_mark` lint (unblocks the pre-commit hook on the current toolchain).
+
 ## 2026-07-06 — mqdb-cli 0.8.14, mqdb-agent 0.8.11, mqdb-cluster 0.3.8, mqdb-vault 0.1.3
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.8.11"
+version = "0.8.12"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.14"
+version = "0.8.15"
 dependencies = [
  "base64",
  "bebytes",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cluster"
-version = "0.3.8"
+version = "0.4.0"
 dependencies = [
  "arc-swap",
  "bebytes",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/README.md
+++ b/README.md
@@ -292,6 +292,16 @@ db.add_unique_constraint("users".into(), vec!["email".into()]).await?;
 db.add_unique_constraint("posts".into(), vec!["user_id".into(), "slug".into()]).await?;
 ```
 
+Unique enforcement is atomic and never oversells (two records sharing one unique value), even under
+concurrency and failover. In agent mode the reservation and record write are one compare-and-swap over
+an `expect_absent` guard key. In cluster mode the claim is epoch-fenced and quorum-durable: a reserve
+succeeds only once a majority of the value's quorum group holds it, a newly promoted primary seals the
+partition (promising its epoch at a majority and learning any reservation it missed) before serving,
+and a record-driven reconciler repairs claims lost to failover. The design is verified in TLA+
+(`specs/ClusterUniqueQuorum.tla`, `specs/UniqueGuard.tla`); see `docs/design/cluster-unique-hardening.md`.
+While a partition is briefly unsealed after a promotion, a unique create fails closed with a retryable
+`503` rather than a spurious conflict.
+
 ### Not-Null Constraints
 
 ```rust

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.8.11"
+version = "0.8.12"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-agent/src/database/crud.rs
+++ b/crates/mqdb-agent/src/database/crud.rs
@@ -14,6 +14,19 @@ use mqdb_core::types::{AccessLevel, OwnershipConfig, SHARES_ENTITY};
 
 const MAX_WRITE_ATTEMPTS: u32 = 32;
 
+fn map_unique_guard_conflict(err: Error) -> Error {
+    if let Error::AbsentPreconditionViolated(ref key) = err
+        && let Some((entity, field, value_bytes)) = keys::decode_unique_guard_key(key)
+    {
+        return Error::UniqueViolation {
+            entity,
+            field,
+            value: String::from_utf8_lossy(&value_bytes).to_string(),
+        };
+    }
+    err
+}
+
 pub struct CallerContext<'a> {
     pub sender: Option<&'a str>,
     pub client_id: Option<&'a str>,
@@ -108,7 +121,7 @@ impl Database {
         let operation_id = uuid::Uuid::new_v4().to_string();
         self.outbox.enqueue_event(&mut batch, &operation_id, &event);
 
-        batch.commit()?;
+        batch.commit().map_err(map_unique_guard_conflict)?;
 
         self.dispatcher.dispatch(event).await?;
         self.outbox.mark_delivered(&operation_id)?;
@@ -277,7 +290,7 @@ impl Database {
         let operation_id = uuid::Uuid::new_v4().to_string();
         self.outbox.enqueue_event(&mut batch, &operation_id, &event);
 
-        batch.commit()?;
+        batch.commit().map_err(map_unique_guard_conflict)?;
 
         self.dispatcher.dispatch(event).await?;
         self.outbox.mark_delivered(&operation_id)?;
@@ -352,7 +365,6 @@ impl Database {
             &self.storage,
             ownership_ctx.as_ref(),
         )?;
-        drop(constraint_manager);
 
         let mut batch = self.storage.batch();
 
@@ -362,6 +374,8 @@ impl Database {
         let index_manager = self.index_manager.read().await;
         index_manager.remove_indexes(&mut batch, &existing_entity);
         drop(index_manager);
+
+        constraint_manager.release_unique_guards(&existing_entity, &mut batch)?;
 
         let mut deleted_entities: Vec<(String, String, Value)> = Vec::new();
         let mut set_null_entities: Vec<(String, String, Value)> = Vec::new();
@@ -383,6 +397,8 @@ impl Database {
                         index_manager.remove_indexes(&mut batch, &cascade_entity);
                         drop(index_manager);
 
+                        constraint_manager.release_unique_guards(&cascade_entity, &mut batch)?;
+
                         deleted_entities.push((
                             cascade_op.entity.clone(),
                             cascade_op.id.clone(),
@@ -400,6 +416,16 @@ impl Database {
                         )?;
 
                         let old_entity = entity.clone();
+
+                        if let Some(old_val) = old_entity.get_field(&set_null_op.field) {
+                            let value_bytes = mqdb_core::keys::encode_value_for_index(old_val)?;
+                            let guard = keys::encode_unique_guard_key(
+                                &set_null_op.entity,
+                                &set_null_op.field,
+                                &value_bytes,
+                            );
+                            batch.remove(guard);
+                        }
 
                         if let Some(obj) = entity.data.as_object_mut() {
                             obj.insert(set_null_op.field.clone(), serde_json::Value::Null);
@@ -428,6 +454,8 @@ impl Database {
                 }
             }
         }
+
+        drop(constraint_manager);
 
         let primary_scope = scope_config.resolve_scope(entity_name, &existing_entity.data);
         let mut events = vec![
@@ -715,6 +743,219 @@ mod concurrency_tests {
             .await
             .unwrap();
         (tmp, Arc::new(db))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn concurrent_unique_create_never_oversells() {
+        use tokio::sync::Barrier;
+
+        const ROUNDS: usize = 200;
+        const WRITERS: usize = 8;
+
+        let (_tmp, db) = test_db().await;
+        db.add_unique_constraint("hold".to_string(), vec!["seat_id".to_string()])
+            .await
+            .unwrap();
+
+        for round in 0..ROUNDS {
+            let seat = format!("SEAT{round}");
+            let barrier = Arc::new(Barrier::new(WRITERS));
+            let mut handles = Vec::with_capacity(WRITERS);
+
+            for writer in 0..WRITERS {
+                let db = Arc::clone(&db);
+                let barrier = Arc::clone(&barrier);
+                let seat = seat.clone();
+                handles.push(tokio::spawn(async move {
+                    let scope = ScopeConfig::default();
+                    let hold_id = format!("h{round}_{writer}");
+                    barrier.wait().await;
+                    db.create(
+                        "hold".to_string(),
+                        json!({ "id": hold_id, "seat_id": seat }),
+                        None,
+                        None,
+                        None,
+                        &scope,
+                    )
+                    .await
+                }));
+            }
+
+            let mut winners = 0usize;
+            for handle in handles {
+                if handle.await.unwrap().is_ok() {
+                    winners += 1;
+                }
+            }
+
+            let seat_bytes = keys::encode_value_for_index(&json!(seat)).unwrap();
+            let prefix = keys::encode_index_prefix("hold", "seat_id", Some(&seat_bytes));
+            let committed = db.storage.prefix_scan(&prefix).unwrap().len();
+            assert_eq!(
+                winners, 1,
+                "round {round}: {winners} winners on one seat (oversell)"
+            );
+            assert_eq!(
+                committed, 1,
+                "round {round}: {committed} index rows for {seat}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn concurrent_unique_update_never_double_claims() {
+        use tokio::sync::Barrier;
+
+        const ROUNDS: usize = 200;
+
+        let (_tmp, db) = test_db().await;
+        db.add_unique_constraint("hold".to_string(), vec!["seat_id".to_string()])
+            .await
+            .unwrap();
+        let scope = ScopeConfig::default();
+
+        for round in 0..ROUNDS {
+            for r in 0..2 {
+                db.create(
+                    "hold".to_string(),
+                    json!({ "id": format!("h{round}_{r}"), "seat_id": format!("INIT{round}_{r}") }),
+                    None,
+                    None,
+                    None,
+                    &scope,
+                )
+                .await
+                .unwrap();
+            }
+
+            let target = format!("SEAT{round}");
+            let barrier = Arc::new(Barrier::new(2));
+            let mut handles = Vec::with_capacity(2);
+            for r in 0..2 {
+                let db = Arc::clone(&db);
+                let barrier = Arc::clone(&barrier);
+                let target = target.clone();
+                handles.push(tokio::spawn(async move {
+                    let scope = ScopeConfig::default();
+                    let caller = CallerContext {
+                        sender: None,
+                        client_id: None,
+                        scope_config: &scope,
+                    };
+                    barrier.wait().await;
+                    db.update(
+                        "hold".to_string(),
+                        format!("h{round}_{r}"),
+                        json!({ "seat_id": target }),
+                        None,
+                        &caller,
+                    )
+                    .await
+                }));
+            }
+
+            let mut winners = 0usize;
+            for handle in handles {
+                if handle.await.unwrap().is_ok() {
+                    winners += 1;
+                }
+            }
+
+            let seat_bytes = keys::encode_value_for_index(&json!(target)).unwrap();
+            let prefix = keys::encode_index_prefix("hold", "seat_id", Some(&seat_bytes));
+            let committed = db.storage.prefix_scan(&prefix).unwrap().len();
+            assert_eq!(
+                winners, 1,
+                "round {round}: {winners} updates claimed the same value (double-claim)"
+            );
+            assert_eq!(
+                committed, 1,
+                "round {round}: {committed} records hold {target}"
+            );
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn delete_releases_unique_guard() {
+        let (_tmp, db) = test_db().await;
+        db.add_unique_constraint("hold".to_string(), vec!["seat_id".to_string()])
+            .await
+            .unwrap();
+        let scope = ScopeConfig::default();
+
+        db.create(
+            "hold".to_string(),
+            json!({ "id": "a", "seat_id": "S1" }),
+            None,
+            None,
+            None,
+            &scope,
+        )
+        .await
+        .unwrap();
+
+        let dup = db
+            .create(
+                "hold".to_string(),
+                json!({ "id": "b", "seat_id": "S1" }),
+                None,
+                None,
+                None,
+                &scope,
+            )
+            .await;
+        assert!(dup.is_err(), "duplicate unique value must be rejected");
+
+        let ownership = OwnershipConfig::default();
+        db.delete(
+            "hold".to_string(),
+            "a".to_string(),
+            None,
+            None,
+            &scope,
+            &ownership,
+        )
+        .await
+        .unwrap();
+
+        db.create(
+            "hold".to_string(),
+            json!({ "id": "c", "seat_id": "S1" }),
+            None,
+            None,
+            None,
+            &scope,
+        )
+        .await
+        .expect("value must be reusable after the owner is deleted");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn add_unique_constraint_rejects_existing_duplicates() {
+        let (_tmp, db) = test_db().await;
+        let scope = ScopeConfig::default();
+
+        for id in ["a", "b"] {
+            db.create(
+                "hold".to_string(),
+                json!({ "id": id, "seat_id": "S1" }),
+                None,
+                None,
+                None,
+                &scope,
+            )
+            .await
+            .unwrap();
+        }
+
+        let res = db
+            .add_unique_constraint("hold".to_string(), vec!["seat_id".to_string()])
+            .await;
+        assert!(
+            res.is_err(),
+            "adding a unique constraint over existing duplicates must fail"
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/crates/mqdb-agent/src/database/schema_ops.rs
+++ b/crates/mqdb-agent/src/database/schema_ops.rs
@@ -120,12 +120,35 @@ impl Database {
     #[tracing::instrument(skip(self), fields(entity = %entity))]
     pub async fn add_unique_constraint(&self, entity: String, fields: Vec<String>) -> Result<()> {
         use mqdb_core::constraint::{Constraint, UniqueConstraint};
+        use mqdb_core::error::Error;
+        use std::collections::HashSet;
 
         self.add_index(entity.clone(), fields.clone()).await?;
 
-        let constraint = Constraint::Unique(UniqueConstraint::new(entity, fields));
+        let constraint = Constraint::Unique(UniqueConstraint::new(entity.clone(), fields.clone()));
 
         let mut batch = self.storage.batch();
+
+        let prefix = keys::encode_data_key(&entity, "");
+        let mut seen: HashSet<Vec<u8>> = HashSet::new();
+        for (key, value) in self.storage.prefix_scan(&prefix)? {
+            let (_, id) = keys::decode_data_key(&key)?;
+            let record = Entity::deserialize(entity.clone(), id, &value)?;
+            for field in &fields {
+                if let Some(v) = record.get_field(field) {
+                    let value_bytes = keys::encode_value_for_index(v)?;
+                    let guard = keys::encode_unique_guard_key(&entity, field, &value_bytes);
+                    if !seen.insert(guard.clone()) {
+                        return Err(Error::UniqueViolation {
+                            entity: entity.clone(),
+                            field: field.clone(),
+                            value: String::from_utf8_lossy(&value_bytes).to_string(),
+                        });
+                    }
+                    batch.insert(guard, record.id.as_bytes().to_vec());
+                }
+            }
+        }
 
         let constraint_manager = self.constraint_manager.read().await;
         constraint_manager.persist_constraint(&mut batch, &constraint)?;

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.14"
+version = "0.8.15"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cli/src/commands/agent.rs
+++ b/crates/mqdb-cli/src/commands/agent.rs
@@ -504,10 +504,9 @@ fn verify_and_log_license(
 ) -> Option<mqdb_core::license::LicenseInfo> {
     let result = if let Some(content) = data {
         crate::license::verify_license_token(content.trim())
-    } else if let Some(p) = path {
-        crate::license::verify_license_file(p)
     } else {
-        return None;
+        let p = path?;
+        crate::license::verify_license_file(p)
     };
 
     match result {

--- a/crates/mqdb-cluster/Cargo.toml
+++ b/crates/mqdb-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cluster"
-version = "0.3.8"
+version = "0.4.0"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/src/cluster/db/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/db/mod.rs
@@ -23,6 +23,6 @@ pub use partition::{
 };
 pub use schema_store::{ClusterSchema, SchemaState, SchemaStore, SchemaStoreError, schema_key};
 pub use unique_store::{
-    ReserveResult, UniqueReservation, UniqueReserveParams, UniqueStore, UniqueStoreError,
-    unique_key,
+    ReassertResult, ReserveResult, UniqueReservation, UniqueReserveParams, UniqueStore,
+    UniqueStoreError, unique_key,
 };

--- a/crates/mqdb-cluster/src/cluster/db/unique_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/unique_store.rs
@@ -510,6 +510,68 @@ impl UniqueStore {
         Ok(imported)
     }
 
+    /// Merge reservations learned from a promotion-seal response into the local store, conservatively:
+    /// learn a claim we lack, upgrade an uncommitted claim to a committed one, but never downgrade a
+    /// committed claim nor reassign a committed value. This is the `leaderView` learning step that
+    /// lets a freshly promoted primary see a reservation it missed before it serves reserves.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned.
+    ///
+    /// # Errors
+    /// Returns `SerializationError` on a malformed key or reservation.
+    pub fn merge_for_seal(&self, data: &[u8]) -> Result<usize, UniqueStoreError> {
+        if data.len() < 4 {
+            return Ok(0);
+        }
+        let count = u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
+        let mut offset = 4;
+        let mut merged = 0;
+        let mut reservations = self.reservations.write().unwrap();
+
+        for _ in 0..count {
+            if offset + 2 > data.len() {
+                break;
+            }
+            let key_len = u16::from_be_bytes([data[offset], data[offset + 1]]) as usize;
+            offset += 2;
+            if offset + key_len > data.len() {
+                break;
+            }
+            let key = std::str::from_utf8(&data[offset..offset + key_len])
+                .map_err(|_| UniqueStoreError::SerializationError)?
+                .to_string();
+            offset += key_len;
+
+            if offset + 4 > data.len() {
+                break;
+            }
+            let data_len = u32::from_be_bytes([
+                data[offset],
+                data[offset + 1],
+                data[offset + 2],
+                data[offset + 3],
+            ]) as usize;
+            offset += 4;
+            if offset + data_len > data.len() {
+                break;
+            }
+            let incoming = Self::deserialize(&data[offset..offset + data_len])
+                .ok_or(UniqueStoreError::SerializationError)?;
+            offset += data_len;
+
+            let adopt = match reservations.get(&key) {
+                None => true,
+                Some(local) => incoming.is_committed() && !local.is_committed(),
+            };
+            if adopt {
+                reservations.insert(key, incoming);
+                merged += 1;
+            }
+        }
+        Ok(merged)
+    }
+
     /// # Panics
     /// Panics if the internal lock is poisoned.
     pub fn clear_partition(&self, partition: PartitionId) -> usize {
@@ -1115,6 +1177,73 @@ mod tests {
         store
             .apply_replicated(Operation::Update, &key, &UniqueStore::serialize(&committed))
             .expect("re-applying the same committed owner is idempotent, not a conflict");
+    }
+
+    #[test]
+    fn merge_for_seal_learns_missing_and_never_downgrades() {
+        // A member holds a committed claim for the value; a promoting primary is missing it.
+        let member = UniqueStore::new(node(1));
+        let committed = UniqueReservation::create(
+            "users",
+            "email",
+            b"a@x.com",
+            "owner-a",
+            "req-a",
+            partition(5),
+            1000,
+        )
+        .with_committed();
+        member
+            .apply_replicated(
+                Operation::Insert,
+                &unique_key(&committed),
+                &UniqueStore::serialize(&committed),
+            )
+            .unwrap();
+        let blob = member.export_for_partition(committed.unique_partition());
+
+        let primary = UniqueStore::new(node(2));
+        assert!(primary.get("users", "email", b"a@x.com").is_none());
+        assert_eq!(primary.merge_for_seal(&blob).unwrap(), 1);
+        let learned = primary.get("users", "email", b"a@x.com").unwrap();
+        assert!(learned.is_committed());
+        assert_eq!(
+            learned.record_id_str(),
+            "owner-a",
+            "the primary learns the missed claim"
+        );
+
+        // A second merge carrying an uncommitted claim for the same value must NOT downgrade it.
+        let uncommitted = UniqueReservation::create(
+            "users",
+            "email",
+            b"a@x.com",
+            "owner-a",
+            "req-a",
+            partition(5),
+            2000,
+        );
+        let stale = UniqueStore::new(node(3));
+        stale
+            .apply_replicated(
+                Operation::Insert,
+                &unique_key(&uncommitted),
+                &UniqueStore::serialize(&uncommitted),
+            )
+            .unwrap();
+        assert_eq!(
+            primary
+                .merge_for_seal(&stale.export_for_partition(uncommitted.unique_partition()))
+                .unwrap(),
+            0,
+            "an uncommitted claim never downgrades a learned committed claim"
+        );
+        assert!(
+            primary
+                .get("users", "email", b"a@x.com")
+                .unwrap()
+                .is_committed()
+        );
     }
 
     #[test]

--- a/crates/mqdb-cluster/src/cluster/db/unique_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/unique_store.rs
@@ -143,6 +143,23 @@ pub enum ReserveResult {
     Conflict,
 }
 
+/// Outcome of reconciling a durable record against the unique claim it should own.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReassertResult {
+    /// No claim existed; a committed claim owned by the record was established
+    /// (repairs a reservation lost to failover/restart).
+    Established,
+    /// An uncommitted claim owned by the record was promoted to committed
+    /// (repairs a lost commit).
+    Repaired,
+    /// The record already owns a committed claim (steady state).
+    AlreadyCommitted,
+    /// A committed claim is held by a DIFFERENT record — an oversell to surface.
+    Conflict,
+    /// An uncommitted claim is held by a different (in-flight) record; skip this cycle.
+    Pending,
+}
+
 pub struct UniqueReserveParams<'a> {
     pub entity: &'a str,
     pub field: &'a str,
@@ -247,6 +264,53 @@ impl UniqueStore {
             }
         }
         false
+    }
+
+    /// Reconcile a durable record against the unique claim it should own: ensure a
+    /// committed claim for `value` owned by `record_id` exists, repairing a lost
+    /// reservation or a lost commit. The durable record is the source of truth.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned.
+    pub fn reassert(
+        &self,
+        entity: &str,
+        field: &str,
+        value: &[u8],
+        record_id: &str,
+        data_partition: PartitionId,
+        now: u64,
+    ) -> ReassertResult {
+        let key = Self::unique_key(entity, field, value);
+        let mut reservations = self.reservations.write().unwrap();
+
+        match reservations.get(&key) {
+            None => {
+                let reservation = UniqueReservation::create(
+                    entity,
+                    field,
+                    value,
+                    record_id,
+                    record_id,
+                    data_partition,
+                    now,
+                )
+                .with_committed();
+                reservations.insert(key, reservation);
+                ReassertResult::Established
+            }
+            Some(existing) if existing.record_id_str() == record_id => {
+                if existing.is_committed() {
+                    ReassertResult::AlreadyCommitted
+                } else {
+                    let committed = existing.clone().with_committed();
+                    reservations.insert(key, committed);
+                    ReassertResult::Repaired
+                }
+            }
+            Some(existing) if existing.is_committed() => ReassertResult::Conflict,
+            Some(_) => ReassertResult::Pending,
+        }
     }
 
     /// # Panics
@@ -886,6 +950,76 @@ mod tests {
 
         let available = store.check("users", "email", b"alice@example.com", 1000);
         assert!(available, "value should be available after release");
+    }
+
+    #[test]
+    fn reassert_establishes_committed_claim_when_absent() {
+        let store = UniqueStore::new(node(1));
+        let result = store.reassert("users", "email", b"a@x.com", "u1", partition(1), 1000);
+        assert_eq!(result, ReassertResult::Established);
+        let r = store.get("users", "email", b"a@x.com").unwrap();
+        assert!(r.is_committed());
+        assert_eq!(r.record_id_str(), "u1");
+    }
+
+    #[test]
+    fn reassert_repairs_lost_commit() {
+        let store = UniqueStore::new(node(1));
+        store.reserve(
+            &params(
+                "users",
+                "email",
+                b"a@x.com",
+                "u1",
+                "req-1",
+                partition(1),
+                5000,
+            ),
+            1000,
+        );
+        let result = store.reassert("users", "email", b"a@x.com", "u1", partition(1), 2000);
+        assert_eq!(result, ReassertResult::Repaired);
+        assert!(
+            store
+                .get("users", "email", b"a@x.com")
+                .unwrap()
+                .is_committed()
+        );
+    }
+
+    #[test]
+    fn reassert_is_idempotent_when_committed() {
+        let store = UniqueStore::new(node(1));
+        store.reassert("users", "email", b"a@x.com", "u1", partition(1), 1000);
+        let result = store.reassert("users", "email", b"a@x.com", "u1", partition(1), 2000);
+        assert_eq!(result, ReassertResult::AlreadyCommitted);
+    }
+
+    #[test]
+    fn reassert_flags_conflict_when_other_committed() {
+        let store = UniqueStore::new(node(1));
+        store.reassert("users", "email", b"a@x.com", "u1", partition(1), 1000);
+        let result = store.reassert("users", "email", b"a@x.com", "u2", partition(1), 2000);
+        assert_eq!(result, ReassertResult::Conflict);
+    }
+
+    #[test]
+    fn reassert_pending_when_other_uncommitted() {
+        let store = UniqueStore::new(node(1));
+        store.reserve(
+            &params(
+                "users",
+                "email",
+                b"a@x.com",
+                "u1",
+                "req-1",
+                partition(1),
+                5000,
+            ),
+            1000,
+        );
+        let result = store.reassert("users", "email", b"a@x.com", "u2", partition(1), 2000);
+        assert_eq!(result, ReassertResult::Pending);
     }
 
     #[test]

--- a/crates/mqdb-cluster/src/cluster/db/unique_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/unique_store.rs
@@ -393,10 +393,16 @@ impl UniqueStore {
             Operation::Insert | Operation::Update => {
                 let reservation =
                     Self::deserialize(data).ok_or(UniqueStoreError::SerializationError)?;
-                self.reservations
-                    .write()
-                    .unwrap()
-                    .insert(id.to_string(), reservation);
+                let mut reservations = self.reservations.write().unwrap();
+                if let Some(existing) = reservations.get(id)
+                    && existing.is_committed()
+                    && existing.record_id_str() != reservation.record_id_str()
+                {
+                    // A committed claim is final: never reassign a committed value to a different
+                    // record, even at a higher epoch (closes the missed-reservation oversell).
+                    return Err(UniqueStoreError::AlreadyCommitted);
+                }
+                reservations.insert(id.to_string(), reservation);
                 Ok(())
             }
             Operation::Delete => {
@@ -1041,6 +1047,74 @@ mod tests {
             .unwrap();
 
         assert_eq!(store.count(), 1);
+    }
+
+    #[test]
+    fn apply_replicated_rejects_reassigning_committed_value() {
+        let store = UniqueStore::new(node(1));
+        let committed = UniqueReservation::create(
+            "users",
+            "email",
+            b"a@x.com",
+            "owner-a",
+            "req-a",
+            partition(5),
+            1000,
+        )
+        .with_committed();
+        let key = unique_key(&committed);
+        store
+            .apply_replicated(Operation::Insert, &key, &UniqueStore::serialize(&committed))
+            .unwrap();
+
+        let intruder = UniqueReservation::create(
+            "users",
+            "email",
+            b"a@x.com",
+            "owner-b",
+            "req-b",
+            partition(5),
+            2000,
+        );
+        let result =
+            store.apply_replicated(Operation::Update, &key, &UniqueStore::serialize(&intruder));
+
+        assert_eq!(
+            result,
+            Err(UniqueStoreError::AlreadyCommitted),
+            "a committed value must not be reassigned to a different record"
+        );
+        assert_eq!(
+            store
+                .get("users", "email", b"a@x.com")
+                .unwrap()
+                .record_id_str(),
+            "owner-a",
+            "the original committed owner is preserved"
+        );
+    }
+
+    #[test]
+    fn apply_replicated_allows_recommit_by_same_record() {
+        let store = UniqueStore::new(node(1));
+        let committed = UniqueReservation::create(
+            "users",
+            "email",
+            b"a@x.com",
+            "owner-a",
+            "req-a",
+            partition(5),
+            1000,
+        )
+        .with_committed();
+        let key = unique_key(&committed);
+        store
+            .apply_replicated(Operation::Insert, &key, &UniqueStore::serialize(&committed))
+            .unwrap();
+
+        store
+            .apply_replicated(Operation::Update, &key, &UniqueStore::serialize(&committed))
+            .expect("re-applying the same committed owner is idempotent, not a conflict");
     }
 
     #[test]

--- a/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
@@ -407,10 +407,10 @@ impl DbRequestHandler {
             .await
         {
             Ok(p) => p,
-            Err(conflict_field) => {
+            Err(failure) => {
                 return JsonOpResult::Response(Self::json_error(
-                    409,
-                    &format!("unique constraint violation on field '{conflict_field}'"),
+                    failure.http_code(),
+                    &failure.message(),
                 ));
             }
         };
@@ -745,10 +745,10 @@ impl DbRequestHandler {
                 .await
             {
                 Ok(p) => p,
-                Err(conflict_field) => {
+                Err(failure) => {
                     return JsonOpResult::Response(Self::json_error(
-                        409,
-                        &format!("unique constraint violation on field '{conflict_field}'"),
+                        failure.http_code(),
+                        &failure.message(),
                     ));
                 }
             };
@@ -1207,7 +1207,10 @@ impl DbRequestHandler {
         local_reserved: Vec<(String, Vec<u8>)>,
         remote_results: Result<
             Vec<(String, Vec<u8>, super::NodeId)>,
-            (String, Vec<(String, Vec<u8>, super::NodeId)>),
+            (
+                super::super::node_controller::ReserveFailure,
+                Vec<(String, Vec<u8>, super::NodeId)>,
+            ),
         >,
         continuation: UniqueCheckContinuation,
     ) -> Option<super::super::db_handler::DbPublishResponse> {
@@ -1228,7 +1231,7 @@ impl DbRequestHandler {
             } => {
                 let vault_sender = sender.clone();
                 let response_payload = match remote_results {
-                    Err((conflict_field, confirmed)) => {
+                    Err((failure, confirmed)) => {
                         controller
                             .release_unique_check_reservations(
                                 &entity,
@@ -1237,10 +1240,7 @@ impl DbRequestHandler {
                                 &confirmed,
                             )
                             .await;
-                        Self::json_error(
-                            409,
-                            &format!("unique constraint violation on field '{conflict_field}'"),
-                        )
+                        Self::json_error(failure.http_code(), &failure.message())
                     }
                     Ok(confirmed_remotes) => {
                         for (f, v, target) in &confirmed_remotes {
@@ -1340,7 +1340,7 @@ impl DbRequestHandler {
             } => {
                 let vault_sender = sender.clone();
                 let response_payload = match remote_results {
-                    Err((conflict_field, confirmed)) => {
+                    Err((failure, confirmed)) => {
                         controller
                             .release_unique_check_reservations(
                                 &entity,
@@ -1349,10 +1349,7 @@ impl DbRequestHandler {
                                 &confirmed,
                             )
                             .await;
-                        Self::json_error(
-                            409,
-                            &format!("unique constraint violation on field '{conflict_field}'"),
-                        )
+                        Self::json_error(failure.http_code(), &failure.message())
                     }
                     Ok(confirmed_remotes) => {
                         for (f, v, target) in &confirmed_remotes {

--- a/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
@@ -418,7 +418,7 @@ impl DbRequestHandler {
         let constraint_data = data.clone();
         let data = self.vault_encrypt_if_needed(vault_crypto, entity, id, data);
 
-        if !phase1.pending_remote.is_empty() {
+        if !phase1.pending_remote.is_empty() || !phase1.pending_quorum.is_empty() {
             let data_bytes = serde_json::to_vec(&data).unwrap_or_default();
             return JsonOpResult::PendingUniqueCheck(Box::new(PendingUniqueWork {
                 phase1,
@@ -753,7 +753,7 @@ impl DbRequestHandler {
                 }
             };
 
-            if !phase1.pending_remote.is_empty() {
+            if !phase1.pending_remote.is_empty() || !phase1.pending_quorum.is_empty() {
                 let data_bytes = serde_json::to_vec(&merged_data).unwrap_or_default();
                 return JsonOpResult::PendingUniqueCheck(Box::new(PendingUniqueWork {
                     phase1,

--- a/crates/mqdb-cluster/src/cluster/db_handler/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/db_handler/tests.rs
@@ -273,6 +273,68 @@ async fn handle_invalid_partition_returns_error() {
 }
 
 #[tokio::test]
+async fn unsealed_partition_reserve_is_retryable_not_a_conflict() {
+    use super::super::db::ClusterConstraint;
+
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let node3 = NodeId::validated(3).unwrap();
+    let handler = DbRequestHandler::new(node1);
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    ctrl.register_peer(node2);
+    ctrl.register_peer(node3);
+
+    let mut map = PartitionMap::default();
+    for i in 0..NUM_PARTITIONS {
+        let p = PartitionId::new(i).unwrap();
+        // Multi-node group => become_primary QUEUES a seal but does not complete it.
+        ctrl.become_primary(p, Epoch::new(1));
+        map.set(
+            p,
+            crate::cluster::PartitionAssignment {
+                primary: Some(node1),
+                replicas: vec![node2, node3],
+                epoch: Epoch::new(1),
+            },
+        );
+    }
+    ctrl.update_partition_map(map);
+    ctrl.constraint_add(&ClusterConstraint::unique("users", "uniq_email", "email"))
+        .await
+        .unwrap();
+
+    // The value is genuinely FREE; the create can only fail because the partition is not yet sealed.
+    let payload =
+        serde_json::to_vec(&serde_json::json!({"id": "u1", "email": "free@x.com"})).unwrap();
+    let response = handler
+        .handle_publish(
+            &mut ctrl,
+            "$DB/users/create",
+            &payload,
+            &MqttRequestContext {
+                response_topic: Some("resp/t"),
+                correlation_data: None,
+                sender: None,
+                client_id: None,
+            },
+        )
+        .await;
+
+    let resp = response.unwrap();
+    let json = parse_json_response(&resp.payload);
+    assert_eq!(json["status"], "error");
+    assert_eq!(
+        json["code"], 503,
+        "a reserve that fails only because the partition is unsealed is transient/retryable (503), \
+         not a permanent unique-constraint violation (409)"
+    );
+    assert!(
+        ctrl.db_get("users", "u1").is_none(),
+        "no record should be created for a fail-closed reserve"
+    );
+}
+
+#[tokio::test]
 async fn no_response_without_response_topic() {
     let node1 = NodeId::validated(1).unwrap();
     let handler = DbRequestHandler::new(node1);

--- a/crates/mqdb-cluster/src/cluster/event_handler/routing.rs
+++ b/crates/mqdb-cluster/src/cluster/event_handler/routing.rs
@@ -146,7 +146,6 @@ impl<T: ClusterTransport + 'static> ClusterEventHandler<T> {
     pub(super) async fn handle_db_publish(&self, node_id: NodeId, event: &ClientPublishEvent) {
         use super::super::db_handler::{DbPublishResult, MqttRequestContext};
         use super::super::node_controller::fk::await_fk_checks;
-        use super::super::node_controller::unique::await_unique_reserves;
 
         debug!(topic = %event.topic, "handling $DB/ request");
         let start = std::time::Instant::now();
@@ -188,9 +187,7 @@ impl<T: ClusterTransport + 'static> ClusterEventHandler<T> {
                 let pending_quorum = pending.phase1.pending_quorum;
                 let continuation = pending.continuation;
                 drop(ctrl);
-                let remote_results =
-                    combine_quorum(await_unique_reserves(pending_remote).await, pending_quorum)
-                        .await;
+                let remote_results = combine_quorum(pending_remote, pending_quorum).await;
                 let mut ctrl = self.controller.write().await;
                 if let Some(response) = self
                     .db_handler
@@ -239,11 +236,7 @@ impl<T: ClusterTransport + 'static> ClusterEventHandler<T> {
                         let pending_quorum = pending.phase1.pending_quorum;
                         let continuation = pending.continuation;
                         drop(ctrl);
-                        let remote_results = combine_quorum(
-                            await_unique_reserves(pending_remote).await,
-                            pending_quorum,
-                        )
-                        .await;
+                        let remote_results = combine_quorum(pending_remote, pending_quorum).await;
                         let mut ctrl = self.controller.write().await;
                         if let Some(response) = self
                             .db_handler
@@ -430,15 +423,23 @@ type RemoteReserveResult = Result<
 >;
 
 async fn combine_quorum(
-    remote_results: RemoteReserveResult,
+    pending_remote: Vec<super::super::node_controller::PendingUniqueReserve>,
     pending_quorum: Vec<(String, tokio::sync::oneshot::Receiver<bool>)>,
 ) -> RemoteReserveResult {
     use super::super::node_controller::ReserveFailure;
-    use super::super::node_controller::unique::await_unique_quorum;
-    let quorum = await_unique_quorum(pending_quorum).await;
+    use super::super::node_controller::unique::{await_unique_quorum, await_unique_reserves};
+    // Await the remote-reserve and local-quorum rounds concurrently so a create waits the max of the
+    // two ~5s deadlines, not their sum.
+    let (remote_results, quorum) = tokio::join!(
+        await_unique_reserves(pending_remote),
+        await_unique_quorum(pending_quorum),
+    );
     match remote_results {
         Ok(confirmed) => match quorum {
-            Ok(()) => Ok(confirmed),
+            Ok(durable) => {
+                tracing::debug!(?durable, "unique reserve is majority-durable");
+                Ok(confirmed)
+            }
             // A quorum that never lands is transient, not a real conflict.
             Err(field) => Err((ReserveFailure::NotDurable(field), confirmed)),
         },

--- a/crates/mqdb-cluster/src/cluster/event_handler/routing.rs
+++ b/crates/mqdb-cluster/src/cluster/event_handler/routing.rs
@@ -185,9 +185,12 @@ impl<T: ClusterTransport + 'static> ClusterEventHandler<T> {
             DbPublishResult::PendingUniqueCheck(pending) => {
                 let local_reserved = pending.phase1.local_reserved;
                 let pending_remote = pending.phase1.pending_remote;
+                let pending_quorum = pending.phase1.pending_quorum;
                 let continuation = pending.continuation;
                 drop(ctrl);
-                let remote_results = await_unique_reserves(pending_remote).await;
+                let remote_results =
+                    combine_quorum(await_unique_reserves(pending_remote).await, pending_quorum)
+                        .await;
                 let mut ctrl = self.controller.write().await;
                 if let Some(response) = self
                     .db_handler
@@ -233,9 +236,14 @@ impl<T: ClusterTransport + 'static> ClusterEventHandler<T> {
                     FkCheckCompletion::NeedUniqueCheck(pending) => {
                         let local_reserved = pending.phase1.local_reserved;
                         let pending_remote = pending.phase1.pending_remote;
+                        let pending_quorum = pending.phase1.pending_quorum;
                         let continuation = pending.continuation;
                         drop(ctrl);
-                        let remote_results = await_unique_reserves(pending_remote).await;
+                        let remote_results = combine_quorum(
+                            await_unique_reserves(pending_remote).await,
+                            pending_quorum,
+                        )
+                        .await;
                         let mut ctrl = self.controller.write().await;
                         if let Some(response) = self
                             .db_handler
@@ -410,5 +418,23 @@ impl<T: ClusterTransport + 'static> ClusterEventHandler<T> {
             remote_nodes,
             is_clean_session,
         })
+    }
+}
+
+type RemoteReserveResult =
+    Result<Vec<(String, Vec<u8>, NodeId)>, (String, Vec<(String, Vec<u8>, NodeId)>)>;
+
+async fn combine_quorum(
+    remote_results: RemoteReserveResult,
+    pending_quorum: Vec<(String, tokio::sync::oneshot::Receiver<bool>)>,
+) -> RemoteReserveResult {
+    use super::super::node_controller::unique::await_unique_quorum;
+    let quorum = await_unique_quorum(pending_quorum).await;
+    match remote_results {
+        Ok(confirmed) => match quorum {
+            Ok(()) => Ok(confirmed),
+            Err(field) => Err((field, confirmed)),
+        },
+        Err(e) => Err(e),
     }
 }

--- a/crates/mqdb-cluster/src/cluster/event_handler/routing.rs
+++ b/crates/mqdb-cluster/src/cluster/event_handler/routing.rs
@@ -421,19 +421,26 @@ impl<T: ClusterTransport + 'static> ClusterEventHandler<T> {
     }
 }
 
-type RemoteReserveResult =
-    Result<Vec<(String, Vec<u8>, NodeId)>, (String, Vec<(String, Vec<u8>, NodeId)>)>;
+type RemoteReserveResult = Result<
+    Vec<(String, Vec<u8>, NodeId)>,
+    (
+        super::super::node_controller::ReserveFailure,
+        Vec<(String, Vec<u8>, NodeId)>,
+    ),
+>;
 
 async fn combine_quorum(
     remote_results: RemoteReserveResult,
     pending_quorum: Vec<(String, tokio::sync::oneshot::Receiver<bool>)>,
 ) -> RemoteReserveResult {
+    use super::super::node_controller::ReserveFailure;
     use super::super::node_controller::unique::await_unique_quorum;
     let quorum = await_unique_quorum(pending_quorum).await;
     match remote_results {
         Ok(confirmed) => match quorum {
             Ok(()) => Ok(confirmed),
-            Err(field) => Err((field, confirmed)),
+            // A quorum that never lands is transient, not a real conflict.
+            Err(field) => Err((ReserveFailure::NotDurable(field), confirmed)),
         },
         Err(e) => Err(e),
     }

--- a/crates/mqdb-cluster/src/cluster/heartbeat.rs
+++ b/crates/mqdb-cluster/src/cluster/heartbeat.rs
@@ -226,6 +226,21 @@ impl HeartbeatManager {
             .collect()
     }
 
+    /// Every node this manager knows about (self + all registered peers), regardless of
+    /// alive status. Stable across heartbeat timeouts — the basis for the unique quorum group.
+    #[must_use]
+    pub fn registered_nodes(&self) -> Vec<NodeId> {
+        let mut nodes: Vec<NodeId> = self
+            .nodes
+            .keys()
+            .filter_map(|&id| NodeId::validated(id))
+            .collect();
+        nodes.push(self.local_node);
+        nodes.sort_unstable_by_key(|n| n.get());
+        nodes.dedup();
+        nodes
+    }
+
     #[must_use]
     pub fn has_alive_peers(&self) -> bool {
         self.nodes
@@ -268,6 +283,26 @@ mod tests {
 
         assert_eq!(mgr.node_status(node2), NodeStatus::Unknown);
         assert_eq!(mgr.node_status(node3), NodeStatus::Unknown);
+    }
+
+    #[test]
+    fn registered_nodes_includes_self_and_peers_regardless_of_status() {
+        let local = NodeId::validated(1).unwrap();
+        let mut mgr = HeartbeatManager::new(local, config());
+        mgr.register_node(NodeId::validated(3).unwrap());
+        mgr.register_node(NodeId::validated(2).unwrap());
+
+        let group = mgr.registered_nodes();
+
+        assert_eq!(
+            group,
+            vec![
+                NodeId::validated(1).unwrap(),
+                NodeId::validated(2).unwrap(),
+                NodeId::validated(3).unwrap(),
+            ],
+            "group is self + all registered peers, sorted and deduped, independent of alive status"
+        );
     }
 
     #[test]

--- a/crates/mqdb-cluster/src/cluster/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/mod.rs
@@ -85,9 +85,9 @@ pub use protocol::{
     AckStatus, BatchReadRequest, BatchReadResponse, CatchupRequest, CatchupResponse, ForwardTarget,
     ForwardedPublish, Heartbeat, JsonDbOp, JsonDbRequest, JsonDbResponse, MessageType, Operation,
     QueryRequest, QueryResponse, QueryStatus, ReplicationAck, ReplicationWrite,
-    TopicSubscriptionBroadcast, UniqueCommitRequest, UniqueCommitResponse, UniqueReleaseRequest,
-    UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse, UniqueReserveStatus,
-    WildcardBroadcast, WildcardOp,
+    TopicSubscriptionBroadcast, UniqueCommitRequest, UniqueCommitResponse, UniqueReassertRequest,
+    UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse,
+    UniqueReserveStatus, WildcardBroadcast, WildcardOp,
 };
 pub use publish_router::{PublishRouteResult, PublishRouter, RoutingTarget, effective_qos};
 pub use qos2_store::{

--- a/crates/mqdb-cluster/src/cluster/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/mod.rs
@@ -87,7 +87,8 @@ pub use protocol::{
     QueryRequest, QueryResponse, QueryStatus, ReplicationAck, ReplicationWrite,
     TopicSubscriptionBroadcast, UniqueCommitRequest, UniqueCommitResponse, UniqueReassertRequest,
     UniqueReleaseRequest, UniqueReleaseResponse, UniqueReplicateAck, UniqueReserveRequest,
-    UniqueReserveResponse, UniqueReserveStatus, WildcardBroadcast, WildcardOp,
+    UniqueReserveResponse, UniqueReserveStatus, UniqueSealRequest, UniqueSealResponse,
+    WildcardBroadcast, WildcardOp,
 };
 pub use publish_router::{PublishRouteResult, PublishRouter, RoutingTarget, effective_qos};
 pub use qos2_store::{

--- a/crates/mqdb-cluster/src/cluster/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/mod.rs
@@ -86,8 +86,8 @@ pub use protocol::{
     ForwardedPublish, Heartbeat, JsonDbOp, JsonDbRequest, JsonDbResponse, MessageType, Operation,
     QueryRequest, QueryResponse, QueryStatus, ReplicationAck, ReplicationWrite,
     TopicSubscriptionBroadcast, UniqueCommitRequest, UniqueCommitResponse, UniqueReassertRequest,
-    UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse,
-    UniqueReserveStatus, WildcardBroadcast, WildcardOp,
+    UniqueReleaseRequest, UniqueReleaseResponse, UniqueReplicateAck, UniqueReserveRequest,
+    UniqueReserveResponse, UniqueReserveStatus, WildcardBroadcast, WildcardOp,
 };
 pub use publish_router::{PublishRouteResult, PublishRouter, RoutingTarget, effective_qos};
 pub use qos2_store::{

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -1404,6 +1404,7 @@ impl<T: ClusterTransport> NodeController<T> {
                     phase1: super::UniqueCheckPhase1Result {
                         local_reserved,
                         pending_remote: pending_remote_reserves,
+                        pending_quorum: Vec::new(),
                     },
                     continuation: UniqueCheckContinuation::CreateFromNodeController {
                         from,

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -1486,6 +1486,16 @@ impl<T: ClusterTransport> NodeController<T> {
         params: &UniqueReservationParams<'_>,
         local_reserved: &mut Vec<(String, Vec<u8>)>,
     ) -> bool {
+        let unique_part = super::db::unique_partition(params.entity, params.field, params.value);
+        if !self.unique_partition_sealed(unique_part) {
+            tracing::warn!(
+                field = params.field,
+                partition = unique_part.get(),
+                "unique partition not sealed at the current epoch; failing reserve closed"
+            );
+            return true;
+        }
+
         let reserve_params = super::db::UniqueReserveParams {
             entity: params.entity,
             field: params.field,

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -690,12 +690,9 @@ impl<T: ClusterTransport> NodeController<T> {
                 )
                 .await
             {
-                Err(conflict_field) => {
+                Err(failure) => {
                     return (
-                        Self::json_error(
-                            409,
-                            &format!("unique constraint violation on field '{conflict_field}'"),
-                        ),
+                        Self::json_error(failure.http_code(), &failure.message()),
                         None,
                     );
                 }
@@ -1344,7 +1341,7 @@ impl<T: ClusterTransport> NodeController<T> {
                 super::db::unique_partition(params.entity, params.field, params.value);
             let primary = self.partition_map.primary(unique_part);
 
-            let is_conflict = if primary == Some(self.node_id) {
+            let failure = if primary == Some(self.node_id) {
                 self.reserve_unique_local(&params, &mut local_reserved, &mut pending_quorum)
                     .await
             } else if let Some(target_node) = primary {
@@ -1368,15 +1365,15 @@ impl<T: ClusterTransport> NodeController<T> {
                             target_node,
                             receiver: rx,
                         });
-                        false
+                        None
                     }
-                    Err(_) => true,
+                    Err(_) => Some(super::ReserveFailure::NotDurable(field.clone())),
                 }
             } else {
-                true
+                Some(super::ReserveFailure::NotDurable(field.clone()))
             };
 
-            if is_conflict {
+            if let Some(failure) = failure {
                 self.release_all_reservations(
                     entity,
                     &request_id,
@@ -1388,10 +1385,7 @@ impl<T: ClusterTransport> NodeController<T> {
                     drop(pending.receiver);
                 }
                 return (
-                    Self::json_error(
-                        409,
-                        &format!("unique constraint violation on field '{field}'"),
-                    ),
+                    Self::json_error(failure.http_code(), &failure.message()),
                     None,
                 );
             }
@@ -1487,7 +1481,7 @@ impl<T: ClusterTransport> NodeController<T> {
         params: &UniqueReservationParams<'_>,
         local_reserved: &mut Vec<(String, Vec<u8>)>,
         pending_quorum: &mut Vec<(String, tokio::sync::oneshot::Receiver<bool>)>,
-    ) -> bool {
+    ) -> Option<super::ReserveFailure> {
         let unique_part = super::db::unique_partition(params.entity, params.field, params.value);
         if !self.unique_partition_sealed(unique_part) {
             tracing::warn!(
@@ -1495,7 +1489,7 @@ impl<T: ClusterTransport> NodeController<T> {
                 partition = unique_part.get(),
                 "unique partition not sealed at the current epoch; failing reserve closed"
             );
-            return true;
+            return Some(super::ReserveFailure::NotDurable(params.field.to_owned()));
         }
 
         let reserve_params = super::db::UniqueReserveParams {
@@ -1519,13 +1513,15 @@ impl<T: ClusterTransport> NodeController<T> {
                     pending_quorum.push((params.field.to_owned(), rx));
                 }
                 local_reserved.push((params.field.to_owned(), params.value.to_vec()));
-                false
+                None
             }
             super::db::ReserveResult::AlreadyReservedBySameRequest => {
                 local_reserved.push((params.field.to_owned(), params.value.to_vec()));
-                false
+                None
             }
-            super::db::ReserveResult::Conflict => true,
+            super::db::ReserveResult::Conflict => {
+                Some(super::ReserveFailure::Conflict(params.field.to_owned()))
+            }
         }
     }
 
@@ -1645,7 +1641,7 @@ impl<T: ClusterTransport> NodeController<T> {
                         super::db::unique_partition(params.entity, params.field, params.value);
                     let primary = self.partition_map.primary(unique_part);
 
-                    let is_conflict = if primary == Some(self.node_id) {
+                    let failure = if primary == Some(self.node_id) {
                         self.reserve_unique_local(&params, &mut local_reserved, &mut fk_quorum)
                             .await
                     } else if let Some(target_node) = primary {
@@ -1675,18 +1671,21 @@ impl<T: ClusterTransport> NodeController<T> {
                                             value.clone(),
                                             target_node,
                                         ));
-                                        false
+                                        None
                                     }
-                                    _ => true,
+                                    Ok(Ok(UniqueReserveStatus::Conflict)) => {
+                                        Some(super::ReserveFailure::Conflict(field.clone()))
+                                    }
+                                    _ => Some(super::ReserveFailure::NotDurable(field.clone())),
                                 }
                             }
-                            Err(_) => true,
+                            Err(_) => Some(super::ReserveFailure::NotDurable(field.clone())),
                         }
                     } else {
-                        true
+                        Some(super::ReserveFailure::NotDurable(field.clone()))
                     };
 
-                    if is_conflict {
+                    if let Some(failure) = failure {
                         self.release_all_reservations(
                             &entity,
                             &request_id,
@@ -1694,10 +1693,7 @@ impl<T: ClusterTransport> NodeController<T> {
                             &remote_reserved,
                         )
                         .await;
-                        let payload = Self::json_error(
-                            409,
-                            &format!("unique constraint violation on field '{field}'"),
-                        );
+                        let payload = Self::json_error(failure.http_code(), &failure.message());
                         let response =
                             JsonDbResponse::new(0, payload, response_topic, correlation_data);
                         let _ = self
@@ -1801,7 +1797,7 @@ impl<T: ClusterTransport> NodeController<T> {
                             super::db::unique_partition(params.entity, params.field, params.value);
                         let primary = self.partition_map.primary(unique_part);
 
-                        let is_conflict = if primary == Some(self.node_id) {
+                        let failure = if primary == Some(self.node_id) {
                             self.reserve_unique_local(&params, &mut local_reserved, &mut fk_quorum)
                                 .await
                         } else if let Some(target_node) = primary {
@@ -1834,18 +1830,21 @@ impl<T: ClusterTransport> NodeController<T> {
                                                 value.clone(),
                                                 target_node,
                                             ));
-                                            false
+                                            None
                                         }
-                                        _ => true,
+                                        Ok(Ok(UniqueReserveStatus::Conflict)) => {
+                                            Some(super::ReserveFailure::Conflict(field.clone()))
+                                        }
+                                        _ => Some(super::ReserveFailure::NotDurable(field.clone())),
                                     }
                                 }
-                                Err(_) => true,
+                                Err(_) => Some(super::ReserveFailure::NotDurable(field.clone())),
                             }
                         } else {
-                            true
+                            Some(super::ReserveFailure::NotDurable(field.clone()))
                         };
 
-                        if is_conflict {
+                        if let Some(failure) = failure {
                             self.release_all_reservations(
                                 &entity,
                                 &request_id,
@@ -1853,10 +1852,7 @@ impl<T: ClusterTransport> NodeController<T> {
                                 &remote_reserved,
                             )
                             .await;
-                            let payload = Self::json_error(
-                                409,
-                                &format!("unique constraint violation on field '{field}'"),
-                            );
+                            let payload = Self::json_error(failure.http_code(), &failure.message());
                             let response =
                                 JsonDbResponse::new(0, payload, response_topic, correlation_data);
                             let _ = self

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -1567,6 +1567,7 @@ impl<T: ClusterTransport> NodeController<T> {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     pub(crate) async fn complete_pending_fk_work(
         &mut self,
         fk_ok: bool,

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -5,7 +5,7 @@ use super::{
     ClusterMessage, ClusterTransport, Epoch, FkCheckContinuation, FkDeleteContinuation, JsonDbOp,
     JsonDbRequest, JsonDbResponse, NodeController, NodeId, PartitionId, PendingFkDeleteWork,
     PendingFkWork, PendingUniqueWork, ReplicationWrite, UniqueCheckContinuation,
-    UniqueReservationParams, UniqueReserveStatus, entity,
+    UniqueReservationParams, entity,
 };
 use crate::cluster::replication::ReplicaState;
 use crate::cluster::store_manager::outbox::{CascadeOutboxPayload, CascadeRemoteOp, OutboxPayload};
@@ -1567,13 +1567,12 @@ impl<T: ClusterTransport> NodeController<T> {
         }
     }
 
-    #[allow(clippy::too_many_lines)]
     pub(crate) async fn complete_pending_fk_work(
         &mut self,
         fk_ok: bool,
         fk_error: Option<String>,
         continuation: FkCheckContinuation,
-    ) {
+    ) -> super::FkThenUniqueOutcome {
         if !fk_ok {
             let msg = fk_error.unwrap_or_else(|| "FK constraint violation".to_string());
             let payload = Self::json_error(409, &msg);
@@ -1590,14 +1589,14 @@ impl<T: ClusterTransport> NodeController<T> {
                 ..
             }) = continuation
             else {
-                return;
+                return super::FkThenUniqueOutcome::Done;
             };
             let response = JsonDbResponse::new(0, payload, response_topic, correlation_data);
             let _ = self
                 .transport
                 .send(from, ClusterMessage::JsonDbResponse(response))
                 .await;
-            return;
+            return super::FkThenUniqueOutcome::Done;
         }
 
         match continuation {
@@ -1613,86 +1612,23 @@ impl<T: ClusterTransport> NodeController<T> {
                 ..
             } => {
                 let now_ms = Self::current_time_ms();
-                let unique_fields = self.stores.constraint_get_unique_fields(&entity);
-                let mut local_reserved: Vec<(String, Vec<u8>)> = Vec::new();
-                let mut remote_reserved: Vec<(String, Vec<u8>, NodeId)> = Vec::new();
-                // This continuation runs holding the controller lock, so it cannot await the quorum
-                // inline (the ack path needs the lock). Reserves here are gated + async-replicated;
-                // the reconciler backstops majority-durability for this rare FK+unique path.
-                let mut fk_quorum: Vec<(String, tokio::sync::oneshot::Receiver<bool>)> = Vec::new();
-
-                for field in &unique_fields {
-                    let value = match data.get(field) {
-                        Some(v) => serde_json::to_vec(v).unwrap_or_default(),
-                        None => continue,
-                    };
-
-                    let params = UniqueReservationParams {
-                        entity: &entity,
-                        field,
-                        value: &value,
-                        id: &id,
-                        request_id: &request_id,
+                let data_bytes = serde_json::to_vec(&data).unwrap_or_default();
+                // FK passed; run the unique reserve. Return the pending work so the majority-await
+                // runs OUTSIDE the controller lock (via spawn_unique_completion) — awaiting it here
+                // would deadlock, since the ack path needs the same lock this task holds.
+                let phase1 = match self
+                    .start_unique_constraint_check(
+                        &entity,
+                        &id,
+                        &data,
                         partition,
+                        &request_id,
                         now_ms,
-                    };
-
-                    let unique_part =
-                        super::db::unique_partition(params.entity, params.field, params.value);
-                    let primary = self.partition_map.primary(unique_part);
-
-                    let failure = if primary == Some(self.node_id) {
-                        self.reserve_unique_local(&params, &mut local_reserved, &mut fk_quorum)
-                            .await
-                    } else if let Some(target_node) = primary {
-                        let reserve_params = super::db::UniqueReserveParams {
-                            entity: params.entity,
-                            field: params.field,
-                            value: params.value,
-                            record_id: params.id,
-                            request_id: params.request_id,
-                            data_partition: params.partition,
-                            ttl_ms: 30_000,
-                        };
-                        match self
-                            .send_unique_reserve_request_async(target_node, &reserve_params)
-                            .await
-                        {
-                            Ok(rx) => {
-                                match tokio::time::timeout(std::time::Duration::from_secs(5), rx)
-                                    .await
-                                {
-                                    Ok(Ok(
-                                        UniqueReserveStatus::Reserved
-                                        | UniqueReserveStatus::AlreadyReserved,
-                                    )) => {
-                                        remote_reserved.push((
-                                            field.clone(),
-                                            value.clone(),
-                                            target_node,
-                                        ));
-                                        None
-                                    }
-                                    Ok(Ok(UniqueReserveStatus::Conflict)) => {
-                                        Some(super::ReserveFailure::Conflict(field.clone()))
-                                    }
-                                    _ => Some(super::ReserveFailure::NotDurable(field.clone())),
-                                }
-                            }
-                            Err(_) => Some(super::ReserveFailure::NotDurable(field.clone())),
-                        }
-                    } else {
-                        Some(super::ReserveFailure::NotDurable(field.clone()))
-                    };
-
-                    if let Some(failure) = failure {
-                        self.release_all_reservations(
-                            &entity,
-                            &request_id,
-                            &local_reserved,
-                            &remote_reserved,
-                        )
-                        .await;
+                    )
+                    .await
+                {
+                    Ok(p) => p,
+                    Err(failure) => {
                         let payload = Self::json_error(failure.http_code(), &failure.message());
                         let response =
                             JsonDbResponse::new(0, payload, response_topic, correlation_data);
@@ -1700,60 +1636,24 @@ impl<T: ClusterTransport> NodeController<T> {
                             .transport
                             .send(from, ClusterMessage::JsonDbResponse(response))
                             .await;
-                        return;
+                        return super::FkThenUniqueOutcome::Done;
                     }
-                }
-
-                let data_bytes = serde_json::to_vec(&data).unwrap_or_default();
-                let response_payload =
-                    match self.db_create_prepare(&entity, &id, &data_bytes, now_ms) {
-                        Ok((db_entity, write)) => {
-                            self.commit_all_reservations(
-                                &entity,
-                                &request_id,
-                                &local_reserved,
-                                &remote_reserved,
-                            )
-                            .await;
-                            let event =
-                                ChangeEvent::create(entity.clone(), id.clone(), data.clone());
-                            let outbox = build_change_event_outbox(&event);
-                            self.db_commit(write, outbox.clone()).await;
-                            self.publish_and_deliver_change_event(event, &outbox.operation_id)
-                                .await;
-                            crate::cluster::db_handler::helpers::json_ok_with_id(
-                                db_entity.id_str(),
-                                &data,
-                            )
-                        }
-                        Err(super::db::DbDataStoreError::AlreadyExists) => {
-                            self.release_all_reservations(
-                                &entity,
-                                &request_id,
-                                &local_reserved,
-                                &remote_reserved,
-                            )
-                            .await;
-                            Self::json_error(409, "entity already exists")
-                        }
-                        Err(_) => {
-                            self.release_all_reservations(
-                                &entity,
-                                &request_id,
-                                &local_reserved,
-                                &remote_reserved,
-                            )
-                            .await;
-                            Self::json_error(500, "internal error")
-                        }
-                    };
-
-                let response =
-                    JsonDbResponse::new(0, response_payload, response_topic, correlation_data);
-                let _ = self
-                    .transport
-                    .send(from, ClusterMessage::JsonDbResponse(response))
-                    .await;
+                };
+                super::FkThenUniqueOutcome::NeedUnique(Box::new(super::PendingUniqueWork {
+                    phase1,
+                    continuation: super::UniqueCheckContinuation::CreateFromNodeController {
+                        from,
+                        entity,
+                        id,
+                        data,
+                        data_bytes,
+                        partition,
+                        request_id,
+                        now_ms,
+                        response_topic,
+                        correlation_data,
+                    },
+                }))
             }
             FkCheckContinuation::UpdateFromNodeController {
                 from,
@@ -1769,164 +1669,56 @@ impl<T: ClusterTransport> NodeController<T> {
                 ..
             } => {
                 let now_ms = Self::current_time_ms();
-                let has_unique_changes = new_diff.as_object().is_some_and(|m| !m.is_empty());
-
-                let mut local_reserved: Vec<(String, Vec<u8>)> = Vec::new();
-                let mut remote_reserved: Vec<(String, Vec<u8>, NodeId)> = Vec::new();
-                let mut fk_quorum: Vec<(String, tokio::sync::oneshot::Receiver<bool>)> = Vec::new();
-
-                if has_unique_changes {
-                    let unique_fields = self.stores.constraint_get_unique_fields(&entity);
-                    for field in &unique_fields {
-                        let value = match new_diff.get(field) {
-                            Some(v) => serde_json::to_vec(v).unwrap_or_default(),
-                            None => continue,
-                        };
-
-                        let params = UniqueReservationParams {
-                            entity: &entity,
-                            field,
-                            value: &value,
-                            id: &id,
-                            request_id: &request_id,
-                            partition,
-                            now_ms,
-                        };
-
-                        let unique_part =
-                            super::db::unique_partition(params.entity, params.field, params.value);
-                        let primary = self.partition_map.primary(unique_part);
-
-                        let failure = if primary == Some(self.node_id) {
-                            self.reserve_unique_local(&params, &mut local_reserved, &mut fk_quorum)
-                                .await
-                        } else if let Some(target_node) = primary {
-                            let reserve_params = super::db::UniqueReserveParams {
-                                entity: params.entity,
-                                field: params.field,
-                                value: params.value,
-                                record_id: params.id,
-                                request_id: params.request_id,
-                                data_partition: params.partition,
-                                ttl_ms: 30_000,
-                            };
-                            match self
-                                .send_unique_reserve_request_async(target_node, &reserve_params)
-                                .await
-                            {
-                                Ok(rx) => {
-                                    match tokio::time::timeout(
-                                        std::time::Duration::from_secs(5),
-                                        rx,
-                                    )
-                                    .await
-                                    {
-                                        Ok(Ok(
-                                            UniqueReserveStatus::Reserved
-                                            | UniqueReserveStatus::AlreadyReserved,
-                                        )) => {
-                                            remote_reserved.push((
-                                                field.clone(),
-                                                value.clone(),
-                                                target_node,
-                                            ));
-                                            None
-                                        }
-                                        Ok(Ok(UniqueReserveStatus::Conflict)) => {
-                                            Some(super::ReserveFailure::Conflict(field.clone()))
-                                        }
-                                        _ => Some(super::ReserveFailure::NotDurable(field.clone())),
-                                    }
-                                }
-                                Err(_) => Some(super::ReserveFailure::NotDurable(field.clone())),
-                            }
-                        } else {
-                            Some(super::ReserveFailure::NotDurable(field.clone()))
-                        };
-
-                        if let Some(failure) = failure {
-                            self.release_all_reservations(
-                                &entity,
-                                &request_id,
-                                &local_reserved,
-                                &remote_reserved,
-                            )
-                            .await;
-                            let payload = Self::json_error(failure.http_code(), &failure.message());
-                            let response =
-                                JsonDbResponse::new(0, payload, response_topic, correlation_data);
-                            let _ = self
-                                .transport
-                                .send(from, ClusterMessage::JsonDbResponse(response))
-                                .await;
-                            return;
-                        }
-                    }
-                }
-
                 let data_bytes = serde_json::to_vec(&merged_data).unwrap_or_default();
-                let response_payload =
-                    match self.db_update_prepare(&entity, &id, &data_bytes, now_ms) {
-                        Ok((db_entity, write)) => {
-                            self.commit_all_reservations(
-                                &entity,
-                                &request_id,
-                                &local_reserved,
-                                &remote_reserved,
-                            )
+                // FK passed; run the unique reserve on the changed fields and return the pending
+                // work so the majority-await runs OUTSIDE the controller lock (see the Create arm).
+                let phase1 = match self
+                    .start_unique_constraint_check(
+                        &entity,
+                        &id,
+                        &new_diff,
+                        partition,
+                        &request_id,
+                        now_ms,
+                    )
+                    .await
+                {
+                    Ok(p) => p,
+                    Err(failure) => {
+                        let payload = Self::json_error(failure.http_code(), &failure.message());
+                        let response =
+                            JsonDbResponse::new(0, payload, response_topic, correlation_data);
+                        let _ = self
+                            .transport
+                            .send(from, ClusterMessage::JsonDbResponse(response))
                             .await;
-                            self.release_unique_constraints(
-                                &entity, &id, &old_diff, partition, &id, now_ms,
-                            )
-                            .await;
-                            let event = ChangeEvent::update(
-                                entity.clone(),
-                                id.clone(),
-                                merged_data.clone(),
-                            );
-                            let outbox = build_change_event_outbox(&event);
-                            self.db_commit(write, outbox.clone()).await;
-                            self.publish_and_deliver_change_event(event, &outbox.operation_id)
-                                .await;
-                            crate::cluster::db_handler::helpers::json_ok_with_id(
-                                db_entity.id_str(),
-                                &merged_data,
-                            )
-                        }
-                        Err(super::db::DbDataStoreError::NotFound) => {
-                            self.release_all_reservations(
-                                &entity,
-                                &request_id,
-                                &local_reserved,
-                                &remote_reserved,
-                            )
-                            .await;
-                            Self::json_error(404, &format!("entity not found: {entity} id={id}"))
-                        }
-                        Err(_) => {
-                            self.release_all_reservations(
-                                &entity,
-                                &request_id,
-                                &local_reserved,
-                                &remote_reserved,
-                            )
-                            .await;
-                            Self::json_error(500, "internal error")
-                        }
-                    };
-
-                let response =
-                    JsonDbResponse::new(0, response_payload, response_topic, correlation_data);
-                let _ = self
-                    .transport
-                    .send(from, ClusterMessage::JsonDbResponse(response))
-                    .await;
+                        return super::FkThenUniqueOutcome::Done;
+                    }
+                };
+                super::FkThenUniqueOutcome::NeedUnique(Box::new(super::PendingUniqueWork {
+                    phase1,
+                    continuation: super::UniqueCheckContinuation::UpdateFromNodeController {
+                        from,
+                        entity,
+                        id,
+                        merged_data,
+                        data_bytes,
+                        partition,
+                        request_id,
+                        now_ms,
+                        new_diff,
+                        old_diff,
+                        response_topic,
+                        correlation_data,
+                    },
+                }))
             }
             FkCheckContinuation::CreateFromDbHandler { .. }
             | FkCheckContinuation::UpdateFromDbHandler { .. } => {
                 tracing::error!(
                     "complete_pending_fk_work received misrouted continuation (expected *FromNodeController)"
                 );
+                super::FkThenUniqueOutcome::Done
             }
         }
     }

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -1322,6 +1322,7 @@ impl<T: ClusterTransport> NodeController<T> {
         let mut local_reserved: Vec<(String, Vec<u8>)> = Vec::new();
         let remote_reserved: Vec<(String, Vec<u8>, NodeId)> = Vec::new();
         let mut pending_remote_reserves = Vec::new();
+        let mut pending_quorum: Vec<(String, tokio::sync::oneshot::Receiver<bool>)> = Vec::new();
 
         for field in &unique_fields {
             let value = match data.get(field) {
@@ -1344,7 +1345,7 @@ impl<T: ClusterTransport> NodeController<T> {
             let primary = self.partition_map.primary(unique_part);
 
             let is_conflict = if primary == Some(self.node_id) {
-                self.reserve_unique_local(&params, &mut local_reserved)
+                self.reserve_unique_local(&params, &mut local_reserved, &mut pending_quorum)
                     .await
             } else if let Some(target_node) = primary {
                 let reserve_params = super::db::UniqueReserveParams {
@@ -1396,7 +1397,7 @@ impl<T: ClusterTransport> NodeController<T> {
             }
         }
 
-        if !pending_remote_reserves.is_empty() {
+        if !pending_remote_reserves.is_empty() || !pending_quorum.is_empty() {
             let data_bytes = serde_json::to_vec(&data).unwrap_or_default();
             return (
                 Vec::new(),
@@ -1404,7 +1405,7 @@ impl<T: ClusterTransport> NodeController<T> {
                     phase1: super::UniqueCheckPhase1Result {
                         local_reserved,
                         pending_remote: pending_remote_reserves,
-                        pending_quorum: Vec::new(),
+                        pending_quorum,
                     },
                     continuation: UniqueCheckContinuation::CreateFromNodeController {
                         from,
@@ -1485,6 +1486,7 @@ impl<T: ClusterTransport> NodeController<T> {
         &mut self,
         params: &UniqueReservationParams<'_>,
         local_reserved: &mut Vec<(String, Vec<u8>)>,
+        pending_quorum: &mut Vec<(String, tokio::sync::oneshot::Receiver<bool>)>,
     ) -> bool {
         let unique_part = super::db::unique_partition(params.entity, params.field, params.value);
         if !self.unique_partition_sealed(unique_part) {
@@ -1512,7 +1514,9 @@ impl<T: ClusterTransport> NodeController<T> {
         match result {
             super::db::ReserveResult::Reserved => {
                 if let Some(w) = write {
-                    self.write_or_forward(w).await;
+                    self.sync_unique_write();
+                    let rx = self.replicate_unique_reserve(w).await;
+                    pending_quorum.push((params.field.to_owned(), rx));
                 }
                 local_reserved.push((params.field.to_owned(), params.value.to_vec()));
                 false
@@ -1616,6 +1620,10 @@ impl<T: ClusterTransport> NodeController<T> {
                 let unique_fields = self.stores.constraint_get_unique_fields(&entity);
                 let mut local_reserved: Vec<(String, Vec<u8>)> = Vec::new();
                 let mut remote_reserved: Vec<(String, Vec<u8>, NodeId)> = Vec::new();
+                // This continuation runs holding the controller lock, so it cannot await the quorum
+                // inline (the ack path needs the lock). Reserves here are gated + async-replicated;
+                // the reconciler backstops majority-durability for this rare FK+unique path.
+                let mut fk_quorum: Vec<(String, tokio::sync::oneshot::Receiver<bool>)> = Vec::new();
 
                 for field in &unique_fields {
                     let value = match data.get(field) {
@@ -1638,7 +1646,7 @@ impl<T: ClusterTransport> NodeController<T> {
                     let primary = self.partition_map.primary(unique_part);
 
                     let is_conflict = if primary == Some(self.node_id) {
-                        self.reserve_unique_local(&params, &mut local_reserved)
+                        self.reserve_unique_local(&params, &mut local_reserved, &mut fk_quorum)
                             .await
                     } else if let Some(target_node) = primary {
                         let reserve_params = super::db::UniqueReserveParams {
@@ -1769,6 +1777,7 @@ impl<T: ClusterTransport> NodeController<T> {
 
                 let mut local_reserved: Vec<(String, Vec<u8>)> = Vec::new();
                 let mut remote_reserved: Vec<(String, Vec<u8>, NodeId)> = Vec::new();
+                let mut fk_quorum: Vec<(String, tokio::sync::oneshot::Receiver<bool>)> = Vec::new();
 
                 if has_unique_changes {
                     let unique_fields = self.stores.constraint_get_unique_fields(&entity);
@@ -1793,7 +1802,7 @@ impl<T: ClusterTransport> NodeController<T> {
                         let primary = self.partition_map.primary(unique_part);
 
                         let is_conflict = if primary == Some(self.node_id) {
-                            self.reserve_unique_local(&params, &mut local_reserved)
+                            self.reserve_unique_local(&params, &mut local_reserved, &mut fk_quorum)
                                 .await
                         } else if let Some(target_node) = primary {
                             let reserve_params = super::db::UniqueReserveParams {

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -105,11 +105,21 @@ pub struct PendingUniqueReserve {
     pub receiver: oneshot::Receiver<UniqueReserveStatus>,
 }
 
+/// Identity of a unique claim, enough to release it: the reservation is keyed by
+/// `(entity, field, value)` and owned by `idempotency_key`.
+pub(crate) struct UniqueClaimId {
+    pub entity: String,
+    pub field: String,
+    pub value: Vec<u8>,
+    pub idempotency_key: String,
+}
+
 pub(super) enum UniqueQuorumCompletion {
     Local(oneshot::Sender<bool>),
     RemoteReserve {
         from: NodeId,
         response_request_id: u64,
+        claim: UniqueClaimId,
     },
 }
 

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -104,11 +104,19 @@ pub struct PendingUniqueReserve {
     pub receiver: oneshot::Receiver<UniqueReserveStatus>,
 }
 
+pub(super) enum UniqueQuorumCompletion {
+    Local(oneshot::Sender<bool>),
+    RemoteReserve {
+        from: NodeId,
+        response_request_id: u64,
+    },
+}
+
 pub(super) struct UniqueQuorumTracker {
     pub acks: HashSet<NodeId>,
     pub needed: usize,
     pub deadline_ms: u64,
-    pub responder: oneshot::Sender<bool>,
+    pub completion: UniqueQuorumCompletion,
 }
 
 pub struct UniqueCheckPhase1Result {
@@ -1182,7 +1190,7 @@ impl<T: ClusterTransport> NodeController<T> {
                 self.handle_unique_replicate(from, *request_id, write).await;
             }
             ClusterMessage::UniqueReplicateAck(ack) => {
-                self.record_unique_quorum_ack(from, ack.request_id);
+                self.record_unique_quorum_ack(from, ack.request_id).await;
             }
             ClusterMessage::FkCheckRequest(req) => {
                 self.handle_fk_check_request(from, req).await;

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -104,9 +104,17 @@ pub struct PendingUniqueReserve {
     pub receiver: oneshot::Receiver<UniqueReserveStatus>,
 }
 
+pub(super) struct UniqueQuorumTracker {
+    pub acks: HashSet<NodeId>,
+    pub needed: usize,
+    pub deadline_ms: u64,
+    pub responder: oneshot::Sender<bool>,
+}
+
 pub struct UniqueCheckPhase1Result {
     pub local_reserved: Vec<(String, Vec<u8>)>,
     pub pending_remote: Vec<PendingUniqueReserve>,
+    pub pending_quorum: Vec<(String, oneshot::Receiver<bool>)>,
 }
 
 pub struct PendingUniqueWork {
@@ -321,6 +329,8 @@ pub struct NodeController<T: ClusterTransport> {
     pub(super) heartbeat: HeartbeatManager,
     pub(super) replicas: HashMap<u16, ReplicaState>,
     pub(super) unique_promised: HashMap<u16, Epoch>,
+    pub(super) pending_unique_quorum: HashMap<u64, UniqueQuorumTracker>,
+    pub(super) unique_quorum_counter: u64,
     pub(super) pending: PendingWrites,
     pub(super) partition_map: PartitionMap,
     pub(super) current_time: u64,
@@ -388,6 +398,8 @@ impl<T: ClusterTransport> NodeController<T> {
             transport,
             replicas: HashMap::new(),
             unique_promised: HashMap::new(),
+            pending_unique_quorum: HashMap::new(),
+            unique_quorum_counter: 0,
             pending: PendingWrites::new(1000),
             partition_map: PartitionMap::default(),
             current_time: 0,
@@ -1166,8 +1178,11 @@ impl<T: ClusterTransport> NodeController<T> {
             ClusterMessage::UniqueReassertRequest(req) => {
                 self.handle_unique_reassert_request(req).await;
             }
-            ClusterMessage::UniqueReplicate(write) => {
-                self.handle_unique_replicate(write);
+            ClusterMessage::UniqueReplicate { request_id, write } => {
+                self.handle_unique_replicate(from, *request_id, write).await;
+            }
+            ClusterMessage::UniqueReplicateAck(ack) => {
+                self.record_unique_quorum_ack(from, ack.request_id);
             }
             ClusterMessage::FkCheckRequest(req) => {
                 self.handle_fk_check_request(from, req).await;

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -1161,7 +1161,6 @@ impl<T: ClusterTransport> NodeController<T> {
             ClusterMessage::UniqueReleaseRequest(req) => {
                 self.handle_unique_release_request(from, req).await;
             }
-            ClusterMessage::UniqueReleaseResponse(_resp) => {}
             ClusterMessage::FkCheckRequest(req) => {
                 self.handle_fk_check_request(from, req).await;
             }

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -134,6 +134,41 @@ pub struct UniqueCheckPhase1Result {
     pub pending_quorum: Vec<(String, oneshot::Receiver<bool>)>,
 }
 
+/// Why a unique reserve failed, so the create can return the right status: a real conflict is a
+/// permanent `409`, while a not-yet-durable reserve (partition unsealed, no primary/quorum) is a
+/// transient `503` the client should retry.
+pub enum ReserveFailure {
+    Conflict(String),
+    NotDurable(String),
+}
+
+impl ReserveFailure {
+    #[must_use]
+    pub fn field(&self) -> &str {
+        match self {
+            Self::Conflict(f) | Self::NotDurable(f) => f,
+        }
+    }
+
+    #[must_use]
+    pub fn http_code(&self) -> u16 {
+        match self {
+            Self::Conflict(_) => 409,
+            Self::NotDurable(_) => 503,
+        }
+    }
+
+    #[must_use]
+    pub fn message(&self) -> String {
+        match self {
+            Self::Conflict(f) => format!("unique constraint violation on field '{f}'"),
+            Self::NotDurable(f) => {
+                format!("unique reservation for field '{f}' is not yet durable; retry")
+            }
+        }
+    }
+}
+
 pub struct PendingUniqueWork {
     pub phase1: UniqueCheckPhase1Result,
     pub continuation: UniqueCheckContinuation,
@@ -1374,7 +1409,7 @@ impl<T: ClusterTransport> NodeController<T> {
         local_reserved: Vec<(String, Vec<u8>)>,
         remote_results: Result<
             Vec<(String, Vec<u8>, NodeId)>,
-            (String, Vec<(String, Vec<u8>, NodeId)>),
+            (ReserveFailure, Vec<(String, Vec<u8>, NodeId)>),
         >,
         continuation: UniqueCheckContinuation,
     ) {
@@ -1392,7 +1427,7 @@ impl<T: ClusterTransport> NodeController<T> {
                 correlation_data,
             } => {
                 let response_payload = match remote_results {
-                    Err((conflict_field, confirmed)) => {
+                    Err((failure, confirmed)) => {
                         self.release_unique_check_reservations(
                             &entity,
                             &request_id,
@@ -1400,10 +1435,7 @@ impl<T: ClusterTransport> NodeController<T> {
                             &confirmed,
                         )
                         .await;
-                        Self::json_error(
-                            409,
-                            &format!("unique constraint violation on field '{conflict_field}'"),
-                        )
+                        Self::json_error(failure.http_code(), &failure.message())
                     }
                     Ok(confirmed_remotes) => {
                         match self.db_create(&entity, &id, &data_bytes, now_ms).await {
@@ -1468,7 +1500,7 @@ impl<T: ClusterTransport> NodeController<T> {
                 correlation_data,
             } => {
                 let response_payload = match remote_results {
-                    Err((conflict_field, confirmed)) => {
+                    Err((failure, confirmed)) => {
                         self.release_unique_check_reservations(
                             &entity,
                             &request_id,
@@ -1476,10 +1508,7 @@ impl<T: ClusterTransport> NodeController<T> {
                             &confirmed,
                         )
                         .await;
-                        Self::json_error(
-                            409,
-                            &format!("unique constraint violation on field '{conflict_field}'"),
-                        )
+                        Self::json_error(failure.http_code(), &failure.message())
                     }
                     Ok(confirmed_remotes) => {
                         match self.db_update(&entity, &id, &data_bytes, now_ms).await {

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -174,6 +174,15 @@ pub struct PendingUniqueWork {
     pub continuation: UniqueCheckContinuation,
 }
 
+/// Result of completing an FK check whose entity also has unique constraints. `Done` means the
+/// response was already sent (FK failed, or the reserve failed synchronously). `NeedUnique` means
+/// the unique reserve has started and its majority-await must run **outside the controller lock**
+/// (via `spawn_unique_completion`), which is why this is returned rather than awaited inline.
+pub enum FkThenUniqueOutcome {
+    Done,
+    NeedUnique(Box<PendingUniqueWork>),
+}
+
 pub struct PendingFkCheck {
     pub target_entity: String,
     pub target_id: String,

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -22,8 +22,8 @@ use super::migration::{MigrationManager, MigrationPhase};
 use super::protocol::{
     BatchReadRequest, CatchupRequest, ForwardedPublish, JsonDbOp, JsonDbRequest, JsonDbResponse,
     QueryRequest, QueryResponse, ReplicationWrite, UniqueCommitRequest, UniqueCommitResponse,
-    UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse,
-    UniqueReserveStatus,
+    UniqueReassertRequest, UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest,
+    UniqueReserveResponse, UniqueReserveStatus,
 };
 use super::query_coordinator::QueryCoordinator;
 use super::quorum::PendingWrites;
@@ -1160,6 +1160,9 @@ impl<T: ClusterTransport> NodeController<T> {
             }
             ClusterMessage::UniqueReleaseRequest(req) => {
                 self.handle_unique_release_request(from, req).await;
+            }
+            ClusterMessage::UniqueReassertRequest(req) => {
+                self.handle_unique_reassert_request(req).await;
             }
             ClusterMessage::FkCheckRequest(req) => {
                 self.handle_fk_check_request(from, req).await;

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -23,7 +23,7 @@ use super::protocol::{
     BatchReadRequest, CatchupRequest, ForwardedPublish, JsonDbOp, JsonDbRequest, JsonDbResponse,
     QueryRequest, QueryResponse, ReplicationWrite, UniqueCommitRequest, UniqueCommitResponse,
     UniqueReassertRequest, UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest,
-    UniqueReserveResponse, UniqueReserveStatus,
+    UniqueReserveResponse, UniqueReserveStatus, UniqueSealRequest, UniqueSealResponse,
 };
 use super::query_coordinator::QueryCoordinator;
 use super::quorum::PendingWrites;
@@ -117,6 +117,14 @@ pub(super) struct UniqueQuorumTracker {
     pub needed: usize,
     pub deadline_ms: u64,
     pub completion: UniqueQuorumCompletion,
+}
+
+pub(super) struct UniqueSealTracker {
+    pub partition: PartitionId,
+    pub epoch: Epoch,
+    pub responses: HashSet<NodeId>,
+    pub needed: usize,
+    pub deadline_ms: u64,
 }
 
 pub struct UniqueCheckPhase1Result {
@@ -337,6 +345,9 @@ pub struct NodeController<T: ClusterTransport> {
     pub(super) heartbeat: HeartbeatManager,
     pub(super) replicas: HashMap<u16, ReplicaState>,
     pub(super) unique_promised: HashMap<u16, Epoch>,
+    pub(super) unique_sealed: HashMap<u16, Epoch>,
+    pub(super) pending_seal_queue: Vec<(PartitionId, Epoch)>,
+    pub(super) pending_unique_seals: HashMap<u64, UniqueSealTracker>,
     pub(super) pending_unique_quorum: HashMap<u64, UniqueQuorumTracker>,
     pub(super) unique_quorum_counter: u64,
     pub(super) pending: PendingWrites,
@@ -406,6 +417,9 @@ impl<T: ClusterTransport> NodeController<T> {
             transport,
             replicas: HashMap::new(),
             unique_promised: HashMap::new(),
+            unique_sealed: HashMap::new(),
+            pending_seal_queue: Vec::new(),
+            pending_unique_seals: HashMap::new(),
             pending_unique_quorum: HashMap::new(),
             unique_quorum_counter: 0,
             pending: PendingWrites::new(1000),
@@ -528,6 +542,7 @@ impl<T: ClusterTransport> NodeController<T> {
             .entry(partition.get())
             .or_insert_with(|| ReplicaState::new(partition, self.node_id));
         state.become_primary(epoch);
+        self.queue_unique_seal(partition, epoch);
     }
 
     pub fn become_replica(&mut self, partition: PartitionId, epoch: Epoch, sequence: u64) {
@@ -1191,6 +1206,12 @@ impl<T: ClusterTransport> NodeController<T> {
             }
             ClusterMessage::UniqueReplicateAck(ack) => {
                 self.record_unique_quorum_ack(from, ack.request_id).await;
+            }
+            ClusterMessage::UniqueSealRequest(req) => {
+                self.handle_unique_seal_request(from, req).await;
+            }
+            ClusterMessage::UniqueSealResponse(resp) => {
+                self.handle_unique_seal_response(from, resp);
             }
             ClusterMessage::FkCheckRequest(req) => {
                 self.handle_fk_check_request(from, req).await;

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -64,6 +64,7 @@ const FORWARD_DEDUP_CAPACITY: usize = 1000;
 pub struct TickOutput {
     pub heartbeat: Option<ClusterMessage>,
     pub catchup_requests: Vec<(NodeId, ClusterMessage)>,
+    pub seal_requests: Vec<(NodeId, ClusterMessage)>,
     pub local_publishes: Vec<(String, Vec<u8>)>,
 }
 
@@ -542,7 +543,7 @@ impl<T: ClusterTransport> NodeController<T> {
             .entry(partition.get())
             .or_insert_with(|| ReplicaState::new(partition, self.node_id));
         state.become_primary(epoch);
-        self.queue_unique_seal(partition, epoch);
+        self.seal_or_queue_unique(partition, epoch);
     }
 
     pub fn become_replica(&mut self, partition: PartitionId, epoch: Epoch, sequence: u64) {
@@ -610,6 +611,7 @@ impl<T: ClusterTransport> NodeController<T> {
         }
 
         self.collect_catchup_requests(now, &mut output);
+        self.collect_pending_seals(&mut output);
         self.collect_stale_scatter_responses(now, &mut output);
         self.collect_stale_vault_decrypts(now);
 
@@ -630,6 +632,9 @@ impl<T: ClusterTransport> NodeController<T> {
             let _ = self.transport.broadcast(hb).await;
         }
         for (target, msg) in output.catchup_requests {
+            let _ = self.transport.send(target, msg).await;
+        }
+        for (target, msg) in output.seal_requests {
             let _ = self.transport.send(target, msg).await;
         }
         for (topic, payload) in output.local_publishes {

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -320,6 +320,7 @@ pub struct NodeController<T: ClusterTransport> {
     pub(super) transport: T,
     pub(super) heartbeat: HeartbeatManager,
     pub(super) replicas: HashMap<u16, ReplicaState>,
+    pub(super) unique_promised: HashMap<u16, Epoch>,
     pub(super) pending: PendingWrites,
     pub(super) partition_map: PartitionMap,
     pub(super) current_time: u64,
@@ -386,6 +387,7 @@ impl<T: ClusterTransport> NodeController<T> {
             heartbeat: HeartbeatManager::new(node_id, config),
             transport,
             replicas: HashMap::new(),
+            unique_promised: HashMap::new(),
             pending: PendingWrites::new(1000),
             partition_map: PartitionMap::default(),
             current_time: 0,
@@ -1163,6 +1165,9 @@ impl<T: ClusterTransport> NodeController<T> {
             }
             ClusterMessage::UniqueReassertRequest(req) => {
                 self.handle_unique_reassert_request(req).await;
+            }
+            ClusterMessage::UniqueReplicate(write) => {
+                self.handle_unique_replicate(write);
             }
             ClusterMessage::FkCheckRequest(req) => {
                 self.handle_fk_check_request(from, req).await;

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -1152,9 +1152,16 @@ impl<T: ClusterTransport> NodeController<T> {
             ClusterMessage::UniqueCommitRequest(req) => {
                 self.handle_unique_commit_request(from, req).await;
             }
+            ClusterMessage::UniqueCommitResponse(resp) if resp.success == 0 => {
+                tracing::warn!(
+                    request_id = resp.request_id,
+                    "unique commit not acknowledged; reconciler will repair"
+                );
+            }
             ClusterMessage::UniqueReleaseRequest(req) => {
                 self.handle_unique_release_request(from, req).await;
             }
+            ClusterMessage::UniqueReleaseResponse(_resp) => {}
             ClusterMessage::FkCheckRequest(req) => {
                 self.handle_fk_check_request(from, req).await;
             }

--- a/crates/mqdb-cluster/src/cluster/node_controller/replication_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/replication_ops.rs
@@ -347,6 +347,11 @@ impl<T: ClusterTransport> NodeController<T> {
             || write.entity == entity::CLIENT_LOCATIONS
             || write.entity == entity::DB_SCHEMA
             || write.entity == entity::DB_CONSTRAINT;
+        if write.entity == entity::DB_UNIQUE {
+            self.replicate_unique_to_group(write).await;
+            return;
+        }
+
         if is_broadcast_entity {
             let _ = self.stores.apply_write(&write);
             let alive = self.heartbeat.alive_nodes();

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -236,6 +236,55 @@ async fn unique_reserve_completes_immediately_for_single_node_group() {
 }
 
 #[tokio::test]
+async fn unsealed_partition_fails_reserve_closed() {
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let node3 = NodeId::validated(3).unwrap();
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    ctrl.register_peer(node2);
+    ctrl.register_peer(node3);
+
+    let entity = "users";
+    ctrl.stores()
+        .db_constraints
+        .add(crate::cluster::db::ClusterConstraint::unique(
+            entity,
+            "uniq_email",
+            "email",
+        ))
+        .unwrap();
+    let value = b"a@x.com";
+    let unique_part = crate::cluster::db::unique_partition(entity, "email", value);
+    // Primary at epoch 1, but a multi-node group has not completed the seal handshake.
+    ctrl.become_primary(unique_part, Epoch::new(1));
+    assert!(
+        !ctrl.unique_partition_sealed(unique_part),
+        "a multi-node group is not sealed until the handshake completes"
+    );
+
+    let data = serde_json::json!({ "email": "a@x.com" });
+    let result = ctrl
+        .check_unique_constraints(
+            entity,
+            "u1",
+            &data,
+            PartitionId::new(5).unwrap(),
+            "req-1",
+            1000,
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "reserve must fail closed while the value partition is unsealed"
+    );
+    assert!(
+        ctrl.stores().unique_get(entity, "email", value).is_none(),
+        "no reservation should be recorded for a fail-closed reserve"
+    );
+}
+
+#[tokio::test]
 async fn unique_seal_completes_for_single_node() {
     let node1 = NodeId::validated(1).unwrap();
     let mut ctrl = create_test_controller(node1, MockTransport::new(node1));

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -152,6 +152,88 @@ async fn replicate_write_sends_to_replicas() {
     assert_eq!(sent.len(), 2);
 }
 
+fn unique_reserve_write(
+    ctrl: &NodeController<MockTransport>,
+    entity: &str,
+    field: &str,
+    value: &[u8],
+) -> ReplicationWrite {
+    let params = crate::cluster::db::UniqueReserveParams {
+        entity,
+        field,
+        value,
+        record_id: "r1",
+        request_id: "req-1",
+        data_partition: PartitionId::new(5).unwrap(),
+        ttl_ms: 30_000,
+    };
+    let (result, write) = ctrl.stores().unique_reserve_replicated(&params, 1000);
+    assert_eq!(result, crate::cluster::db::ReserveResult::Reserved);
+    write.expect("reserve should yield a replication write")
+}
+
+#[tokio::test]
+async fn unique_reserve_resolves_on_majority_ack() {
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let node3 = NodeId::validated(3).unwrap();
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    ctrl.register_peer(node2);
+    ctrl.register_peer(node3);
+    ctrl.become_primary(PartitionId::new(5).unwrap(), Epoch::new(1));
+
+    let write = unique_reserve_write(&ctrl, "users", "email", b"a@x.com");
+    let rx = ctrl.replicate_unique_reserve(write).await;
+
+    // group is {1,2,3}, majority 2, self already counts as one; one more ack completes it.
+    ctrl.record_unique_quorum_ack(node2, 1);
+
+    assert_eq!(
+        rx.await,
+        Ok(true),
+        "reserve resolves once a majority holds it"
+    );
+}
+
+#[tokio::test]
+async fn unique_reserve_fails_closed_on_timeout() {
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let node3 = NodeId::validated(3).unwrap();
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    ctrl.register_peer(node2);
+    ctrl.register_peer(node3);
+    ctrl.become_primary(PartitionId::new(5).unwrap(), Epoch::new(1));
+
+    let write = unique_reserve_write(&ctrl, "users", "email", b"a@x.com");
+    let rx = ctrl.replicate_unique_reserve(write).await;
+
+    // no acks arrive; the deadline sweep must fail the reserve closed.
+    ctrl.sweep_unique_quorum(NodeController::<MockTransport>::current_time_ms() + 10_000);
+
+    assert_eq!(
+        rx.await,
+        Ok(false),
+        "a reserve that never reaches a majority fails closed"
+    );
+}
+
+#[tokio::test]
+async fn unique_reserve_completes_immediately_for_single_node_group() {
+    let node1 = NodeId::validated(1).unwrap();
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    ctrl.become_primary(PartitionId::new(5).unwrap(), Epoch::new(1));
+
+    let write = unique_reserve_write(&ctrl, "users", "email", b"a@x.com");
+    let rx = ctrl.replicate_unique_reserve(write).await;
+
+    assert_eq!(
+        rx.await,
+        Ok(true),
+        "a single-node group is its own majority; reserve is immediately durable"
+    );
+}
+
 #[tokio::test]
 async fn receive_heartbeat_marks_alive() {
     let node1 = NodeId::validated(1).unwrap();

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -236,6 +236,56 @@ async fn unique_reserve_completes_immediately_for_single_node_group() {
 }
 
 #[tokio::test]
+async fn fk_then_unique_defers_reserve_to_async_completion() {
+    use crate::cluster::db::ClusterConstraint;
+    use crate::cluster::node_controller::{FkCheckContinuation, FkThenUniqueOutcome};
+
+    let node1 = NodeId::validated(1).unwrap();
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    // Single-node group: become_primary seals every partition synchronously.
+    let mut map = crate::cluster::PartitionMap::default();
+    for i in 0..NUM_PARTITIONS {
+        let p = PartitionId::new(i).unwrap();
+        ctrl.become_primary(p, Epoch::new(1));
+        map.set(
+            p,
+            crate::cluster::PartitionAssignment {
+                primary: Some(node1),
+                replicas: vec![],
+                epoch: Epoch::new(1),
+            },
+        );
+    }
+    ctrl.update_partition_map(map);
+    ctrl.stores()
+        .db_constraints
+        .add(ClusterConstraint::unique("users", "uniq_email", "email"))
+        .unwrap();
+
+    let continuation = FkCheckContinuation::CreateFromNodeController {
+        from: node1,
+        entity: "users".to_string(),
+        id: "u1".to_string(),
+        data: serde_json::json!({ "id": "u1", "email": "a@x.com" }),
+        partition: crate::cluster::db::data_partition("users", "u1"),
+        request_id: "req-1".to_string(),
+        response_topic: "resp/t".to_string(),
+        correlation_data: None,
+    };
+
+    let outcome = ctrl
+        .complete_pending_fk_work(true, None, continuation)
+        .await;
+
+    // The reserve must be handed to the async completion (which awaits the quorum OUTSIDE the lock),
+    // never performed inline here — doing so would deadlock on the ack path.
+    assert!(
+        matches!(outcome, FkThenUniqueOutcome::NeedUnique(_)),
+        "an FK+unique create must defer its reserve to spawn_unique_completion"
+    );
+}
+
+#[tokio::test]
 async fn unsealed_partition_fails_reserve_closed() {
     let node1 = NodeId::validated(1).unwrap();
     let node2 = NodeId::validated(2).unwrap();

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -186,7 +186,7 @@ async fn unique_reserve_resolves_on_majority_ack() {
     let rx = ctrl.replicate_unique_reserve(write).await;
 
     // group is {1,2,3}, majority 2, self already counts as one; one more ack completes it.
-    ctrl.record_unique_quorum_ack(node2, 1);
+    ctrl.record_unique_quorum_ack(node2, 1).await;
 
     assert_eq!(
         rx.await,
@@ -209,7 +209,8 @@ async fn unique_reserve_fails_closed_on_timeout() {
     let rx = ctrl.replicate_unique_reserve(write).await;
 
     // no acks arrive; the deadline sweep must fail the reserve closed.
-    ctrl.sweep_unique_quorum(NodeController::<MockTransport>::current_time_ms() + 10_000);
+    ctrl.sweep_unique_quorum(NodeController::<MockTransport>::current_time_ms() + 10_000)
+        .await;
 
     assert_eq!(
         rx.await,

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -236,6 +236,78 @@ async fn unique_reserve_completes_immediately_for_single_node_group() {
 }
 
 #[tokio::test]
+async fn unique_seal_completes_for_single_node() {
+    let node1 = NodeId::validated(1).unwrap();
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    let p = PartitionId::new(5).unwrap();
+
+    ctrl.become_primary(p, Epoch::new(2));
+    ctrl.drain_pending_seals().await;
+
+    assert_eq!(
+        ctrl.unique_sealed.get(&p.get()),
+        Some(&Epoch::new(2)),
+        "a single-node group is its own majority; the partition seals immediately"
+    );
+}
+
+#[tokio::test]
+async fn unique_seal_reaches_majority_on_response() {
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let node3 = NodeId::validated(3).unwrap();
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    ctrl.register_peer(node2);
+    ctrl.register_peer(node3);
+    let p = PartitionId::new(5).unwrap();
+
+    ctrl.become_primary(p, Epoch::new(2));
+    ctrl.drain_pending_seals().await;
+    assert_eq!(
+        ctrl.unique_sealed.get(&p.get()),
+        None,
+        "not sealed until a majority of the group has promised the epoch"
+    );
+
+    let resp = UniqueSealResponse::create(1, p, 2, true);
+    ctrl.handle_unique_seal_response(node2, &resp);
+
+    assert_eq!(
+        ctrl.unique_sealed.get(&p.get()),
+        Some(&Epoch::new(2)),
+        "self + one accepting member is a majority of three"
+    );
+}
+
+#[tokio::test]
+async fn unique_seal_request_fenced_by_higher_promise() {
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    let p = PartitionId::new(5).unwrap();
+
+    ctrl.handle_unique_seal_request(node2, &UniqueSealRequest::create(1, p, 3))
+        .await;
+    ctrl.handle_unique_seal_request(node2, &UniqueSealRequest::create(2, p, 2))
+        .await;
+
+    let accepts: Vec<bool> = ctrl
+        .transport
+        .sent_messages()
+        .iter()
+        .filter_map(|(_, m)| match m {
+            ClusterMessage::UniqueSealResponse(r) => Some(r.is_accepted()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        accepts,
+        vec![true, false],
+        "epoch 3 is promised, so the stale epoch-2 seal is fenced out"
+    );
+}
+
+#[tokio::test]
 async fn receive_heartbeat_marks_alive() {
     let node1 = NodeId::validated(1).unwrap();
     let node2 = NodeId::validated(2).unwrap();

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -220,6 +220,65 @@ async fn unique_reserve_fails_closed_on_timeout() {
 }
 
 #[tokio::test]
+async fn remote_reserve_quorum_timeout_releases_local_reservation() {
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let node3 = NodeId::validated(3).unwrap();
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    ctrl.register_peer(node2);
+    ctrl.register_peer(node3);
+    ctrl.become_primary(PartitionId::new(5).unwrap(), Epoch::new(1));
+
+    // A remote-coordinated reserve landed on the value-primary: it holds the reservation locally
+    // and defers its response until the reservation is majority-durable.
+    let write = unique_reserve_write(&ctrl, "users", "email", b"a@x.com");
+    assert!(
+        ctrl.stores()
+            .unique_get("users", "email", b"a@x.com")
+            .is_some(),
+        "the value-primary holds the reservation after the local reserve"
+    );
+    ctrl.replicate_unique_reserve_remote(
+        write,
+        node2,
+        42,
+        UniqueClaimId {
+            entity: "users".to_string(),
+            field: "email".to_string(),
+            value: b"a@x.com".to_vec(),
+            idempotency_key: "req-1".to_string(),
+        },
+    )
+    .await;
+
+    // No group member acks; the deadline sweep fails the reserve closed. It must ALSO release the
+    // local reservation, or a transient quorum timeout wedges the value until its 30s TTL.
+    ctrl.sweep_unique_quorum(NodeController::<MockTransport>::current_time_ms() + 10_000)
+        .await;
+
+    assert!(
+        ctrl.stores()
+            .unique_get("users", "email", b"a@x.com")
+            .is_none(),
+        "a remote reserve that never reached a majority must release its local reservation"
+    );
+
+    let sent_error = ctrl.transport.sent_messages().iter().any(|(to, m)| {
+        *to == node2
+            && matches!(
+                m,
+                ClusterMessage::UniqueReserveResponse(r)
+                    if r.request_id == 42
+                        && matches!(r.status(), UniqueReserveStatus::Error)
+            )
+    });
+    assert!(
+        sent_error,
+        "the coordinator must receive an Error response so it fails the create closed"
+    );
+}
+
+#[tokio::test]
 async fn unique_reserve_completes_immediately_for_single_node_group() {
     let node1 = NodeId::validated(1).unwrap();
     let mut ctrl = create_test_controller(node1, MockTransport::new(node1));

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -318,7 +318,7 @@ async fn unique_seal_reaches_majority_on_response() {
         "not sealed until a majority of the group has promised the epoch"
     );
 
-    let resp = UniqueSealResponse::create(1, p, 2, true);
+    let resp = UniqueSealResponse::create(1, p, 2, true, Vec::new());
     ctrl.handle_unique_seal_response(node2, &resp);
 
     assert_eq!(
@@ -326,6 +326,56 @@ async fn unique_seal_reaches_majority_on_response() {
         Some(&Epoch::new(2)),
         "self + one accepting member is a majority of three"
     );
+}
+
+#[tokio::test]
+async fn seal_response_teaches_primary_a_missed_reservation() {
+    use crate::cluster::db::{UniqueReservation, UniqueStore};
+
+    let node1 = NodeId::validated(1).unwrap();
+    let node2 = NodeId::validated(2).unwrap();
+    let node3 = NodeId::validated(3).unwrap();
+    let mut ctrl = create_test_controller(node1, MockTransport::new(node1));
+    ctrl.register_peer(node2);
+    ctrl.register_peer(node3);
+
+    let value = b"a@x.com";
+    let unique_part = crate::cluster::db::unique_partition("users", "email", value);
+    // A committed claim for the value exists on the group, but this promoting primary missed it.
+    let committed = UniqueReservation::create(
+        "users",
+        "email",
+        value,
+        "owner-a",
+        "req-a",
+        PartitionId::new(5).unwrap(),
+        1000,
+    )
+    .with_committed();
+    let member = UniqueStore::new(node2);
+    member
+        .apply_replicated(
+            crate::cluster::protocol::Operation::Insert,
+            &crate::cluster::db::unique_key(&committed),
+            &UniqueStore::serialize(&committed),
+        )
+        .unwrap();
+    let blob = member.export_for_partition(unique_part);
+
+    assert!(
+        ctrl.stores().unique_get("users", "email", value).is_none(),
+        "primary starts out missing the reservation"
+    );
+
+    let resp = UniqueSealResponse::create(1, unique_part, 2, true, blob);
+    ctrl.handle_unique_seal_response(node2, &resp);
+
+    let learned = ctrl
+        .stores()
+        .unique_get("users", "email", value)
+        .expect("the seal response must teach the primary the reservation it missed");
+    assert!(learned.is_committed());
+    assert_eq!(learned.record_id_str(), "owner-a");
 }
 
 #[tokio::test]

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -294,9 +294,12 @@ impl<T: ClusterTransport> NodeController<T> {
                 data_partition,
                 ttl_ms: req.ttl_ms,
             };
-            let result = self
+            let (result, write) = self
                 .stores
-                .unique_reserve(&reserve_params, Self::current_time_ms());
+                .unique_reserve_replicated(&reserve_params, Self::current_time_ms());
+            if let Some(w) = write {
+                self.write_or_forward(w).await;
+            }
             match result {
                 super::super::db::ReserveResult::Reserved => UniqueReserveStatus::Reserved,
                 super::super::db::ReserveResult::AlreadyReservedBySameRequest => {
@@ -324,11 +327,20 @@ impl<T: ClusterTransport> NodeController<T> {
         let field = req.field_str();
         let idempotency_key = req.idempotency_key_str();
 
-        let _ = self
-            .stores
-            .unique_commit(entity, field, &req.value, idempotency_key);
+        let committed =
+            match self
+                .stores
+                .unique_commit_replicated(entity, field, &req.value, idempotency_key)
+            {
+                Ok((_, w)) => {
+                    self.write_or_forward(w).await;
+                    true
+                }
+                Err(super::super::db::UniqueStoreError::AlreadyCommitted) => true,
+                Err(_) => false,
+            };
 
-        let response = super::UniqueCommitResponse::create(req.request_id, true);
+        let response = super::UniqueCommitResponse::create(req.request_id, committed);
         let _ = self
             .transport
             .send(from, ClusterMessage::UniqueCommitResponse(response))
@@ -344,9 +356,12 @@ impl<T: ClusterTransport> NodeController<T> {
         let field = req.field_str();
         let idempotency_key = req.idempotency_key_str();
 
-        let _ = self
-            .stores
-            .unique_release(entity, field, &req.value, idempotency_key);
+        if let Some(w) =
+            self.stores
+                .unique_release_replicated(entity, field, &req.value, idempotency_key)
+        {
+            self.write_or_forward(w).await;
+        }
 
         let response = super::UniqueReleaseResponse::create(req.request_id, true);
         let _ = self

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -491,6 +491,75 @@ impl<T: ClusterTransport> NodeController<T> {
             .await;
     }
 
+    /// The fixed quorum group for the `DB_UNIQUE` keyspace: the registered cluster membership
+    /// (stable across heartbeat timeouts), decoupled from data replication factor.
+    #[must_use]
+    pub(crate) fn unique_quorum_group(&self) -> Vec<NodeId> {
+        self.heartbeat.registered_nodes()
+    }
+
+    /// Replicate a `DB_UNIQUE` write to the whole quorum group (sequence-free, epoch-fenced).
+    /// The local store is already updated by the store op that produced `write`; this fans the
+    /// decision out to the group members, who accept it idempotently under the epoch fence.
+    pub(crate) async fn replicate_unique_to_group(
+        &mut self,
+        write: crate::cluster::protocol::ReplicationWrite,
+    ) {
+        let partition = write.partition;
+        let epoch = self.epoch(partition).unwrap_or(crate::cluster::Epoch::ZERO);
+        let stamped = crate::cluster::protocol::ReplicationWrite::new(
+            partition,
+            write.operation,
+            epoch,
+            0,
+            write.entity,
+            write.id,
+            write.data,
+        );
+
+        let promised = self
+            .unique_promised
+            .entry(partition.get())
+            .or_insert(crate::cluster::Epoch::ZERO);
+        if epoch > *promised {
+            *promised = epoch;
+        }
+
+        for node in self.unique_quorum_group() {
+            if node != self.node_id {
+                let _ = self
+                    .transport
+                    .send(node, ClusterMessage::UniqueReplicate(stamped.clone()))
+                    .await;
+            }
+        }
+    }
+
+    /// Receive a group `DB_UNIQUE` replication write: accept iff the write's epoch is not below
+    /// this node's promised epoch for the partition (the fence), then apply last-writer-wins.
+    pub(crate) fn handle_unique_replicate(
+        &mut self,
+        write: &crate::cluster::protocol::ReplicationWrite,
+    ) {
+        let promised = self
+            .unique_promised
+            .entry(write.partition.get())
+            .or_insert(crate::cluster::Epoch::ZERO);
+        if write.epoch < *promised {
+            tracing::debug!(
+                partition = write.partition.get(),
+                write_epoch = write.epoch.get(),
+                promised = promised.get(),
+                "rejecting stale-epoch unique replicate"
+            );
+            return;
+        }
+        *promised = write.epoch;
+        if let Err(e) = self.stores.apply_write(write) {
+            tracing::error!(?e, "failed to apply unique replicate write");
+        }
+    }
+
     async fn send_unique_reassert_fire_and_forget(
         &self,
         target_node: NodeId,

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -3,8 +3,8 @@
 
 use super::{
     ClusterMessage, ClusterTransport, NodeController, NodeId, PartitionId, PendingUniqueReserve,
-    UniqueCheckPhase1Result, UniqueCommitRequest, UniqueReleaseRequest, UniqueReserveRequest,
-    UniqueReserveResponse, UniqueReserveStatus,
+    UniqueCheckPhase1Result, UniqueCommitRequest, UniqueReassertRequest, UniqueReleaseRequest,
+    UniqueReserveRequest, UniqueReserveResponse, UniqueReserveStatus,
 };
 use tokio::sync::oneshot;
 
@@ -374,6 +374,50 @@ impl<T: ClusterTransport> NodeController<T> {
             .await;
     }
 
+    pub(crate) async fn handle_unique_reassert_request(&mut self, req: &UniqueReassertRequest) {
+        let Some(data_partition) = req.data_partition() else {
+            return;
+        };
+        self.reassert_unique_claim(
+            req.entity_str(),
+            req.field_str(),
+            &req.value,
+            req.record_id_str(),
+            data_partition,
+        )
+        .await;
+    }
+
+    async fn reassert_unique_claim(
+        &mut self,
+        entity: &str,
+        field: &str,
+        value: &[u8],
+        record_id: &str,
+        data_partition: PartitionId,
+    ) {
+        let (result, write) = self.stores.reassert_replicated(
+            entity,
+            field,
+            value,
+            record_id,
+            data_partition,
+            Self::current_time_ms(),
+        );
+        if let Some(w) = write {
+            self.write_or_forward(w).await;
+            self.sync_unique_write();
+        }
+        if matches!(result, super::super::db::ReassertResult::Conflict) {
+            tracing::error!(
+                entity,
+                field,
+                record_id,
+                "unique oversell detected: committed claim held by a different record"
+            );
+        }
+    }
+
     fn allocate_unique_request_id(&self) -> u64 {
         self.pending_constraints.allocate_unique_id()
     }
@@ -445,5 +489,88 @@ impl<T: ClusterTransport> NodeController<T> {
             .transport
             .send(target_node, ClusterMessage::UniqueReleaseRequest(request))
             .await;
+    }
+
+    async fn send_unique_reassert_fire_and_forget(
+        &self,
+        target_node: NodeId,
+        entity: &str,
+        field: &str,
+        value: &[u8],
+        record_id: &str,
+        data_partition: PartitionId,
+    ) {
+        let request =
+            UniqueReassertRequest::create(0, entity, field, value, record_id, data_partition);
+
+        let _ = self
+            .transport
+            .send(target_node, ClusterMessage::UniqueReassertRequest(request))
+            .await;
+    }
+
+    /// Reconcile every durable record this node owns (data-partition primary) against its
+    /// unique claim, repairing a reservation lost to failover/restart or a lost commit. The
+    /// durable record is the source of truth; each record is reconciled by exactly one node.
+    pub async fn reconcile_unique_claims(&mut self) {
+        let entities: Vec<String> = {
+            let mut set = std::collections::BTreeSet::new();
+            for constraint in self.stores.constraint_list_all() {
+                if constraint.constraint_type() == super::super::db::ConstraintType::Unique {
+                    set.insert(constraint.entity_str().to_string());
+                }
+            }
+            set.into_iter().collect()
+        };
+
+        for entity in &entities {
+            let unique_fields = self.stores.constraint_get_unique_fields(entity);
+            if unique_fields.is_empty() {
+                continue;
+            }
+            let records = self.stores.db_data.list(entity);
+            for record in records {
+                let data_partition = record.partition();
+                if self.partition_map.primary(data_partition) != Some(self.node_id) {
+                    continue;
+                }
+                let Ok(parsed) = serde_json::from_slice::<serde_json::Value>(&record.data) else {
+                    continue;
+                };
+                let record_id = record.id_str().to_string();
+                for field in &unique_fields {
+                    let value = match parsed.get(field) {
+                        Some(v) => serde_json::to_vec(v).unwrap_or_default(),
+                        None => continue,
+                    };
+
+                    let unique_part = super::super::db::unique_partition(entity, field, &value);
+                    match self.partition_map.primary(unique_part) {
+                        Some(primary) if primary == self.node_id => {
+                            self.reassert_unique_claim(
+                                entity,
+                                field,
+                                &value,
+                                &record_id,
+                                data_partition,
+                            )
+                            .await;
+                        }
+                        Some(target) => {
+                            self.send_unique_reassert_fire_and_forget(
+                                target,
+                                entity,
+                                field,
+                                &value,
+                                &record_id,
+                                data_partition,
+                            )
+                            .await;
+                        }
+                        None => {}
+                    }
+                }
+            }
+        }
     }
 }

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -9,6 +9,7 @@ use super::{
 use tokio::sync::oneshot;
 
 const UNIQUE_RESERVE_TIMEOUT_SECS: u64 = 5;
+const UNIQUE_QUORUM_TIMEOUT_MS: u64 = 5000;
 
 pub async fn await_unique_reserves(
     pending: Vec<PendingUniqueReserve>,
@@ -38,6 +39,20 @@ pub async fn await_unique_reserves(
     Ok(confirmed)
 }
 
+/// Await majority-durability for every locally reserved unique value. Returns `Err(field)` for the
+/// first reserve that failed to reach a group majority before its deadline (fail-closed).
+pub async fn await_unique_quorum(
+    pending: Vec<(String, oneshot::Receiver<bool>)>,
+) -> Result<(), String> {
+    for (field, receiver) in pending {
+        match receiver.await {
+            Ok(true) => {}
+            _ => return Err(field),
+        }
+    }
+    Ok(())
+}
+
 impl<T: ClusterTransport> NodeController<T> {
     #[allow(clippy::missing_errors_doc)]
     pub async fn start_unique_constraint_check(
@@ -52,6 +67,7 @@ impl<T: ClusterTransport> NodeController<T> {
         let unique_fields = self.stores.constraint_get_unique_fields(entity);
         let mut local_reserved: Vec<(String, Vec<u8>)> = Vec::new();
         let mut pending_remote: Vec<PendingUniqueReserve> = Vec::new();
+        let mut pending_quorum: Vec<(String, oneshot::Receiver<bool>)> = Vec::new();
 
         for field in &unique_fields {
             let value = match data.get(field) {
@@ -80,8 +96,9 @@ impl<T: ClusterTransport> NodeController<T> {
                 match result {
                     super::super::db::ReserveResult::Reserved => {
                         if let Some(w) = write {
-                            self.write_or_forward(w).await;
                             self.sync_unique_write();
+                            let rx = self.replicate_unique_reserve(w).await;
+                            pending_quorum.push((field.clone(), rx));
                         }
                         local_reserved.push((field.clone(), value));
                         false
@@ -132,6 +149,7 @@ impl<T: ClusterTransport> NodeController<T> {
         Ok(UniqueCheckPhase1Result {
             local_reserved,
             pending_remote,
+            pending_quorum,
         })
     }
 
@@ -498,12 +516,18 @@ impl<T: ClusterTransport> NodeController<T> {
         self.heartbeat.registered_nodes()
     }
 
-    /// Replicate a `DB_UNIQUE` write to the whole quorum group (sequence-free, epoch-fenced).
-    /// The local store is already updated by the store op that produced `write`; this fans the
-    /// decision out to the group members, who accept it idempotently under the epoch fence.
-    pub(crate) async fn replicate_unique_to_group(
+    /// Majority size for the current quorum group.
+    #[must_use]
+    pub(crate) fn unique_majority(&self) -> usize {
+        self.unique_quorum_group().len() / 2 + 1
+    }
+
+    /// Stamp `write` with the value-partition epoch, bump this node's promised epoch, and fan the
+    /// decision out to every other group member under `request_id` (0 = untracked/fire-and-forget).
+    async fn send_unique_replicate(
         &mut self,
         write: crate::cluster::protocol::ReplicationWrite,
+        request_id: u64,
     ) {
         let partition = write.partition;
         let epoch = self.epoch(partition).unwrap_or(crate::cluster::Epoch::ZERO);
@@ -529,16 +553,74 @@ impl<T: ClusterTransport> NodeController<T> {
             if node != self.node_id {
                 let _ = self
                     .transport
-                    .send(node, ClusterMessage::UniqueReplicate(stamped.clone()))
+                    .send(
+                        node,
+                        ClusterMessage::UniqueReplicate {
+                            request_id,
+                            write: stamped.clone(),
+                        },
+                    )
                     .await;
             }
         }
     }
 
-    /// Receive a group `DB_UNIQUE` replication write: accept iff the write's epoch is not below
-    /// this node's promised epoch for the partition (the fence), then apply last-writer-wins.
-    pub(crate) fn handle_unique_replicate(
+    /// Replicate a `DB_UNIQUE` write to the whole quorum group, fire-and-forget (commit/release/
+    /// reassert): the Phase-1 reconciler repairs any member that misses it.
+    pub(crate) async fn replicate_unique_to_group(
         &mut self,
+        write: crate::cluster::protocol::ReplicationWrite,
+    ) {
+        self.send_unique_replicate(write, 0).await;
+    }
+
+    /// Replicate a reserve `DB_UNIQUE` write to the group and return a receiver that resolves
+    /// `true` once a **majority** of the group (including this node) holds it, or `false` on
+    /// timeout. The local store already holds the reservation, so this node counts as one ack.
+    pub(crate) async fn replicate_unique_reserve(
+        &mut self,
+        write: crate::cluster::protocol::ReplicationWrite,
+    ) -> oneshot::Receiver<bool> {
+        let (tx, rx) = oneshot::channel();
+        let needed = self.unique_majority();
+        let request_id = self.next_unique_quorum_id();
+
+        self.send_unique_replicate(write, request_id).await;
+
+        let mut acks = std::collections::HashSet::new();
+        acks.insert(self.node_id);
+        if acks.len() >= needed {
+            let _ = tx.send(true);
+        } else {
+            let deadline_ms = Self::current_time_ms() + UNIQUE_QUORUM_TIMEOUT_MS;
+            self.pending_unique_quorum.insert(
+                request_id,
+                super::UniqueQuorumTracker {
+                    acks,
+                    needed,
+                    deadline_ms,
+                    responder: tx,
+                },
+            );
+        }
+        rx
+    }
+
+    fn next_unique_quorum_id(&mut self) -> u64 {
+        self.unique_quorum_counter += 1;
+        if self.unique_quorum_counter == 0 {
+            self.unique_quorum_counter = 1;
+        }
+        self.unique_quorum_counter
+    }
+
+    /// Receive a group `DB_UNIQUE` replication write: accept iff the write's epoch is not below
+    /// this node's promised epoch for the partition (the fence), then apply last-writer-wins and
+    /// ack the coordinator if the write is quorum-tracked (`request_id != 0`).
+    pub(crate) async fn handle_unique_replicate(
+        &mut self,
+        from: NodeId,
+        request_id: u64,
         write: &crate::cluster::protocol::ReplicationWrite,
     ) {
         let promised = self
@@ -557,6 +639,44 @@ impl<T: ClusterTransport> NodeController<T> {
         *promised = write.epoch;
         if let Err(e) = self.stores.apply_write(write) {
             tracing::error!(?e, "failed to apply unique replicate write");
+            return;
+        }
+        self.sync_unique_write();
+
+        if request_id != 0 {
+            let ack = crate::cluster::protocol::UniqueReplicateAck::create(request_id);
+            let _ = self
+                .transport
+                .send(from, ClusterMessage::UniqueReplicateAck(ack))
+                .await;
+        }
+    }
+
+    /// Record a group member's ack for a tracked reserve; resolve the waiter once a majority
+    /// (including this node) holds the reservation.
+    pub(crate) fn record_unique_quorum_ack(&mut self, from: NodeId, request_id: u64) {
+        if let Some(tracker) = self.pending_unique_quorum.get_mut(&request_id) {
+            tracker.acks.insert(from);
+            if tracker.acks.len() >= tracker.needed
+                && let Some(tracker) = self.pending_unique_quorum.remove(&request_id)
+            {
+                let _ = tracker.responder.send(true);
+            }
+        }
+    }
+
+    /// Fail any reserve whose quorum was not reached before its deadline (fail-closed).
+    pub(crate) fn sweep_unique_quorum(&mut self, now_ms: u64) {
+        let expired: Vec<u64> = self
+            .pending_unique_quorum
+            .iter()
+            .filter(|(_, t)| t.deadline_ms <= now_ms)
+            .map(|(&id, _)| id)
+            .collect();
+        for id in expired {
+            if let Some(tracker) = self.pending_unique_quorum.remove(&id) {
+                let _ = tracker.responder.send(false);
+            }
         }
     }
 

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -4,12 +4,15 @@
 use super::{
     ClusterMessage, ClusterTransport, NodeController, NodeId, PartitionId, PendingUniqueReserve,
     UniqueCheckPhase1Result, UniqueCommitRequest, UniqueReassertRequest, UniqueReleaseRequest,
-    UniqueReserveRequest, UniqueReserveResponse, UniqueReserveStatus,
+    UniqueReserveRequest, UniqueReserveResponse, UniqueReserveStatus, UniqueSealRequest,
+    UniqueSealResponse,
 };
+use crate::cluster::Epoch;
 use tokio::sync::oneshot;
 
 const UNIQUE_RESERVE_TIMEOUT_SECS: u64 = 5;
 const UNIQUE_QUORUM_TIMEOUT_MS: u64 = 5000;
+const UNIQUE_SEAL_TIMEOUT_MS: u64 = 5000;
 
 pub async fn await_unique_reserves(
     pending: Vec<PendingUniqueReserve>,
@@ -749,6 +752,166 @@ impl<T: ClusterTransport> NodeController<T> {
             if let Some(tracker) = self.pending_unique_quorum.remove(&id) {
                 self.fire_unique_quorum_completion(tracker.completion, false)
                     .await;
+            }
+        }
+    }
+
+    /// Queue a promotion seal for a unique partition (deduped; skipped if already sealed ≥ epoch).
+    /// Drained by the event-loop tick so `become_primary` stays synchronous.
+    pub(crate) fn queue_unique_seal(&mut self, partition: PartitionId, epoch: Epoch) {
+        if self
+            .unique_sealed
+            .get(&partition.get())
+            .is_some_and(|&s| s >= epoch)
+        {
+            return;
+        }
+        if !self
+            .pending_seal_queue
+            .iter()
+            .any(|&(p, e)| p == partition && e >= epoch)
+        {
+            self.pending_seal_queue.push((partition, epoch));
+        }
+    }
+
+    /// Initiate any queued promotion seals: promise this node's epoch at a majority of the group
+    /// before it serves reserves for the partition (fences a superseded primary).
+    pub(crate) async fn drain_pending_seals(&mut self) {
+        let queue = std::mem::take(&mut self.pending_seal_queue);
+        for (partition, epoch) in queue {
+            if self
+                .unique_sealed
+                .get(&partition.get())
+                .is_some_and(|&s| s >= epoch)
+            {
+                continue;
+            }
+            if self
+                .pending_unique_seals
+                .values()
+                .any(|t| t.partition == partition && t.epoch >= epoch)
+            {
+                continue;
+            }
+            if self.epoch(partition) != Some(epoch) {
+                continue;
+            }
+            self.initiate_unique_seal(partition, epoch).await;
+        }
+    }
+
+    async fn initiate_unique_seal(&mut self, partition: PartitionId, epoch: Epoch) {
+        let promised = self
+            .unique_promised
+            .entry(partition.get())
+            .or_insert(Epoch::ZERO);
+        if epoch > *promised {
+            *promised = epoch;
+        }
+
+        let needed = self.unique_majority();
+        let request_id = self.next_unique_quorum_id();
+        for node in self.unique_quorum_group() {
+            if node != self.node_id {
+                let req = UniqueSealRequest::create(request_id, partition, epoch.get());
+                let _ = self
+                    .transport
+                    .send(node, ClusterMessage::UniqueSealRequest(req))
+                    .await;
+            }
+        }
+
+        let mut responses = std::collections::HashSet::new();
+        responses.insert(self.node_id);
+        if responses.len() >= needed {
+            self.mark_unique_sealed(partition, epoch);
+        } else {
+            let deadline_ms = Self::current_time_ms() + UNIQUE_SEAL_TIMEOUT_MS;
+            self.pending_unique_seals.insert(
+                request_id,
+                super::UniqueSealTracker {
+                    partition,
+                    epoch,
+                    responses,
+                    needed,
+                    deadline_ms,
+                },
+            );
+        }
+    }
+
+    pub(crate) async fn handle_unique_seal_request(
+        &mut self,
+        from: NodeId,
+        req: &UniqueSealRequest,
+    ) {
+        let Some(partition) = req.partition_id() else {
+            return;
+        };
+        let epoch = Epoch::new(req.epoch);
+        let promised = self
+            .unique_promised
+            .entry(partition.get())
+            .or_insert(Epoch::ZERO);
+        let accepted = if epoch >= *promised {
+            *promised = epoch;
+            true
+        } else {
+            false
+        };
+        let resp = UniqueSealResponse::create(req.request_id, partition, req.epoch, accepted);
+        let _ = self
+            .transport
+            .send(from, ClusterMessage::UniqueSealResponse(resp))
+            .await;
+    }
+
+    pub(crate) fn handle_unique_seal_response(&mut self, from: NodeId, resp: &UniqueSealResponse) {
+        if !resp.is_accepted() {
+            // A group member has promised a higher epoch — this node is superseded; abandon.
+            self.pending_unique_seals.remove(&resp.request_id);
+            return;
+        }
+        let reached = match self.pending_unique_seals.get_mut(&resp.request_id) {
+            Some(tracker) => {
+                tracker.responses.insert(from);
+                tracker.responses.len() >= tracker.needed
+            }
+            None => false,
+        };
+        if reached && let Some(tracker) = self.pending_unique_seals.remove(&resp.request_id) {
+            self.mark_unique_sealed(tracker.partition, tracker.epoch);
+        }
+    }
+
+    fn mark_unique_sealed(&mut self, partition: PartitionId, epoch: Epoch) {
+        let entry = self
+            .unique_sealed
+            .entry(partition.get())
+            .or_insert(Epoch::ZERO);
+        if epoch > *entry {
+            *entry = epoch;
+        }
+        tracing::debug!(
+            partition = partition.get(),
+            epoch = epoch.get(),
+            "unique partition sealed"
+        );
+    }
+
+    /// Retry seals that did not reach a majority before their deadline (liveness).
+    pub(crate) fn sweep_unique_seals(&mut self, now_ms: u64) {
+        let expired: Vec<(u64, PartitionId, Epoch)> = self
+            .pending_unique_seals
+            .iter()
+            .filter(|(_, t)| t.deadline_ms <= now_ms)
+            .map(|(&id, t)| (id, t.partition, t.epoch))
+            .collect();
+        for (id, partition, epoch) in expired {
+            self.pending_unique_seals.remove(&id);
+            if self.epoch(partition) == Some(epoch) {
+                self.queue_unique_seal(partition, epoch);
             }
         }
     }

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -3,9 +3,9 @@
 
 use super::{
     ClusterMessage, ClusterTransport, NodeController, NodeId, PartitionId, PendingUniqueReserve,
-    UniqueCheckPhase1Result, UniqueCommitRequest, UniqueReassertRequest, UniqueReleaseRequest,
-    UniqueReserveRequest, UniqueReserveResponse, UniqueReserveStatus, UniqueSealRequest,
-    UniqueSealResponse,
+    ReserveFailure, UniqueCheckPhase1Result, UniqueCommitRequest, UniqueReassertRequest,
+    UniqueReleaseRequest, UniqueReserveRequest, UniqueReserveResponse, UniqueReserveStatus,
+    UniqueSealRequest, UniqueSealResponse,
 };
 use crate::cluster::Epoch;
 use tokio::sync::oneshot;
@@ -16,7 +16,7 @@ const UNIQUE_SEAL_TIMEOUT_MS: u64 = 5000;
 
 pub async fn await_unique_reserves(
     pending: Vec<PendingUniqueReserve>,
-) -> Result<Vec<(String, Vec<u8>, NodeId)>, (String, Vec<(String, Vec<u8>, NodeId)>)> {
+) -> Result<Vec<(String, Vec<u8>, NodeId)>, (ReserveFailure, Vec<(String, Vec<u8>, NodeId)>)> {
     let mut confirmed: Vec<(String, Vec<u8>, NodeId)> = Vec::new();
 
     for pending_reserve in pending {
@@ -33,8 +33,13 @@ pub async fn await_unique_reserves(
                     pending_reserve.target_node,
                 ));
             }
+            // A remote conflict is a permanent 409; a remote error, timeout, or dropped channel is a
+            // transient not-durable failure the client should retry (503).
+            Ok(Ok(UniqueReserveStatus::Conflict)) => {
+                return Err((ReserveFailure::Conflict(pending_reserve.field), confirmed));
+            }
             _ => {
-                return Err((pending_reserve.field, confirmed));
+                return Err((ReserveFailure::NotDurable(pending_reserve.field), confirmed));
             }
         }
     }
@@ -66,7 +71,7 @@ impl<T: ClusterTransport> NodeController<T> {
         data_partition: PartitionId,
         request_id: &str,
         now_ms: u64,
-    ) -> Result<UniqueCheckPhase1Result, String> {
+    ) -> Result<UniqueCheckPhase1Result, ReserveFailure> {
         let unique_fields = self.stores.constraint_get_unique_fields(entity);
         let mut local_reserved: Vec<(String, Vec<u8>)> = Vec::new();
         let mut pending_remote: Vec<PendingUniqueReserve> = Vec::new();
@@ -91,15 +96,8 @@ impl<T: ClusterTransport> NodeController<T> {
                 ttl_ms: 30_000,
             };
 
-            let is_conflict = if primary == Some(self.node_id) {
-                if !self.unique_partition_sealed(unique_part) {
-                    tracing::warn!(
-                        field,
-                        partition = unique_part.get(),
-                        "unique partition not sealed at the current epoch; failing reserve closed"
-                    );
-                    true
-                } else {
+            let failure: Option<ReserveFailure> = if primary == Some(self.node_id) {
+                if self.unique_partition_sealed(unique_part) {
                     let (result, write) = self
                         .stores
                         .unique_reserve_replicated(&reserve_params, now_ms);
@@ -112,14 +110,23 @@ impl<T: ClusterTransport> NodeController<T> {
                                 pending_quorum.push((field.clone(), rx));
                             }
                             local_reserved.push((field.clone(), value));
-                            false
+                            None
                         }
                         super::super::db::ReserveResult::AlreadyReservedBySameRequest => {
                             local_reserved.push((field.clone(), value));
-                            false
+                            None
                         }
-                        super::super::db::ReserveResult::Conflict => true,
+                        super::super::db::ReserveResult::Conflict => {
+                            Some(ReserveFailure::Conflict(field.clone()))
+                        }
                     }
+                } else {
+                    tracing::warn!(
+                        field,
+                        partition = unique_part.get(),
+                        "unique partition not sealed at the current epoch; failing reserve closed"
+                    );
+                    Some(ReserveFailure::NotDurable(field.clone()))
                 }
             } else if let Some(target_node) = primary {
                 let receiver = self
@@ -134,15 +141,15 @@ impl<T: ClusterTransport> NodeController<T> {
                             target_node,
                             receiver: rx,
                         });
-                        false
+                        None
                     }
-                    Err(_) => true,
+                    Err(_) => Some(ReserveFailure::NotDurable(field.clone())),
                 }
             } else {
-                true
+                Some(ReserveFailure::NotDurable(field.clone()))
             };
 
-            if is_conflict {
+            if let Some(failure) = failure {
                 for (f, v) in &local_reserved {
                     if let Some(w) = self
                         .stores
@@ -154,7 +161,7 @@ impl<T: ClusterTransport> NodeController<T> {
                 for pending in pending_remote {
                     drop(pending.receiver);
                 }
-                return Err(field.clone());
+                return Err(failure);
             }
         }
 
@@ -198,7 +205,8 @@ impl<T: ClusterTransport> NodeController<T> {
     ) -> Result<(), String> {
         let phase1 = self
             .start_unique_constraint_check(entity, id, data, data_partition, request_id, now_ms)
-            .await?;
+            .await
+            .map_err(|f| f.field().to_string())?;
 
         if !phase1.pending_remote.is_empty() {
             let remote_results = await_unique_reserves(phase1.pending_remote).await;
@@ -209,7 +217,7 @@ impl<T: ClusterTransport> NodeController<T> {
                             .await;
                     }
                 }
-                Err((conflict_field, confirmed)) => {
+                Err((failure, confirmed)) => {
                     self.release_unique_check_reservations(
                         entity,
                         request_id,
@@ -217,7 +225,7 @@ impl<T: ClusterTransport> NodeController<T> {
                         &confirmed,
                     )
                     .await;
-                    return Err(conflict_field);
+                    return Err(failure.field().to_string());
                 }
             }
         }

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -923,7 +923,20 @@ impl<T: ClusterTransport> NodeController<T> {
         } else {
             false
         };
-        let resp = UniqueSealResponse::create(req.request_id, partition, req.epoch, accepted);
+        // An accepting member returns its reservations for the partition so the promoting primary
+        // learns any claim it missed (the leaderView step) before it serves reserves.
+        let reservations = if accepted {
+            self.stores.db_unique.export_for_partition(partition)
+        } else {
+            Vec::new()
+        };
+        let resp = UniqueSealResponse::create(
+            req.request_id,
+            partition,
+            req.epoch,
+            accepted,
+            reservations,
+        );
         let _ = self
             .transport
             .send(from, ClusterMessage::UniqueSealResponse(resp))
@@ -935,6 +948,12 @@ impl<T: ClusterTransport> NodeController<T> {
             // A group member has promised a higher epoch — this node is superseded; abandon.
             self.pending_unique_seals.remove(&resp.request_id);
             return;
+        }
+        // Learn any reservation this promoting primary was missing before it is allowed to serve.
+        if !resp.reservations.is_empty()
+            && let Err(e) = self.stores.db_unique.merge_for_seal(&resp.reservations)
+        {
+            tracing::warn!(error = ?e, "failed to merge reservations from seal response");
         }
         let reached = match self.pending_unique_seals.get_mut(&resp.request_id) {
             Some(tracker) => {

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -317,12 +317,18 @@ impl<T: ClusterTransport> NodeController<T> {
             let (result, write) = self
                 .stores
                 .unique_reserve_replicated(&reserve_params, Self::current_time_ms());
-            if let Some(w) = write {
-                self.write_or_forward(w).await;
-                self.sync_unique_write();
-            }
             match result {
-                super::super::db::ReserveResult::Reserved => UniqueReserveStatus::Reserved,
+                super::super::db::ReserveResult::Reserved => {
+                    if let Some(w) = write {
+                        self.sync_unique_write();
+                        // Defer the response until a majority of the group holds the reservation;
+                        // the tracker sends the UniqueReserveResponse when quorum is reached.
+                        self.replicate_unique_reserve_remote(w, from, req.request_id)
+                            .await;
+                        return;
+                    }
+                    UniqueReserveStatus::Reserved
+                }
                 super::super::db::ReserveResult::AlreadyReservedBySameRequest => {
                     UniqueReserveStatus::AlreadyReserved
                 }
@@ -599,11 +605,74 @@ impl<T: ClusterTransport> NodeController<T> {
                     acks,
                     needed,
                     deadline_ms,
-                    responder: tx,
+                    completion: super::UniqueQuorumCompletion::Local(tx),
                 },
             );
         }
         rx
+    }
+
+    /// Replicate a remote-coordinated reserve to the group and, once a **majority** holds it (or the
+    /// deadline passes), send the deferred `UniqueReserveResponse` back to `from`. This makes a
+    /// reserve routed from a non-primary coordinator majority-durable before it is acknowledged.
+    pub(crate) async fn replicate_unique_reserve_remote(
+        &mut self,
+        write: crate::cluster::protocol::ReplicationWrite,
+        from: NodeId,
+        response_request_id: u64,
+    ) {
+        let needed = self.unique_majority();
+        let request_id = self.next_unique_quorum_id();
+
+        self.send_unique_replicate(write, request_id).await;
+
+        let completion = super::UniqueQuorumCompletion::RemoteReserve {
+            from,
+            response_request_id,
+        };
+        let mut acks = std::collections::HashSet::new();
+        acks.insert(self.node_id);
+        if acks.len() >= needed {
+            self.fire_unique_quorum_completion(completion, true).await;
+        } else {
+            let deadline_ms = Self::current_time_ms() + UNIQUE_QUORUM_TIMEOUT_MS;
+            self.pending_unique_quorum.insert(
+                request_id,
+                super::UniqueQuorumTracker {
+                    acks,
+                    needed,
+                    deadline_ms,
+                    completion,
+                },
+            );
+        }
+    }
+
+    async fn fire_unique_quorum_completion(
+        &mut self,
+        completion: super::UniqueQuorumCompletion,
+        success: bool,
+    ) {
+        match completion {
+            super::UniqueQuorumCompletion::Local(tx) => {
+                let _ = tx.send(success);
+            }
+            super::UniqueQuorumCompletion::RemoteReserve {
+                from,
+                response_request_id,
+            } => {
+                let status = if success {
+                    UniqueReserveStatus::Reserved
+                } else {
+                    UniqueReserveStatus::Error
+                };
+                let response = UniqueReserveResponse::create(response_request_id, status);
+                let _ = self
+                    .transport
+                    .send(from, ClusterMessage::UniqueReserveResponse(response))
+                    .await;
+            }
+        }
     }
 
     fn next_unique_quorum_id(&mut self) -> u64 {
@@ -652,21 +721,24 @@ impl<T: ClusterTransport> NodeController<T> {
         }
     }
 
-    /// Record a group member's ack for a tracked reserve; resolve the waiter once a majority
+    /// Record a group member's ack for a tracked reserve; complete it once a majority
     /// (including this node) holds the reservation.
-    pub(crate) fn record_unique_quorum_ack(&mut self, from: NodeId, request_id: u64) {
-        if let Some(tracker) = self.pending_unique_quorum.get_mut(&request_id) {
-            tracker.acks.insert(from);
-            if tracker.acks.len() >= tracker.needed
-                && let Some(tracker) = self.pending_unique_quorum.remove(&request_id)
-            {
-                let _ = tracker.responder.send(true);
+    pub(crate) async fn record_unique_quorum_ack(&mut self, from: NodeId, request_id: u64) {
+        let reached = match self.pending_unique_quorum.get_mut(&request_id) {
+            Some(tracker) => {
+                tracker.acks.insert(from);
+                tracker.acks.len() >= tracker.needed
             }
+            None => false,
+        };
+        if reached && let Some(tracker) = self.pending_unique_quorum.remove(&request_id) {
+            self.fire_unique_quorum_completion(tracker.completion, true)
+                .await;
         }
     }
 
     /// Fail any reserve whose quorum was not reached before its deadline (fail-closed).
-    pub(crate) fn sweep_unique_quorum(&mut self, now_ms: u64) {
+    pub(crate) async fn sweep_unique_quorum(&mut self, now_ms: u64) {
         let expired: Vec<u64> = self
             .pending_unique_quorum
             .iter()
@@ -675,7 +747,8 @@ impl<T: ClusterTransport> NodeController<T> {
             .collect();
         for id in expired {
             if let Some(tracker) = self.pending_unique_quorum.remove(&id) {
-                let _ = tracker.responder.send(false);
+                self.fire_unique_quorum_completion(tracker.completion, false)
+                    .await;
             }
         }
     }

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -47,18 +47,20 @@ pub async fn await_unique_reserves(
     Ok(confirmed)
 }
 
-/// Await majority-durability for every locally reserved unique value. Returns `Err(field)` for the
-/// first reserve that failed to reach a group majority before its deadline (fail-closed).
+/// Await majority-durability for every locally reserved unique value. Returns the fields now
+/// confirmed majority-durable on success, or `Err(field)` for the first reserve that failed to
+/// reach a group majority before its deadline (fail-closed).
 pub async fn await_unique_quorum(
     pending: Vec<(String, oneshot::Receiver<bool>)>,
-) -> Result<(), String> {
+) -> Result<Vec<String>, String> {
+    let mut durable = Vec::with_capacity(pending.len());
     for (field, receiver) in pending {
         match receiver.await {
-            Ok(true) => {}
+            Ok(true) => durable.push(field),
             _ => return Err(field),
         }
     }
-    Ok(())
+    Ok(durable)
 }
 
 impl<T: ClusterTransport> NodeController<T> {
@@ -351,8 +353,18 @@ impl<T: ClusterTransport> NodeController<T> {
                         self.sync_unique_write();
                         // Defer the response until a majority of the group holds the reservation;
                         // the tracker sends the UniqueReserveResponse when quorum is reached.
-                        self.replicate_unique_reserve_remote(w, from, req.request_id)
-                            .await;
+                        self.replicate_unique_reserve_remote(
+                            w,
+                            from,
+                            req.request_id,
+                            super::UniqueClaimId {
+                                entity: entity.to_owned(),
+                                field: field.to_owned(),
+                                value: req.value.clone(),
+                                idempotency_key: idempotency_key.to_owned(),
+                            },
+                        )
+                        .await;
                         return;
                     }
                     UniqueReserveStatus::Reserved
@@ -648,6 +660,7 @@ impl<T: ClusterTransport> NodeController<T> {
         write: crate::cluster::protocol::ReplicationWrite,
         from: NodeId,
         response_request_id: u64,
+        claim: super::UniqueClaimId,
     ) {
         let needed = self.unique_majority();
         let request_id = self.next_unique_quorum_id();
@@ -657,6 +670,7 @@ impl<T: ClusterTransport> NodeController<T> {
         let completion = super::UniqueQuorumCompletion::RemoteReserve {
             from,
             response_request_id,
+            claim,
         };
         let mut acks = std::collections::HashSet::new();
         acks.insert(self.node_id);
@@ -688,10 +702,22 @@ impl<T: ClusterTransport> NodeController<T> {
             super::UniqueQuorumCompletion::RemoteReserve {
                 from,
                 response_request_id,
+                claim,
             } => {
                 let status = if success {
                     UniqueReserveStatus::Reserved
                 } else {
+                    // The reserve never reached a majority: release the local reservation this node
+                    // holds so a transient quorum timeout does not wedge the value until its TTL.
+                    if let Some(w) = self.stores.unique_release_replicated(
+                        &claim.entity,
+                        &claim.field,
+                        &claim.value,
+                        &claim.idempotency_key,
+                    ) {
+                        self.write_or_forward(w).await;
+                        self.sync_unique_write();
+                    }
                     UniqueReserveStatus::Error
                 };
                 let response = UniqueReserveResponse::create(response_request_id, status);

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -92,25 +92,34 @@ impl<T: ClusterTransport> NodeController<T> {
             };
 
             let is_conflict = if primary == Some(self.node_id) {
-                let (result, write) = self
-                    .stores
-                    .unique_reserve_replicated(&reserve_params, now_ms);
+                if !self.unique_partition_sealed(unique_part) {
+                    tracing::warn!(
+                        field,
+                        partition = unique_part.get(),
+                        "unique partition not sealed at the current epoch; failing reserve closed"
+                    );
+                    true
+                } else {
+                    let (result, write) = self
+                        .stores
+                        .unique_reserve_replicated(&reserve_params, now_ms);
 
-                match result {
-                    super::super::db::ReserveResult::Reserved => {
-                        if let Some(w) = write {
-                            self.sync_unique_write();
-                            let rx = self.replicate_unique_reserve(w).await;
-                            pending_quorum.push((field.clone(), rx));
+                    match result {
+                        super::super::db::ReserveResult::Reserved => {
+                            if let Some(w) = write {
+                                self.sync_unique_write();
+                                let rx = self.replicate_unique_reserve(w).await;
+                                pending_quorum.push((field.clone(), rx));
+                            }
+                            local_reserved.push((field.clone(), value));
+                            false
                         }
-                        local_reserved.push((field.clone(), value));
-                        false
+                        super::super::db::ReserveResult::AlreadyReservedBySameRequest => {
+                            local_reserved.push((field.clone(), value));
+                            false
+                        }
+                        super::super::db::ReserveResult::Conflict => true,
                     }
-                    super::super::db::ReserveResult::AlreadyReservedBySameRequest => {
-                        local_reserved.push((field.clone(), value));
-                        false
-                    }
-                    super::super::db::ReserveResult::Conflict => true,
                 }
             } else if let Some(target_node) = primary {
                 let receiver = self
@@ -307,7 +316,15 @@ impl<T: ClusterTransport> NodeController<T> {
         let record_id = req.record_id_str();
         let idempotency_key = req.idempotency_key_str();
 
-        let status = if let Some(data_partition) = req.data_partition() {
+        let unique_part = super::super::db::unique_partition(entity, field, &req.value);
+        let status = if !self.unique_partition_sealed(unique_part) {
+            tracing::warn!(
+                field,
+                partition = unique_part.get(),
+                "unique partition not sealed at the current epoch; rejecting remote reserve"
+            );
+            UniqueReserveStatus::Error
+        } else if let Some(data_partition) = req.data_partition() {
             let reserve_params = super::super::db::UniqueReserveParams {
                 entity,
                 field,
@@ -756,6 +773,33 @@ impl<T: ClusterTransport> NodeController<T> {
         }
     }
 
+    /// Seal a unique partition immediately if this node is its own majority (single-node group),
+    /// else queue a seal round. Called from `become_primary` (stays synchronous).
+    pub(crate) fn seal_or_queue_unique(&mut self, partition: PartitionId, epoch: Epoch) {
+        if self.unique_majority() == 1 {
+            let promised = self
+                .unique_promised
+                .entry(partition.get())
+                .or_insert(Epoch::ZERO);
+            if epoch > *promised {
+                *promised = epoch;
+            }
+            self.mark_unique_sealed(partition, epoch);
+        } else {
+            self.queue_unique_seal(partition, epoch);
+        }
+    }
+
+    /// Whether this node has sealed the partition at its current acting (primary) epoch — the
+    /// precondition for serving reserves (a superseded primary is not sealed at its stale epoch).
+    #[must_use]
+    pub(crate) fn unique_partition_sealed(&self, partition: PartitionId) -> bool {
+        match self.epoch(partition) {
+            Some(epoch) => self.unique_sealed.get(&partition.get()) == Some(&epoch),
+            None => false,
+        }
+    }
+
     /// Queue a promotion seal for a unique partition (deduped; skipped if already sealed ≥ epoch).
     /// Drained by the event-loop tick so `become_primary` stays synchronous.
     pub(crate) fn queue_unique_seal(&mut self, partition: PartitionId, epoch: Epoch) {
@@ -775,33 +819,53 @@ impl<T: ClusterTransport> NodeController<T> {
         }
     }
 
-    /// Initiate any queued promotion seals: promise this node's epoch at a majority of the group
-    /// before it serves reserves for the partition (fences a superseded primary).
+    /// Initiate any queued promotion seals by sending seal requests directly (used by the cluster
+    /// agent's async tick). Promises this node's epoch at a majority before it serves reserves.
     pub(crate) async fn drain_pending_seals(&mut self) {
         let queue = std::mem::take(&mut self.pending_seal_queue);
         for (partition, epoch) in queue {
-            if self
-                .unique_sealed
-                .get(&partition.get())
-                .is_some_and(|&s| s >= epoch)
-            {
-                continue;
+            for (node, msg) in self.prepare_unique_seal(partition, epoch) {
+                let _ = self.transport.send(node, msg).await;
             }
-            if self
-                .pending_unique_seals
-                .values()
-                .any(|t| t.partition == partition && t.epoch >= epoch)
-            {
-                continue;
-            }
-            if self.epoch(partition) != Some(epoch) {
-                continue;
-            }
-            self.initiate_unique_seal(partition, epoch).await;
         }
     }
 
-    async fn initiate_unique_seal(&mut self, partition: PartitionId, epoch: Epoch) {
+    /// Collect seal requests for queued promotions into the tick output (used by the synchronous
+    /// `tick`/`send_tick_output` path).
+    pub(crate) fn collect_pending_seals(&mut self, output: &mut super::TickOutput) {
+        let queue = std::mem::take(&mut self.pending_seal_queue);
+        for (partition, epoch) in queue {
+            output
+                .seal_requests
+                .extend(self.prepare_unique_seal(partition, epoch));
+        }
+    }
+
+    /// Promise this node's epoch for the partition and register a seal tracker; returns the seal
+    /// requests to send to the group (empty if already sealed/in-flight/superseded or self-majority).
+    fn prepare_unique_seal(
+        &mut self,
+        partition: PartitionId,
+        epoch: Epoch,
+    ) -> Vec<(NodeId, ClusterMessage)> {
+        if self
+            .unique_sealed
+            .get(&partition.get())
+            .is_some_and(|&s| s >= epoch)
+        {
+            return Vec::new();
+        }
+        if self
+            .pending_unique_seals
+            .values()
+            .any(|t| t.partition == partition && t.epoch >= epoch)
+        {
+            return Vec::new();
+        }
+        if self.epoch(partition) != Some(epoch) {
+            return Vec::new();
+        }
+
         let promised = self
             .unique_promised
             .entry(partition.get())
@@ -812,13 +876,11 @@ impl<T: ClusterTransport> NodeController<T> {
 
         let needed = self.unique_majority();
         let request_id = self.next_unique_quorum_id();
+        let mut requests = Vec::new();
         for node in self.unique_quorum_group() {
             if node != self.node_id {
                 let req = UniqueSealRequest::create(request_id, partition, epoch.get());
-                let _ = self
-                    .transport
-                    .send(node, ClusterMessage::UniqueSealRequest(req))
-                    .await;
+                requests.push((node, ClusterMessage::UniqueSealRequest(req)));
             }
         }
 
@@ -839,6 +901,7 @@ impl<T: ClusterTransport> NodeController<T> {
                 },
             );
         }
+        requests
     }
 
     pub(crate) async fn handle_unique_seal_request(

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -81,6 +81,7 @@ impl<T: ClusterTransport> NodeController<T> {
                     super::super::db::ReserveResult::Reserved => {
                         if let Some(w) = write {
                             self.write_or_forward(w).await;
+                            self.sync_unique_write();
                         }
                         local_reserved.push((field.clone(), value));
                         false
@@ -220,6 +221,7 @@ impl<T: ClusterTransport> NodeController<T> {
                     .unique_commit_replicated(entity, field, &value, request_id)
                 {
                     self.write_or_forward(w).await;
+                    self.sync_unique_write();
                 }
             } else if let Some(target_node) = primary {
                 self.send_unique_commit_fire_and_forget(
@@ -299,6 +301,7 @@ impl<T: ClusterTransport> NodeController<T> {
                 .unique_reserve_replicated(&reserve_params, Self::current_time_ms());
             if let Some(w) = write {
                 self.write_or_forward(w).await;
+                self.sync_unique_write();
             }
             match result {
                 super::super::db::ReserveResult::Reserved => UniqueReserveStatus::Reserved,
@@ -334,6 +337,7 @@ impl<T: ClusterTransport> NodeController<T> {
             {
                 Ok((_, w)) => {
                     self.write_or_forward(w).await;
+                    self.sync_unique_write();
                     true
                 }
                 Err(super::super::db::UniqueStoreError::AlreadyCommitted) => true,
@@ -372,6 +376,14 @@ impl<T: ClusterTransport> NodeController<T> {
 
     fn allocate_unique_request_id(&self) -> u64 {
         self.pending_constraints.allocate_unique_id()
+    }
+
+    /// Durably fsync a just-written unique reservation/commit so it survives a crash
+    /// before the operation is acknowledged.
+    fn sync_unique_write(&self) {
+        if let Err(e) = self.stores.sync_storage() {
+            tracing::warn!(error = ?e, "failed to sync unique write");
+        }
     }
 
     pub(crate) async fn send_unique_reserve_request_async(

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -468,7 +468,7 @@ impl<T: ClusterTransport> NodeController<T> {
 
     /// Durably fsync a just-written unique reservation/commit so it survives a crash
     /// before the operation is acknowledged.
-    fn sync_unique_write(&self) {
+    pub(crate) fn sync_unique_write(&self) {
         if let Err(e) = self.stores.sync_storage() {
             tracing::warn!(error = ?e, "failed to sync unique write");
         }

--- a/crates/mqdb-cluster/src/cluster/partition_storage.rs
+++ b/crates/mqdb-cluster/src/cluster/partition_storage.rs
@@ -152,6 +152,14 @@ impl PartitionStorage {
         self.backend.flush()
     }
 
+    /// Durably persists pending writes (fsync), independent of the durability mode.
+    ///
+    /// # Errors
+    /// Returns an error if the storage backend fails to sync.
+    pub fn sync(&self) -> Result<()> {
+        self.backend.sync()
+    }
+
     #[must_use]
     pub fn make_key(partition: PartitionId, entity: &str, id: &str) -> Vec<u8> {
         format!("{:02x}/{entity}/{id}", partition.get()).into_bytes()

--- a/crates/mqdb-cluster/src/cluster/protocol/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/mod.rs
@@ -24,5 +24,6 @@ pub use replication::{CatchupRequest, CatchupResponse, ReplicationAck, Replicati
 pub use types::{AckStatus, JsonDbOp, MessageType, Operation, QueryStatus};
 pub use unique::{
     UniqueCommitRequest, UniqueCommitResponse, UniqueReassertRequest, UniqueReleaseRequest,
-    UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse, UniqueReserveStatus,
+    UniqueReleaseResponse, UniqueReplicateAck, UniqueReserveRequest, UniqueReserveResponse,
+    UniqueReserveStatus,
 };

--- a/crates/mqdb-cluster/src/cluster/protocol/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/mod.rs
@@ -25,5 +25,5 @@ pub use types::{AckStatus, JsonDbOp, MessageType, Operation, QueryStatus};
 pub use unique::{
     UniqueCommitRequest, UniqueCommitResponse, UniqueReassertRequest, UniqueReleaseRequest,
     UniqueReleaseResponse, UniqueReplicateAck, UniqueReserveRequest, UniqueReserveResponse,
-    UniqueReserveStatus,
+    UniqueReserveStatus, UniqueSealRequest, UniqueSealResponse,
 };

--- a/crates/mqdb-cluster/src/cluster/protocol/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/mod.rs
@@ -23,6 +23,6 @@ pub use query::{BatchReadRequest, BatchReadResponse, QueryRequest, QueryResponse
 pub use replication::{CatchupRequest, CatchupResponse, ReplicationAck, ReplicationWrite};
 pub use types::{AckStatus, JsonDbOp, MessageType, Operation, QueryStatus};
 pub use unique::{
-    UniqueCommitRequest, UniqueCommitResponse, UniqueReleaseRequest, UniqueReleaseResponse,
-    UniqueReserveRequest, UniqueReserveResponse, UniqueReserveStatus,
+    UniqueCommitRequest, UniqueCommitResponse, UniqueReassertRequest, UniqueReleaseRequest,
+    UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse, UniqueReserveStatus,
 };

--- a/crates/mqdb-cluster/src/cluster/protocol/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/tests.rs
@@ -446,13 +446,14 @@ fn unique_seal_request_roundtrip() {
 
 #[test]
 fn unique_seal_response_roundtrip() {
-    let resp = UniqueSealResponse::create(7, PartitionId::new(9).unwrap(), 3, true);
+    let resp = UniqueSealResponse::create(7, PartitionId::new(9).unwrap(), 3, true, vec![1, 2, 3]);
     let bytes = resp.to_be_bytes();
     let (decoded, _) = UniqueSealResponse::try_from_be_bytes(&bytes).unwrap();
     assert_eq!(decoded.request_id, 7);
     assert_eq!(decoded.partition_id(), PartitionId::new(9));
     assert_eq!(decoded.epoch, 3);
     assert!(decoded.is_accepted());
+    assert_eq!(decoded.reservations, vec![1, 2, 3]);
 }
 
 #[test]

--- a/crates/mqdb-cluster/src/cluster/protocol/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/tests.rs
@@ -435,6 +435,27 @@ fn unique_release_response_roundtrip() {
 }
 
 #[test]
+fn unique_seal_request_roundtrip() {
+    let req = UniqueSealRequest::create(7, PartitionId::new(9).unwrap(), 3);
+    let bytes = req.to_be_bytes();
+    let (decoded, _) = UniqueSealRequest::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(decoded.request_id, 7);
+    assert_eq!(decoded.partition_id(), PartitionId::new(9));
+    assert_eq!(decoded.epoch, 3);
+}
+
+#[test]
+fn unique_seal_response_roundtrip() {
+    let resp = UniqueSealResponse::create(7, PartitionId::new(9).unwrap(), 3, true);
+    let bytes = resp.to_be_bytes();
+    let (decoded, _) = UniqueSealResponse::try_from_be_bytes(&bytes).unwrap();
+    assert_eq!(decoded.request_id, 7);
+    assert_eq!(decoded.partition_id(), PartitionId::new(9));
+    assert_eq!(decoded.epoch, 3);
+    assert!(decoded.is_accepted());
+}
+
+#[test]
 fn unique_reassert_request_roundtrip() {
     let req = UniqueReassertRequest::create(
         555,

--- a/crates/mqdb-cluster/src/cluster/protocol/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/tests.rs
@@ -433,3 +433,25 @@ fn unique_release_response_roundtrip() {
     assert_eq!(decoded.request_id, 777);
     assert!(!decoded.is_success());
 }
+
+#[test]
+fn unique_reassert_request_roundtrip() {
+    let req = UniqueReassertRequest::create(
+        555,
+        "users",
+        "email",
+        b"a@x.com",
+        "u1",
+        PartitionId::new(7).unwrap(),
+    );
+
+    let bytes = req.to_be_bytes();
+    let (decoded, _) = UniqueReassertRequest::try_from_be_bytes(&bytes).unwrap();
+
+    assert_eq!(decoded.request_id, 555);
+    assert_eq!(decoded.entity_str(), "users");
+    assert_eq!(decoded.field_str(), "email");
+    assert_eq!(decoded.value, b"a@x.com");
+    assert_eq!(decoded.record_id_str(), "u1");
+    assert_eq!(decoded.data_partition(), PartitionId::new(7));
+}

--- a/crates/mqdb-cluster/src/cluster/protocol/types.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/types.rs
@@ -28,6 +28,7 @@ pub enum MessageType {
     UniqueCommitResponse = 83,
     UniqueReleaseRequest = 84,
     UniqueReleaseResponse = 85,
+    UniqueReassertRequest = 86,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/mqdb-cluster/src/cluster/protocol/types.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/types.rs
@@ -29,6 +29,7 @@ pub enum MessageType {
     UniqueReleaseRequest = 84,
     UniqueReleaseResponse = 85,
     UniqueReassertRequest = 86,
+    UniqueReplicate = 87,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/mqdb-cluster/src/cluster/protocol/types.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/types.rs
@@ -31,6 +31,8 @@ pub enum MessageType {
     UniqueReassertRequest = 86,
     UniqueReplicate = 87,
     UniqueReplicateAck = 88,
+    UniqueSealRequest = 89,
+    UniqueSealResponse = 94,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/mqdb-cluster/src/cluster/protocol/types.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/types.rs
@@ -32,6 +32,10 @@ pub enum MessageType {
     UniqueReplicate = 87,
     UniqueReplicateAck = 88,
     UniqueSealRequest = 89,
+    FkCheckRequest = 90,
+    FkCheckResponse = 91,
+    FkReverseLookupRequest = 92,
+    FkReverseLookupResponse = 93,
     UniqueSealResponse = 94,
 }
 

--- a/crates/mqdb-cluster/src/cluster/protocol/types.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/types.rs
@@ -30,6 +30,7 @@ pub enum MessageType {
     UniqueReleaseResponse = 85,
     UniqueReassertRequest = 86,
     UniqueReplicate = 87,
+    UniqueReplicateAck = 88,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/mqdb-cluster/src/cluster/protocol/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/unique.rs
@@ -306,3 +306,71 @@ impl UniqueReleaseResponse {
         self.success != 0
     }
 }
+
+#[derive(Debug, Clone, BeBytes)]
+pub struct UniqueReassertRequest {
+    pub version: u8,
+    pub request_id: u64,
+    pub entity_len: u16,
+    #[FromField(entity_len)]
+    pub entity: Vec<u8>,
+    pub field_len: u16,
+    #[FromField(field_len)]
+    pub field: Vec<u8>,
+    pub value_len: u32,
+    #[FromField(value_len)]
+    pub value: Vec<u8>,
+    pub record_id_len: u16,
+    #[FromField(record_id_len)]
+    pub record_id: Vec<u8>,
+    pub data_partition: u16,
+}
+
+impl UniqueReassertRequest {
+    pub const VERSION: u8 = 1;
+
+    #[must_use]
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn create(
+        request_id: u64,
+        entity: &str,
+        field: &str,
+        value: &[u8],
+        record_id: &str,
+        data_partition: PartitionId,
+    ) -> Self {
+        Self {
+            version: Self::VERSION,
+            request_id,
+            entity_len: entity.len() as u16,
+            entity: entity.as_bytes().to_vec(),
+            field_len: field.len() as u16,
+            field: field.as_bytes().to_vec(),
+            value_len: value.len() as u32,
+            value: value.to_vec(),
+            record_id_len: record_id.len() as u16,
+            record_id: record_id.as_bytes().to_vec(),
+            data_partition: data_partition.get(),
+        }
+    }
+
+    #[must_use]
+    pub fn entity_str(&self) -> &str {
+        std::str::from_utf8(&self.entity).unwrap_or("")
+    }
+
+    #[must_use]
+    pub fn field_str(&self) -> &str {
+        std::str::from_utf8(&self.field).unwrap_or("")
+    }
+
+    #[must_use]
+    pub fn record_id_str(&self) -> &str {
+        std::str::from_utf8(&self.record_id).unwrap_or("")
+    }
+
+    #[must_use]
+    pub fn data_partition(&self) -> Option<PartitionId> {
+        PartitionId::new(self.data_partition)
+    }
+}

--- a/crates/mqdb-cluster/src/cluster/protocol/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/unique.rs
@@ -374,3 +374,21 @@ impl UniqueReassertRequest {
         PartitionId::new(self.data_partition)
     }
 }
+
+#[derive(Debug, Clone, BeBytes)]
+pub struct UniqueReplicateAck {
+    pub version: u8,
+    pub request_id: u64,
+}
+
+impl UniqueReplicateAck {
+    pub const VERSION: u8 = 1;
+
+    #[must_use]
+    pub fn create(request_id: u64) -> Self {
+        Self {
+            version: Self::VERSION,
+            request_id,
+        }
+    }
+}

--- a/crates/mqdb-cluster/src/cluster/protocol/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/unique.rs
@@ -427,19 +427,31 @@ pub struct UniqueSealResponse {
     pub partition: u16,
     pub epoch: u64,
     pub accepted: u8,
+    pub reservations_len: u32,
+    #[FromField(reservations_len)]
+    pub reservations: Vec<u8>,
 }
 
 impl UniqueSealResponse {
     pub const VERSION: u8 = 1;
 
     #[must_use]
-    pub fn create(request_id: u64, partition: PartitionId, epoch: u64, accepted: bool) -> Self {
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn create(
+        request_id: u64,
+        partition: PartitionId,
+        epoch: u64,
+        accepted: bool,
+        reservations: Vec<u8>,
+    ) -> Self {
         Self {
             version: Self::VERSION,
             request_id,
             partition: partition.get(),
             epoch,
             accepted: u8::from(accepted),
+            reservations_len: reservations.len() as u32,
+            reservations,
         }
     }
 

--- a/crates/mqdb-cluster/src/cluster/protocol/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/unique.rs
@@ -392,3 +392,64 @@ impl UniqueReplicateAck {
         }
     }
 }
+
+#[derive(Debug, Clone, BeBytes)]
+pub struct UniqueSealRequest {
+    pub version: u8,
+    pub request_id: u64,
+    pub partition: u16,
+    pub epoch: u64,
+}
+
+impl UniqueSealRequest {
+    pub const VERSION: u8 = 1;
+
+    #[must_use]
+    pub fn create(request_id: u64, partition: PartitionId, epoch: u64) -> Self {
+        Self {
+            version: Self::VERSION,
+            request_id,
+            partition: partition.get(),
+            epoch,
+        }
+    }
+
+    #[must_use]
+    pub fn partition_id(&self) -> Option<PartitionId> {
+        PartitionId::new(self.partition)
+    }
+}
+
+#[derive(Debug, Clone, BeBytes)]
+pub struct UniqueSealResponse {
+    pub version: u8,
+    pub request_id: u64,
+    pub partition: u16,
+    pub epoch: u64,
+    pub accepted: u8,
+}
+
+impl UniqueSealResponse {
+    pub const VERSION: u8 = 1;
+
+    #[must_use]
+    pub fn create(request_id: u64, partition: PartitionId, epoch: u64, accepted: bool) -> Self {
+        Self {
+            version: Self::VERSION,
+            request_id,
+            partition: partition.get(),
+            epoch,
+            accepted: u8::from(accepted),
+        }
+    }
+
+    #[must_use]
+    pub fn is_accepted(&self) -> bool {
+        self.accepted != 0
+    }
+
+    #[must_use]
+    pub fn partition_id(&self) -> Option<PartitionId> {
+        PartitionId::new(self.partition)
+    }
+}

--- a/crates/mqdb-cluster/src/cluster/store_manager/apply.rs
+++ b/crates/mqdb-cluster/src/cluster/store_manager/apply.rs
@@ -6,6 +6,19 @@ use crate::cluster::entity;
 use crate::cluster::protocol::ReplicationWrite;
 
 impl StoreManager {
+    /// Durably persists pending writes (fsync), independent of the durability mode.
+    ///
+    /// # Errors
+    /// Returns `StoreApplyError::PersistenceError` if the sync fails.
+    pub fn sync_storage(&self) -> Result<(), StoreApplyError> {
+        if let Some(storage) = &self.storage {
+            storage
+                .sync()
+                .map_err(|_| StoreApplyError::PersistenceError)?;
+        }
+        Ok(())
+    }
+
     /// # Errors
     /// Returns `StoreApplyError::PersistenceError` if the batch write to storage fails.
     pub fn persist_writes_batch(&self, writes: &[ReplicationWrite]) -> Result<(), StoreApplyError> {

--- a/crates/mqdb-cluster/src/cluster/store_manager/unique_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/store_manager/unique_ops.rs
@@ -3,12 +3,52 @@
 
 use super::StoreManager;
 use crate::cluster::db::{
-    ReserveResult, UniqueReservation, UniqueReserveParams, UniqueStore, unique_partition,
+    ReassertResult, ReserveResult, UniqueReservation, UniqueReserveParams, UniqueStore,
+    unique_partition,
 };
 use crate::cluster::protocol::{Operation, ReplicationWrite};
-use crate::cluster::{Epoch, entity};
+use crate::cluster::{Epoch, PartitionId, entity};
 
 impl StoreManager {
+    /// Reconcile a durable record against its unique claim (record-driven repair). On a
+    /// state change (`Established`/`Repaired`), returns the write to persist + replicate.
+    #[must_use]
+    pub fn reassert_replicated(
+        &self,
+        entity: &str,
+        field: &str,
+        value: &[u8],
+        record_id: &str,
+        data_partition: PartitionId,
+        now: u64,
+    ) -> (ReassertResult, Option<ReplicationWrite>) {
+        let result = self
+            .db_unique
+            .reassert(entity, field, value, record_id, data_partition, now);
+        match result {
+            ReassertResult::Established | ReassertResult::Repaired => {
+                if let Some(r) = self.db_unique.get(entity, field, value) {
+                    let serialized = UniqueStore::serialize(&r);
+                    let partition = unique_partition(entity, field, value);
+                    let key = super::super::db::unique_key(&r);
+                    let write = ReplicationWrite::new(
+                        partition,
+                        Operation::Update,
+                        Epoch::ZERO,
+                        0,
+                        entity::DB_UNIQUE.to_string(),
+                        key,
+                        serialized,
+                    );
+                    (result, Some(write))
+                } else {
+                    (result, None)
+                }
+            }
+            _ => (result, None),
+        }
+    }
+
     #[must_use]
     pub fn unique_reserve_replicated(
         &self,

--- a/crates/mqdb-cluster/src/cluster/transport.rs
+++ b/crates/mqdb-cluster/src/cluster/transport.rs
@@ -62,6 +62,7 @@ pub enum ClusterMessage {
     UniqueReleaseRequest(UniqueReleaseRequest),
     UniqueReleaseResponse(UniqueReleaseResponse),
     UniqueReassertRequest(UniqueReassertRequest),
+    UniqueReplicate(ReplicationWrite),
     FkCheckRequest(FkCheckRequest),
     FkCheckResponse(FkCheckResponse),
     FkReverseLookupRequest(FkReverseLookupRequest),
@@ -104,6 +105,7 @@ impl ClusterMessage {
             Self::UniqueReleaseRequest(_) => 84,
             Self::UniqueReleaseResponse(_) => 85,
             Self::UniqueReassertRequest(_) => 86,
+            Self::UniqueReplicate(_) => 87,
             Self::FkCheckRequest(_) => 90,
             Self::FkCheckResponse(_) => 91,
             Self::FkReverseLookupRequest(_) => 92,
@@ -146,6 +148,7 @@ impl ClusterMessage {
             Self::UniqueReleaseRequest(_) => "UniqueReleaseRequest",
             Self::UniqueReleaseResponse(_) => "UniqueReleaseResponse",
             Self::UniqueReassertRequest(_) => "UniqueReassertRequest",
+            Self::UniqueReplicate(_) => "UniqueReplicate",
             Self::FkCheckRequest(_) => "FkCheckRequest",
             Self::FkCheckResponse(_) => "FkCheckResponse",
             Self::FkReverseLookupRequest(_) => "FkReverseLookupRequest",
@@ -194,6 +197,7 @@ impl ClusterMessage {
             Self::UniqueReleaseRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
             Self::UniqueReleaseResponse(resp) => buf.extend_from_slice(&resp.to_be_bytes()),
             Self::UniqueReassertRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
+            Self::UniqueReplicate(w) => buf.extend_from_slice(&w.to_bytes()),
             Self::FkCheckRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
             Self::FkCheckResponse(resp) => buf.extend_from_slice(&resp.to_be_bytes()),
             Self::FkReverseLookupRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
@@ -305,6 +309,7 @@ impl ClusterMessage {
                 let (req, _) = UniqueReassertRequest::try_from_be_bytes(data).ok()?;
                 Some(Self::UniqueReassertRequest(req))
             }
+            87 => Some(Self::UniqueReplicate(ReplicationWrite::from_bytes(data)?)),
             90 => {
                 let (req, _) = FkCheckRequest::try_from_be_bytes(data).ok()?;
                 if req.version != FkCheckRequest::VERSION {

--- a/crates/mqdb-cluster/src/cluster/transport.rs
+++ b/crates/mqdb-cluster/src/cluster/transport.rs
@@ -6,8 +6,8 @@ use super::protocol::{
     FkCheckResponse, FkReverseLookupRequest, FkReverseLookupResponse, ForwardedPublish, Heartbeat,
     JsonDbRequest, JsonDbResponse, QueryRequest, QueryResponse, ReplicationAck, ReplicationWrite,
     TopicSubscriptionBroadcast, UniqueCommitRequest, UniqueCommitResponse, UniqueReassertRequest,
-    UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse,
-    WildcardBroadcast,
+    UniqueReleaseRequest, UniqueReleaseResponse, UniqueReplicateAck, UniqueReserveRequest,
+    UniqueReserveResponse, WildcardBroadcast,
 };
 use super::raft::{
     AppendEntriesRequest, AppendEntriesResponse, PartitionUpdate, RequestVoteRequest,
@@ -62,7 +62,11 @@ pub enum ClusterMessage {
     UniqueReleaseRequest(UniqueReleaseRequest),
     UniqueReleaseResponse(UniqueReleaseResponse),
     UniqueReassertRequest(UniqueReassertRequest),
-    UniqueReplicate(ReplicationWrite),
+    UniqueReplicate {
+        request_id: u64,
+        write: ReplicationWrite,
+    },
+    UniqueReplicateAck(UniqueReplicateAck),
     FkCheckRequest(FkCheckRequest),
     FkCheckResponse(FkCheckResponse),
     FkReverseLookupRequest(FkReverseLookupRequest),
@@ -105,7 +109,8 @@ impl ClusterMessage {
             Self::UniqueReleaseRequest(_) => 84,
             Self::UniqueReleaseResponse(_) => 85,
             Self::UniqueReassertRequest(_) => 86,
-            Self::UniqueReplicate(_) => 87,
+            Self::UniqueReplicate { .. } => 87,
+            Self::UniqueReplicateAck(_) => 88,
             Self::FkCheckRequest(_) => 90,
             Self::FkCheckResponse(_) => 91,
             Self::FkReverseLookupRequest(_) => 92,
@@ -148,7 +153,8 @@ impl ClusterMessage {
             Self::UniqueReleaseRequest(_) => "UniqueReleaseRequest",
             Self::UniqueReleaseResponse(_) => "UniqueReleaseResponse",
             Self::UniqueReassertRequest(_) => "UniqueReassertRequest",
-            Self::UniqueReplicate(_) => "UniqueReplicate",
+            Self::UniqueReplicate { .. } => "UniqueReplicate",
+            Self::UniqueReplicateAck(_) => "UniqueReplicateAck",
             Self::FkCheckRequest(_) => "FkCheckRequest",
             Self::FkCheckResponse(_) => "FkCheckResponse",
             Self::FkReverseLookupRequest(_) => "FkReverseLookupRequest",
@@ -197,7 +203,11 @@ impl ClusterMessage {
             Self::UniqueReleaseRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
             Self::UniqueReleaseResponse(resp) => buf.extend_from_slice(&resp.to_be_bytes()),
             Self::UniqueReassertRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
-            Self::UniqueReplicate(w) => buf.extend_from_slice(&w.to_bytes()),
+            Self::UniqueReplicate { request_id, write } => {
+                buf.extend_from_slice(&request_id.to_be_bytes());
+                buf.extend_from_slice(&write.to_bytes());
+            }
+            Self::UniqueReplicateAck(ack) => buf.extend_from_slice(&ack.to_be_bytes()),
             Self::FkCheckRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
             Self::FkCheckResponse(resp) => buf.extend_from_slice(&resp.to_be_bytes()),
             Self::FkReverseLookupRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
@@ -309,7 +319,18 @@ impl ClusterMessage {
                 let (req, _) = UniqueReassertRequest::try_from_be_bytes(data).ok()?;
                 Some(Self::UniqueReassertRequest(req))
             }
-            87 => Some(Self::UniqueReplicate(ReplicationWrite::from_bytes(data)?)),
+            87 => {
+                if data.len() < 8 {
+                    return None;
+                }
+                let request_id = u64::from_be_bytes(data[..8].try_into().ok()?);
+                let write = ReplicationWrite::from_bytes(&data[8..])?;
+                Some(Self::UniqueReplicate { request_id, write })
+            }
+            88 => {
+                let (ack, _) = UniqueReplicateAck::try_from_be_bytes(data).ok()?;
+                Some(Self::UniqueReplicateAck(ack))
+            }
             90 => {
                 let (req, _) = FkCheckRequest::try_from_be_bytes(data).ok()?;
                 if req.version != FkCheckRequest::VERSION {

--- a/crates/mqdb-cluster/src/cluster/transport.rs
+++ b/crates/mqdb-cluster/src/cluster/transport.rs
@@ -5,8 +5,9 @@ use super::protocol::{
     BatchReadRequest, BatchReadResponse, CatchupRequest, CatchupResponse, FkCheckRequest,
     FkCheckResponse, FkReverseLookupRequest, FkReverseLookupResponse, ForwardedPublish, Heartbeat,
     JsonDbRequest, JsonDbResponse, QueryRequest, QueryResponse, ReplicationAck, ReplicationWrite,
-    TopicSubscriptionBroadcast, UniqueCommitRequest, UniqueCommitResponse, UniqueReleaseRequest,
-    UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse, WildcardBroadcast,
+    TopicSubscriptionBroadcast, UniqueCommitRequest, UniqueCommitResponse, UniqueReassertRequest,
+    UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse,
+    WildcardBroadcast,
 };
 use super::raft::{
     AppendEntriesRequest, AppendEntriesResponse, PartitionUpdate, RequestVoteRequest,
@@ -60,6 +61,7 @@ pub enum ClusterMessage {
     UniqueCommitResponse(UniqueCommitResponse),
     UniqueReleaseRequest(UniqueReleaseRequest),
     UniqueReleaseResponse(UniqueReleaseResponse),
+    UniqueReassertRequest(UniqueReassertRequest),
     FkCheckRequest(FkCheckRequest),
     FkCheckResponse(FkCheckResponse),
     FkReverseLookupRequest(FkReverseLookupRequest),
@@ -101,6 +103,7 @@ impl ClusterMessage {
             Self::UniqueCommitResponse(_) => 83,
             Self::UniqueReleaseRequest(_) => 84,
             Self::UniqueReleaseResponse(_) => 85,
+            Self::UniqueReassertRequest(_) => 86,
             Self::FkCheckRequest(_) => 90,
             Self::FkCheckResponse(_) => 91,
             Self::FkReverseLookupRequest(_) => 92,
@@ -142,6 +145,7 @@ impl ClusterMessage {
             Self::UniqueCommitResponse(_) => "UniqueCommitResponse",
             Self::UniqueReleaseRequest(_) => "UniqueReleaseRequest",
             Self::UniqueReleaseResponse(_) => "UniqueReleaseResponse",
+            Self::UniqueReassertRequest(_) => "UniqueReassertRequest",
             Self::FkCheckRequest(_) => "FkCheckRequest",
             Self::FkCheckResponse(_) => "FkCheckResponse",
             Self::FkReverseLookupRequest(_) => "FkReverseLookupRequest",
@@ -189,6 +193,7 @@ impl ClusterMessage {
             Self::UniqueCommitResponse(resp) => buf.extend_from_slice(&resp.to_be_bytes()),
             Self::UniqueReleaseRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
             Self::UniqueReleaseResponse(resp) => buf.extend_from_slice(&resp.to_be_bytes()),
+            Self::UniqueReassertRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
             Self::FkCheckRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
             Self::FkCheckResponse(resp) => buf.extend_from_slice(&resp.to_be_bytes()),
             Self::FkReverseLookupRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
@@ -295,6 +300,10 @@ impl ClusterMessage {
             85 => {
                 let (resp, _) = UniqueReleaseResponse::try_from_be_bytes(data).ok()?;
                 Some(Self::UniqueReleaseResponse(resp))
+            }
+            86 => {
+                let (req, _) = UniqueReassertRequest::try_from_be_bytes(data).ok()?;
+                Some(Self::UniqueReassertRequest(req))
             }
             90 => {
                 let (req, _) = FkCheckRequest::try_from_be_bytes(data).ok()?;

--- a/crates/mqdb-cluster/src/cluster/transport.rs
+++ b/crates/mqdb-cluster/src/cluster/transport.rs
@@ -7,7 +7,7 @@ use super::protocol::{
     JsonDbRequest, JsonDbResponse, QueryRequest, QueryResponse, ReplicationAck, ReplicationWrite,
     TopicSubscriptionBroadcast, UniqueCommitRequest, UniqueCommitResponse, UniqueReassertRequest,
     UniqueReleaseRequest, UniqueReleaseResponse, UniqueReplicateAck, UniqueReserveRequest,
-    UniqueReserveResponse, WildcardBroadcast,
+    UniqueReserveResponse, UniqueSealRequest, UniqueSealResponse, WildcardBroadcast,
 };
 use super::raft::{
     AppendEntriesRequest, AppendEntriesResponse, PartitionUpdate, RequestVoteRequest,
@@ -67,6 +67,8 @@ pub enum ClusterMessage {
         write: ReplicationWrite,
     },
     UniqueReplicateAck(UniqueReplicateAck),
+    UniqueSealRequest(UniqueSealRequest),
+    UniqueSealResponse(UniqueSealResponse),
     FkCheckRequest(FkCheckRequest),
     FkCheckResponse(FkCheckResponse),
     FkReverseLookupRequest(FkReverseLookupRequest),
@@ -111,6 +113,8 @@ impl ClusterMessage {
             Self::UniqueReassertRequest(_) => 86,
             Self::UniqueReplicate { .. } => 87,
             Self::UniqueReplicateAck(_) => 88,
+            Self::UniqueSealRequest(_) => 89,
+            Self::UniqueSealResponse(_) => 94,
             Self::FkCheckRequest(_) => 90,
             Self::FkCheckResponse(_) => 91,
             Self::FkReverseLookupRequest(_) => 92,
@@ -155,6 +159,8 @@ impl ClusterMessage {
             Self::UniqueReassertRequest(_) => "UniqueReassertRequest",
             Self::UniqueReplicate { .. } => "UniqueReplicate",
             Self::UniqueReplicateAck(_) => "UniqueReplicateAck",
+            Self::UniqueSealRequest(_) => "UniqueSealRequest",
+            Self::UniqueSealResponse(_) => "UniqueSealResponse",
             Self::FkCheckRequest(_) => "FkCheckRequest",
             Self::FkCheckResponse(_) => "FkCheckResponse",
             Self::FkReverseLookupRequest(_) => "FkReverseLookupRequest",
@@ -208,6 +214,8 @@ impl ClusterMessage {
                 buf.extend_from_slice(&write.to_bytes());
             }
             Self::UniqueReplicateAck(ack) => buf.extend_from_slice(&ack.to_be_bytes()),
+            Self::UniqueSealRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
+            Self::UniqueSealResponse(resp) => buf.extend_from_slice(&resp.to_be_bytes()),
             Self::FkCheckRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
             Self::FkCheckResponse(resp) => buf.extend_from_slice(&resp.to_be_bytes()),
             Self::FkReverseLookupRequest(req) => buf.extend_from_slice(&req.to_be_bytes()),
@@ -330,6 +338,14 @@ impl ClusterMessage {
             88 => {
                 let (ack, _) = UniqueReplicateAck::try_from_be_bytes(data).ok()?;
                 Some(Self::UniqueReplicateAck(ack))
+            }
+            89 => {
+                let (req, _) = UniqueSealRequest::try_from_be_bytes(data).ok()?;
+                Some(Self::UniqueSealRequest(req))
+            }
+            94 => {
+                let (resp, _) = UniqueSealResponse::try_from_be_bytes(data).ok()?;
+                Some(Self::UniqueSealResponse(resp))
             }
             90 => {
                 let (req, _) = FkCheckRequest::try_from_be_bytes(data).ok()?;

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -243,6 +243,8 @@ impl ClusteredAgent {
         ctrl.transport().log_queue_stats();
         ctrl.pending_constraints().sweep_closed();
         ctrl.sweep_unique_quorum(now).await;
+        ctrl.sweep_unique_seals(now);
+        ctrl.drain_pending_seals().await;
     }
 
     async fn handle_processing_batch(&self, batch: ProcessingBatch) {

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -14,7 +14,7 @@ use tracing::{debug, info, warn};
 
 use super::{
     CLEANUP_INTERVAL_SECS, RETAINED_SYNC_CLEANUP_INTERVAL_SECS, RETAINED_SYNC_TTL_SECS,
-    TTL_CLEANUP_INTERVAL_SECS,
+    TTL_CLEANUP_INTERVAL_SECS, UNIQUE_RECONCILE_INTERVAL_SECS,
 };
 
 impl ClusteredAgent {
@@ -85,6 +85,10 @@ impl ClusteredAgent {
             Duration::from_secs(30),
         );
         let mut license_check_interval = interval(Duration::from_hours(1));
+        let mut unique_reconcile_interval = tokio::time::interval_at(
+            tokio::time::Instant::now() + Duration::from_secs(UNIQUE_RECONCILE_INTERVAL_SECS),
+            Duration::from_secs(UNIQUE_RECONCILE_INTERVAL_SECS),
+        );
         let mut shutdown_rx = self.shutdown_tx.subscribe();
         let tx_tick = self
             .tx_tick
@@ -152,6 +156,9 @@ impl ClusteredAgent {
                 }
                 _ = license_check_interval.tick() => {
                     self.handle_license_check();
+                }
+                _ = unique_reconcile_interval.tick() => {
+                    self.handle_unique_reconcile().await;
                 }
                 _ = shutdown_rx.recv() => {
                     info!("cluster node shutting down");
@@ -473,10 +480,6 @@ impl ClusteredAgent {
             if stale_offsets > 0 {
                 info!(stale_offsets, "cleaned up stale consumer offsets");
             }
-            let expired_unique = ctrl.stores().unique_cleanup_expired(now);
-            if expired_unique > 0 {
-                info!(expired_unique, "cleaned up expired unique reservations");
-            }
             ctrl.stores().cleanup_expired_sessions(now)
         };
         if !expired_sessions.is_empty() {
@@ -489,6 +492,16 @@ impl ClusteredAgent {
                 let client_id = session.client_id_str();
                 clear_expired_session_subscriptions(&mut ctrl, client_id).await;
             }
+        }
+    }
+
+    async fn handle_unique_reconcile(&self) {
+        let mut ctrl = self.controller.write().await;
+        ctrl.reconcile_unique_claims().await;
+        let now = current_time_ms();
+        let expired_unique = ctrl.stores().unique_cleanup_expired(now);
+        if expired_unique > 0 {
+            info!(expired_unique, "reclaimed abandoned unique reservations");
         }
     }
 

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -404,11 +404,16 @@ impl ClusteredAgent {
         let continuation = pending.continuation;
         tokio::spawn(async move {
             use crate::cluster::node_controller::ReserveFailure;
-            let remote_results = match (
-                await_unique_reserves(pending_remote).await,
-                await_unique_quorum(pending_quorum).await,
+            // Await the remote-reserve and local-quorum rounds concurrently so a create waits the
+            // max of the two ~5s deadlines, not their sum.
+            let remote_results = match tokio::join!(
+                await_unique_reserves(pending_remote),
+                await_unique_quorum(pending_quorum),
             ) {
-                (Ok(confirmed), Ok(())) => Ok(confirmed),
+                (Ok(confirmed), Ok(durable)) => {
+                    tracing::debug!(?durable, "unique reserve is majority-durable");
+                    Ok(confirmed)
+                }
                 (Ok(confirmed), Err(field)) => Err((ReserveFailure::NotDurable(field), confirmed)),
                 (Err(e), _) => Err(e),
             };

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -427,14 +427,21 @@ impl ClusteredAgent {
         let pending_checks = pending.pending_checks;
         let continuation = pending.continuation;
         tokio::spawn(async move {
+            use crate::cluster::node_controller::FkThenUniqueOutcome;
             let fk_result = await_fk_checks(pending_checks).await;
-            let mut ctrl = controller.write().await;
-            let (fk_ok, fk_error) = match fk_result {
-                Ok(()) => (true, None),
-                Err(msg) => (false, Some(msg)),
+            let outcome = {
+                let mut ctrl = controller.write().await;
+                let (fk_ok, fk_error) = match fk_result {
+                    Ok(()) => (true, None),
+                    Err(msg) => (false, Some(msg)),
+                };
+                ctrl.complete_pending_fk_work(fk_ok, fk_error, continuation)
+                    .await
+                // controller write lock is released here, before the majority-await below.
             };
-            ctrl.complete_pending_fk_work(fk_ok, fk_error, continuation)
-                .await;
+            if let FkThenUniqueOutcome::NeedUnique(pending) = outcome {
+                Self::spawn_unique_completion(controller, *pending);
+            }
         });
     }
 

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -396,13 +396,21 @@ impl ClusteredAgent {
         controller: Arc<tokio::sync::RwLock<NodeController<super::ClusterTransportKind>>>,
         pending: crate::cluster::node_controller::PendingUniqueWork,
     ) {
-        use crate::cluster::node_controller::unique::await_unique_reserves;
+        use crate::cluster::node_controller::unique::{await_unique_quorum, await_unique_reserves};
 
         let local_reserved = pending.phase1.local_reserved;
         let pending_remote = pending.phase1.pending_remote;
+        let pending_quorum = pending.phase1.pending_quorum;
         let continuation = pending.continuation;
         tokio::spawn(async move {
-            let remote_results = await_unique_reserves(pending_remote).await;
+            let remote_results = match (
+                await_unique_reserves(pending_remote).await,
+                await_unique_quorum(pending_quorum).await,
+            ) {
+                (Ok(confirmed), Ok(())) => Ok(confirmed),
+                (Ok(confirmed), Err(field)) => Err((field, confirmed)),
+                (Err(e), _) => Err(e),
+            };
             let mut ctrl = controller.write().await;
             ctrl.complete_pending_unique_work(local_reserved, remote_results, continuation)
                 .await;

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -242,6 +242,7 @@ impl ClusteredAgent {
         }
         ctrl.transport().log_queue_stats();
         ctrl.pending_constraints().sweep_closed();
+        ctrl.sweep_unique_quorum(now);
     }
 
     async fn handle_processing_batch(&self, batch: ProcessingBatch) {

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -403,12 +403,13 @@ impl ClusteredAgent {
         let pending_quorum = pending.phase1.pending_quorum;
         let continuation = pending.continuation;
         tokio::spawn(async move {
+            use crate::cluster::node_controller::ReserveFailure;
             let remote_results = match (
                 await_unique_reserves(pending_remote).await,
                 await_unique_quorum(pending_quorum).await,
             ) {
                 (Ok(confirmed), Ok(())) => Ok(confirmed),
-                (Ok(confirmed), Err(field)) => Err((field, confirmed)),
+                (Ok(confirmed), Err(field)) => Err((ReserveFailure::NotDurable(field), confirmed)),
                 (Err(e), _) => Err(e),
             };
             let mut ctrl = controller.write().await;

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -242,7 +242,7 @@ impl ClusteredAgent {
         }
         ctrl.transport().log_queue_stats();
         ctrl.pending_constraints().sweep_closed();
-        ctrl.sweep_unique_quorum(now);
+        ctrl.sweep_unique_quorum(now).await;
     }
 
     async fn handle_processing_batch(&self, batch: ProcessingBatch) {

--- a/crates/mqdb-cluster/src/cluster_agent/mod.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/mod.rs
@@ -25,6 +25,7 @@ use tokio::sync::{RwLock, broadcast, watch};
 
 const CLEANUP_INTERVAL_SECS: u64 = 3600;
 const TTL_CLEANUP_INTERVAL_SECS: u64 = 60;
+const UNIQUE_RECONCILE_INTERVAL_SECS: u64 = 10;
 const RETAINED_SYNC_CLEANUP_INTERVAL_SECS: u64 = 30;
 const RETAINED_SYNC_TTL_SECS: u64 = 5;
 

--- a/crates/mqdb-cluster/tests/cluster_integration_test.rs
+++ b/crates/mqdb-cluster/tests/cluster_integration_test.rs
@@ -3877,6 +3877,91 @@ fn json_value_bytes(value: &str) -> Vec<u8> {
 }
 
 #[tokio::test]
+async fn unique_seal_fences_superseded_primary_reserve() {
+    use mqdb_cluster::cluster::db::{ReserveResult, UniqueReserveParams};
+    use mqdb_cluster::cluster::{ClusterMessage, InboundMessage, UniqueSealRequest};
+
+    let mut cluster = TestCluster::new(3);
+    cluster.setup_all_primaries().await;
+
+    let value = b"sku-seal".as_slice();
+    let unique_part = mqdb_cluster::cluster::db::unique_partition("products", "sku", value);
+    let node0_id = cluster.nodes[0].id;
+
+    // A newly promoted primary seals the partition at epoch 2 by promising it at the group: each
+    // member records the promise on receiving the seal request.
+    for i in 1..cluster.nodes.len() {
+        cluster.nodes[i]
+            .controller
+            .transport()
+            .requeue(InboundMessage {
+                from: node0_id,
+                message: ClusterMessage::UniqueSealRequest(UniqueSealRequest::create(
+                    1,
+                    unique_part,
+                    2,
+                )),
+                received_at: 0,
+            });
+        cluster.advance_ms(1);
+        cluster.nodes[i].controller.process_messages().await;
+    }
+
+    // The superseded epoch-1 primary tries to replicate a reservation to the group; sealed members
+    // must reject it (epoch below their promise).
+    let params = UniqueReserveParams {
+        entity: "products",
+        field: "sku",
+        value,
+        record_id: "old",
+        request_id: "req-old",
+        data_partition: PartitionId::new(5).unwrap(),
+        ttl_ms: 30_000,
+    };
+    let (result, write) = cluster.nodes[0]
+        .controller
+        .stores()
+        .unique_reserve_replicated(&params, 1000);
+    assert_eq!(result, ReserveResult::Reserved);
+    let write = write.unwrap();
+    let stale = ReplicationWrite::new(
+        write.partition,
+        write.operation,
+        Epoch::new(1),
+        0,
+        write.entity.clone(),
+        write.id.clone(),
+        write.data.clone(),
+    );
+
+    for i in 1..cluster.nodes.len() {
+        cluster.nodes[i]
+            .controller
+            .transport()
+            .requeue(InboundMessage {
+                from: node0_id,
+                message: ClusterMessage::UniqueReplicate {
+                    request_id: 0,
+                    write: stale.clone(),
+                },
+                received_at: 0,
+            });
+        cluster.advance_ms(1);
+        cluster.nodes[i].controller.process_messages().await;
+    }
+
+    for node in &cluster.nodes[1..] {
+        assert!(
+            node.controller
+                .stores()
+                .unique_get("products", "sku", value)
+                .is_none(),
+            "a sealed member must reject the superseded primary's stale-epoch reservation"
+        );
+    }
+}
+
+#[tokio::test]
 async fn unique_reconcile_reestablishes_lost_reservation() {
     use mqdb_cluster::cluster::db::ClusterConstraint;
 

--- a/crates/mqdb-cluster/tests/cluster_integration_test.rs
+++ b/crates/mqdb-cluster/tests/cluster_integration_test.rs
@@ -4080,3 +4080,114 @@ async fn unique_reassert_request_cross_node_establishes() {
     assert!(claim.is_committed());
     assert_eq!(claim.record_id_str(), "product-9");
 }
+
+#[tokio::test]
+async fn unique_write_replicates_to_quorum_group() {
+    use mqdb_cluster::cluster::db::{ReserveResult, UniqueReserveParams};
+
+    let mut cluster = TestCluster::new(3);
+    cluster.setup_all_primaries().await;
+
+    let value = b"gadget".as_slice();
+    let params = UniqueReserveParams {
+        entity: "products",
+        field: "sku",
+        value,
+        record_id: "g1",
+        request_id: "req-g",
+        data_partition: PartitionId::new(7).unwrap(),
+        ttl_ms: 30_000,
+    };
+    let (result, write) = cluster.nodes[0]
+        .controller
+        .stores()
+        .unique_reserve_replicated(&params, 1000);
+    assert_eq!(result, ReserveResult::Reserved);
+
+    cluster.nodes[0]
+        .controller
+        .write_or_forward(write.unwrap())
+        .await;
+    cluster.advance_ms(5);
+    for node in cluster.nodes.iter_mut().skip(1) {
+        node.controller.process_messages().await;
+    }
+
+    for node in &cluster.nodes[1..] {
+        let claim = node
+            .controller
+            .stores()
+            .unique_get("products", "sku", value)
+            .expect("every quorum-group member should hold the replicated reservation");
+        assert_eq!(claim.record_id_str(), "g1");
+    }
+}
+
+#[tokio::test]
+async fn unique_replicate_fences_stale_epoch() {
+    use mqdb_cluster::cluster::db::{ReserveResult, UniqueReserveParams};
+    use mqdb_cluster::cluster::{ClusterMessage, InboundMessage};
+
+    let mut cluster = TestCluster::new(3);
+    cluster.setup_all_primaries().await;
+
+    let value = b"widget".as_slice();
+    let params = UniqueReserveParams {
+        entity: "products",
+        field: "sku",
+        value,
+        record_id: "p1",
+        request_id: "req-1",
+        data_partition: PartitionId::new(5).unwrap(),
+        ttl_ms: 30_000,
+    };
+    let (result, insert_write) = cluster.nodes[0]
+        .controller
+        .stores()
+        .unique_reserve_replicated(&params, 1000);
+    assert_eq!(result, ReserveResult::Reserved);
+    let insert_write = insert_write.unwrap();
+    let delete_write = cluster.nodes[0]
+        .controller
+        .stores()
+        .unique_release_replicated("products", "sku", value, "req-1")
+        .unwrap();
+
+    let at_epoch = |w: &ReplicationWrite, e: u64| {
+        ReplicationWrite::new(
+            w.partition,
+            w.operation,
+            Epoch::new(e),
+            0,
+            w.entity.clone(),
+            w.id.clone(),
+            w.data.clone(),
+        )
+    };
+
+    let node0_id = cluster.nodes[0].id;
+    for msg in [
+        ClusterMessage::UniqueReplicate(at_epoch(&insert_write, 2)),
+        ClusterMessage::UniqueReplicate(at_epoch(&delete_write, 1)),
+    ] {
+        cluster.nodes[2]
+            .controller
+            .transport()
+            .requeue(InboundMessage {
+                from: node0_id,
+                message: msg,
+                received_at: 0,
+            });
+        cluster.advance_ms(1);
+        cluster.nodes[2].controller.process_messages().await;
+    }
+
+    assert!(
+        cluster.nodes[2]
+            .controller
+            .stores()
+            .unique_get("products", "sku", value)
+            .is_some(),
+        "a stale-epoch release must be fenced out, leaving the epoch-2 reservation intact"
+    );
+}

--- a/crates/mqdb-cluster/tests/cluster_integration_test.rs
+++ b/crates/mqdb-cluster/tests/cluster_integration_test.rs
@@ -3841,7 +3841,16 @@ async fn unique_constraint_cross_node_message_flow() {
         message: ClusterMessage::UniqueReserveRequest(request),
         received_at: 0,
     };
+    // Node 1 (value primary) applies the reserve and group-replicates it, deferring its response.
     cluster.nodes[0].controller.transport().requeue(request_msg);
+    cluster.advance_ms(1);
+    cluster.nodes[0].controller.process_messages().await;
+
+    // Node 2 (the other group member) accepts the replicate and acks it.
+    cluster.advance_ms(1);
+    cluster.nodes[1].controller.process_messages().await;
+
+    // Node 1 sees the majority ack and only now sends the deferred reserve response.
     cluster.advance_ms(1);
     cluster.nodes[0].controller.process_messages().await;
 
@@ -3854,7 +3863,8 @@ async fn unique_constraint_cross_node_message_flow() {
         }
     }
 
-    let resp = reserve_response.expect("Node 1 should have sent a reserve response to Node 2");
+    let resp = reserve_response
+        .expect("Node 1 should send a reserve response once the reservation is majority-durable");
     assert_eq!(resp.request_id, 42, "Response request_id should match");
     assert!(
         matches!(resp.status(), UniqueReserveStatus::Reserved),

--- a/crates/mqdb-cluster/tests/cluster_integration_test.rs
+++ b/crates/mqdb-cluster/tests/cluster_integration_test.rs
@@ -4167,8 +4167,14 @@ async fn unique_replicate_fences_stale_epoch() {
 
     let node0_id = cluster.nodes[0].id;
     for msg in [
-        ClusterMessage::UniqueReplicate(at_epoch(&insert_write, 2)),
-        ClusterMessage::UniqueReplicate(at_epoch(&delete_write, 1)),
+        ClusterMessage::UniqueReplicate {
+            request_id: 0,
+            write: at_epoch(&insert_write, 2),
+        },
+        ClusterMessage::UniqueReplicate {
+            request_id: 0,
+            write: at_epoch(&delete_write, 1),
+        },
     ] {
         cluster.nodes[2]
             .controller

--- a/crates/mqdb-cluster/tests/cluster_integration_test.rs
+++ b/crates/mqdb-cluster/tests/cluster_integration_test.rs
@@ -3861,3 +3861,222 @@ async fn unique_constraint_cross_node_message_flow() {
         "First reserve should succeed"
     );
 }
+
+fn json_value_bytes(value: &str) -> Vec<u8> {
+    serde_json::to_vec(&serde_json::Value::String(value.to_string())).unwrap()
+}
+
+#[tokio::test]
+async fn unique_reconcile_reestablishes_lost_reservation() {
+    use mqdb_cluster::cluster::db::ClusterConstraint;
+
+    let mut cluster = TestCluster::new(1);
+    for i in 0..NUM_PARTITIONS {
+        cluster.nodes[0]
+            .controller
+            .become_primary(PartitionId::new(i).unwrap(), Epoch::new(1));
+    }
+
+    cluster.nodes[0]
+        .controller
+        .stores()
+        .db_constraints
+        .add(ClusterConstraint::unique("users", "uniq_email", "email"))
+        .unwrap();
+    cluster.nodes[0]
+        .controller
+        .stores()
+        .db_data
+        .create("users", "u1", br#"{"email":"a@x.com"}"#, 1000)
+        .unwrap();
+
+    let value = json_value_bytes("a@x.com");
+    assert!(
+        cluster.nodes[0]
+            .controller
+            .stores()
+            .unique_get("users", "email", &value)
+            .is_none(),
+        "no claim should exist before reconcile (reservation lost to failover)"
+    );
+
+    cluster.nodes[0].controller.reconcile_unique_claims().await;
+
+    let claim = cluster.nodes[0]
+        .controller
+        .stores()
+        .unique_get("users", "email", &value)
+        .expect("reconcile should establish a committed claim from the durable record");
+    assert!(claim.is_committed());
+    assert_eq!(claim.record_id_str(), "u1");
+}
+
+#[tokio::test]
+async fn unique_reconcile_repairs_lost_commit() {
+    use mqdb_cluster::cluster::db::{ClusterConstraint, UniqueReserveParams};
+
+    let mut cluster = TestCluster::new(1);
+    for i in 0..NUM_PARTITIONS {
+        cluster.nodes[0]
+            .controller
+            .become_primary(PartitionId::new(i).unwrap(), Epoch::new(1));
+    }
+
+    let stores = cluster.nodes[0].controller.stores();
+    stores
+        .db_constraints
+        .add(ClusterConstraint::unique("users", "uniq_email", "email"))
+        .unwrap();
+    stores
+        .db_data
+        .create("users", "u1", br#"{"email":"a@x.com"}"#, 1000)
+        .unwrap();
+
+    let value = json_value_bytes("a@x.com");
+    let params = UniqueReserveParams {
+        entity: "users",
+        field: "email",
+        value: &value,
+        record_id: "u1",
+        request_id: "req-lost-commit",
+        data_partition: PartitionId::new(5).unwrap(),
+        ttl_ms: 30_000,
+    };
+    let (result, _) = stores.unique_reserve_replicated(&params, 1000);
+    assert_eq!(result, mqdb_cluster::cluster::db::ReserveResult::Reserved);
+    assert!(
+        !stores
+            .unique_get("users", "email", &value)
+            .unwrap()
+            .is_committed(),
+        "reservation must be uncommitted before reconcile (commit was lost)"
+    );
+
+    cluster.nodes[0].controller.reconcile_unique_claims().await;
+
+    let claim = cluster.nodes[0]
+        .controller
+        .stores()
+        .unique_get("users", "email", &value)
+        .expect("claim should still exist");
+    assert!(
+        claim.is_committed(),
+        "reconcile should promote the uncommitted claim to committed"
+    );
+    assert_eq!(claim.record_id_str(), "u1");
+}
+
+#[tokio::test]
+async fn unique_reconcile_leaves_abandoned_for_ttl_reclaim() {
+    use mqdb_cluster::cluster::db::{ClusterConstraint, ReserveResult, UniqueReserveParams};
+
+    let mut cluster = TestCluster::new(1);
+    for i in 0..NUM_PARTITIONS {
+        cluster.nodes[0]
+            .controller
+            .become_primary(PartitionId::new(i).unwrap(), Epoch::new(1));
+    }
+
+    let stores = cluster.nodes[0].controller.stores();
+    stores
+        .db_constraints
+        .add(ClusterConstraint::unique("users", "uniq_email", "email"))
+        .unwrap();
+
+    let value = json_value_bytes("ghost@x.com");
+    let ttl_ms = 1000;
+    let params = UniqueReserveParams {
+        entity: "users",
+        field: "email",
+        value: &value,
+        record_id: "ghost",
+        request_id: "req-abandoned",
+        data_partition: PartitionId::new(5).unwrap(),
+        ttl_ms,
+    };
+    let (result, _) = stores.unique_reserve_replicated(&params, 1000);
+    assert_eq!(result, ReserveResult::Reserved);
+
+    cluster.nodes[0].controller.reconcile_unique_claims().await;
+
+    assert!(
+        cluster.nodes[0]
+            .controller
+            .stores()
+            .unique_get("users", "email", &value)
+            .is_some(),
+        "reconcile must not touch an abandoned reservation whose record does not exist"
+    );
+
+    let reclaimed = cluster.nodes[0]
+        .controller
+        .stores()
+        .unique_cleanup_expired(1000 + ttl_ms + 100);
+    assert_eq!(
+        reclaimed, 1,
+        "TTL cleanup should reclaim the abandoned claim"
+    );
+    assert!(
+        cluster.nodes[0]
+            .controller
+            .stores()
+            .unique_get("users", "email", &value)
+            .is_none(),
+        "value should be free after TTL reclaim"
+    );
+}
+
+#[tokio::test]
+async fn unique_reassert_request_cross_node_establishes() {
+    use mqdb_cluster::cluster::{ClusterMessage, InboundMessage, UniqueReassertRequest};
+
+    let mut cluster = TestCluster::new(2);
+    cluster.runtime.network().set_base_latency_ms(0);
+
+    for i in 0..NUM_PARTITIONS {
+        let partition = PartitionId::new(i).unwrap();
+        cluster.nodes[0]
+            .controller
+            .become_primary(partition, Epoch::new(1));
+        cluster.nodes[1]
+            .controller
+            .become_replica(partition, Epoch::new(1), 0);
+    }
+
+    for node in &mut cluster.nodes {
+        let output = node.controller.tick(0);
+        node.controller.send_tick_output(output).await;
+    }
+    cluster.advance_ms(5);
+    for node in &mut cluster.nodes {
+        node.controller.process_messages().await;
+    }
+
+    let value = json_value_bytes("SKU-9");
+    let request = UniqueReassertRequest::create(
+        0,
+        "products",
+        "sku",
+        &value,
+        "product-9",
+        PartitionId::new(5).unwrap(),
+    );
+
+    let node2_id = cluster.nodes[1].id;
+    let request_msg = InboundMessage {
+        from: node2_id,
+        message: ClusterMessage::UniqueReassertRequest(request),
+        received_at: 0,
+    };
+    cluster.nodes[0].controller.transport().requeue(request_msg);
+    cluster.advance_ms(1);
+    cluster.nodes[0].controller.process_messages().await;
+
+    let claim = cluster.nodes[0]
+        .controller
+        .stores()
+        .unique_get("products", "sku", &value)
+        .expect("reassert should establish a committed claim on the value-primary");
+    assert!(claim.is_committed());
+    assert_eq!(claim.record_id_str(), "product-9");
+}

--- a/crates/mqdb-cluster/tests/cluster_integration_test.rs
+++ b/crates/mqdb-cluster/tests/cluster_integration_test.rs
@@ -3884,6 +3884,7 @@ fn json_value_bytes(value: &str) -> Vec<u8> {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn no_oversell_when_new_primary_missed_a_reservation() {
     // Model-as-oracle NoOversell test for the exact scenario ClusterUniqueMonotonic.tla flagged:
     // a promoted primary that MISSED an existing reservation must still refuse to reassign the value.

--- a/crates/mqdb-cluster/tests/cluster_integration_test.rs
+++ b/crates/mqdb-cluster/tests/cluster_integration_test.rs
@@ -3822,6 +3822,13 @@ async fn unique_constraint_cross_node_message_flow() {
         node.controller.process_messages().await;
     }
 
+    // Complete the promotion seal handshake so node 0 may serve reserves for the value partition.
+    for _ in 0..3 {
+        cluster.advance_ms(1);
+        cluster.nodes[0].controller.process_messages().await;
+        cluster.nodes[1].controller.process_messages().await;
+    }
+
     let request = UniqueReserveRequest::create(
         42,
         "products",

--- a/crates/mqdb-cluster/tests/cluster_integration_test.rs
+++ b/crates/mqdb-cluster/tests/cluster_integration_test.rs
@@ -3846,22 +3846,18 @@ async fn unique_constraint_cross_node_message_flow() {
     cluster.nodes[0].controller.process_messages().await;
 
     cluster.advance_ms(1);
-    let response = cluster.nodes[1].controller.transport().recv();
-    assert!(
-        response.is_some(),
-        "Node 1 should have sent response to Node 2"
-    );
-
-    if let Some(msg) = response {
-        assert_eq!(msg.from, node1_id, "Response should be from node 1");
-        if let ClusterMessage::UniqueReserveResponse(ref resp) = msg.message {
-            assert_eq!(resp.request_id, 42, "Response request_id should match");
-            assert!(
-                matches!(resp.status(), UniqueReserveStatus::Reserved),
-                "First reserve should succeed"
-            );
-        } else {
-            panic!("Expected UniqueReserveResponse");
+    let mut reserve_response = None;
+    while let Some(msg) = cluster.nodes[1].controller.transport().recv() {
+        if let ClusterMessage::UniqueReserveResponse(resp) = msg.message {
+            assert_eq!(msg.from, node1_id, "Response should be from node 1");
+            reserve_response = Some(resp);
         }
     }
+
+    let resp = reserve_response.expect("Node 1 should have sent a reserve response to Node 2");
+    assert_eq!(resp.request_id, 42, "Response request_id should match");
+    assert!(
+        matches!(resp.status(), UniqueReserveStatus::Reserved),
+        "First reserve should succeed"
+    );
 }

--- a/crates/mqdb-cluster/tests/cluster_integration_test.rs
+++ b/crates/mqdb-cluster/tests/cluster_integration_test.rs
@@ -3884,6 +3884,133 @@ fn json_value_bytes(value: &str) -> Vec<u8> {
 }
 
 #[tokio::test]
+async fn no_oversell_when_new_primary_missed_a_reservation() {
+    // Model-as-oracle NoOversell test for the exact scenario ClusterUniqueMonotonic.tla flagged:
+    // a promoted primary that MISSED an existing reservation must still refuse to reassign the value.
+    // Without the seal reservation-learning (d-2), node1 would grant the value to a second record and
+    // oversell — so this test fails if that fix regresses.
+    use mqdb_cluster::cluster::db::{ReserveResult, UniqueReserveParams};
+    use mqdb_cluster::cluster::{ClusterMessage, InboundMessage};
+
+    let mut cluster = TestCluster::new(3);
+    cluster.runtime.network().set_base_latency_ms(0);
+    for i in 0..NUM_PARTITIONS {
+        let p = PartitionId::new(i).unwrap();
+        cluster.nodes[0].controller.become_primary(p, Epoch::new(1));
+        cluster.nodes[1]
+            .controller
+            .become_replica(p, Epoch::new(1), 0);
+        cluster.nodes[2]
+            .controller
+            .become_replica(p, Epoch::new(1), 0);
+    }
+
+    let value = json_value_bytes("sku-1");
+    let unique_part = mqdb_cluster::cluster::db::unique_partition("products", "sku", &value);
+    let node0_id = cluster.nodes[0].id;
+
+    // node0 (epoch 1) reserves the value for record "A", but the replication reaches only node2 —
+    // node1 (the future primary) never sees it.
+    let params_a = UniqueReserveParams {
+        entity: "products",
+        field: "sku",
+        value: &value,
+        record_id: "A",
+        request_id: "req-A",
+        data_partition: PartitionId::new(5).unwrap(),
+        ttl_ms: 30_000,
+    };
+    let (res_a, write_a) = cluster.nodes[0]
+        .controller
+        .stores()
+        .unique_reserve_replicated(&params_a, 1000);
+    assert_eq!(res_a, ReserveResult::Reserved);
+    let write_a = write_a.unwrap();
+    let stamped_a = ReplicationWrite::new(
+        write_a.partition,
+        write_a.operation,
+        Epoch::new(1),
+        0,
+        write_a.entity.clone(),
+        write_a.id.clone(),
+        write_a.data.clone(),
+    );
+    cluster.nodes[2]
+        .controller
+        .transport()
+        .requeue(InboundMessage {
+            from: node0_id,
+            message: ClusterMessage::UniqueReplicate {
+                request_id: 0,
+                write: stamped_a,
+            },
+            received_at: 0,
+        });
+    cluster.advance_ms(1);
+    cluster.nodes[2].controller.process_messages().await;
+    assert!(
+        cluster.nodes[1]
+            .controller
+            .stores()
+            .unique_get("products", "sku", &value)
+            .is_none(),
+        "the future primary must genuinely be missing the reservation for the test to be meaningful"
+    );
+
+    // Failover: node1 is promoted to primary at epoch 2 and seals — the seal must LEARN A.
+    cluster.nodes[1]
+        .controller
+        .become_primary(unique_part, Epoch::new(2));
+    for _ in 0..4 {
+        let output = cluster.nodes[1].controller.tick(0);
+        cluster.nodes[1].controller.send_tick_output(output).await;
+        cluster.advance_ms(1);
+        cluster.nodes[0].controller.process_messages().await;
+        cluster.nodes[2].controller.process_messages().await;
+        cluster.advance_ms(1);
+        cluster.nodes[1].controller.process_messages().await;
+    }
+
+    let learned = cluster.nodes[1]
+        .controller
+        .stores()
+        .unique_get("products", "sku", &value)
+        .expect("the promotion seal must teach the new primary the reservation it missed");
+    assert_eq!(learned.record_id_str(), "A");
+
+    // The new primary now tries to reserve the SAME value for a DIFFERENT record "B".
+    let params_b = UniqueReserveParams {
+        entity: "products",
+        field: "sku",
+        value: &value,
+        record_id: "B",
+        request_id: "req-B",
+        data_partition: PartitionId::new(5).unwrap(),
+        ttl_ms: 30_000,
+    };
+    let (res_b, _) = cluster.nodes[1]
+        .controller
+        .stores()
+        .unique_reserve_replicated(&params_b, 2000);
+    assert_eq!(
+        res_b,
+        ReserveResult::Conflict,
+        "the value is already held by A; the promoted primary must not oversell it to B"
+    );
+
+    // NoOversell: exactly one record holds the value, and it is the original owner.
+    assert_eq!(
+        cluster.nodes[1]
+            .controller
+            .stores()
+            .unique_get("products", "sku", &value)
+            .unwrap()
+            .record_id_str(),
+        "A",
+    );
+}
+
+#[tokio::test]
 async fn unique_seal_fences_superseded_primary_reserve() {
     use mqdb_cluster::cluster::db::{ReserveResult, UniqueReserveParams};
     use mqdb_cluster::cluster::{ClusterMessage, InboundMessage, UniqueSealRequest};

--- a/crates/mqdb-cluster/tests/simulation/transport.rs
+++ b/crates/mqdb-cluster/tests/simulation/transport.rs
@@ -224,6 +224,9 @@ impl SimulatedTransport {
                 let (req, _) = UniqueReassertRequest::try_from_be_bytes(payload).ok()?;
                 Some(ClusterMessage::UniqueReassertRequest(req))
             }
+            87 => Some(ClusterMessage::UniqueReplicate(
+                ReplicationWrite::from_bytes(payload)?,
+            )),
             _ => None,
         }
     }

--- a/crates/mqdb-cluster/tests/simulation/transport.rs
+++ b/crates/mqdb-cluster/tests/simulation/transport.rs
@@ -11,8 +11,8 @@ use mqdb_cluster::cluster::{
     JsonDbResponse, NUM_PARTITIONS, NodeId, PartitionId, QueryRequest, QueryResponse,
     ReplicationAck, ReplicationWrite, SnapshotChunk, SnapshotComplete, SnapshotRequest,
     TopicSubscriptionBroadcast, TransportError, UniqueCommitRequest, UniqueCommitResponse,
-    UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest, UniqueReserveResponse,
-    WildcardBroadcast,
+    UniqueReassertRequest, UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest,
+    UniqueReserveResponse, WildcardBroadcast,
 };
 
 use super::framework::{VirtualClock, VirtualNetwork};
@@ -219,6 +219,10 @@ impl SimulatedTransport {
             85 => {
                 let (resp, _) = UniqueReleaseResponse::try_from_be_bytes(payload).ok()?;
                 Some(ClusterMessage::UniqueReleaseResponse(resp))
+            }
+            86 => {
+                let (req, _) = UniqueReassertRequest::try_from_be_bytes(payload).ok()?;
+                Some(ClusterMessage::UniqueReassertRequest(req))
             }
             _ => None,
         }

--- a/crates/mqdb-cluster/tests/simulation/transport.rs
+++ b/crates/mqdb-cluster/tests/simulation/transport.rs
@@ -12,7 +12,8 @@ use mqdb_cluster::cluster::{
     ReplicationAck, ReplicationWrite, SnapshotChunk, SnapshotComplete, SnapshotRequest,
     TopicSubscriptionBroadcast, TransportError, UniqueCommitRequest, UniqueCommitResponse,
     UniqueReassertRequest, UniqueReleaseRequest, UniqueReleaseResponse, UniqueReplicateAck,
-    UniqueReserveRequest, UniqueReserveResponse, WildcardBroadcast,
+    UniqueReserveRequest, UniqueReserveResponse, UniqueSealRequest, UniqueSealResponse,
+    WildcardBroadcast,
 };
 
 use super::framework::{VirtualClock, VirtualNetwork};
@@ -235,6 +236,14 @@ impl SimulatedTransport {
             88 => {
                 let (ack, _) = UniqueReplicateAck::try_from_be_bytes(payload).ok()?;
                 Some(ClusterMessage::UniqueReplicateAck(ack))
+            }
+            89 => {
+                let (req, _) = UniqueSealRequest::try_from_be_bytes(payload).ok()?;
+                Some(ClusterMessage::UniqueSealRequest(req))
+            }
+            94 => {
+                let (resp, _) = UniqueSealResponse::try_from_be_bytes(payload).ok()?;
+                Some(ClusterMessage::UniqueSealResponse(resp))
             }
             _ => None,
         }

--- a/crates/mqdb-cluster/tests/simulation/transport.rs
+++ b/crates/mqdb-cluster/tests/simulation/transport.rs
@@ -11,8 +11,8 @@ use mqdb_cluster::cluster::{
     JsonDbResponse, NUM_PARTITIONS, NodeId, PartitionId, QueryRequest, QueryResponse,
     ReplicationAck, ReplicationWrite, SnapshotChunk, SnapshotComplete, SnapshotRequest,
     TopicSubscriptionBroadcast, TransportError, UniqueCommitRequest, UniqueCommitResponse,
-    UniqueReassertRequest, UniqueReleaseRequest, UniqueReleaseResponse, UniqueReserveRequest,
-    UniqueReserveResponse, WildcardBroadcast,
+    UniqueReassertRequest, UniqueReleaseRequest, UniqueReleaseResponse, UniqueReplicateAck,
+    UniqueReserveRequest, UniqueReserveResponse, WildcardBroadcast,
 };
 
 use super::framework::{VirtualClock, VirtualNetwork};
@@ -224,9 +224,18 @@ impl SimulatedTransport {
                 let (req, _) = UniqueReassertRequest::try_from_be_bytes(payload).ok()?;
                 Some(ClusterMessage::UniqueReassertRequest(req))
             }
-            87 => Some(ClusterMessage::UniqueReplicate(
-                ReplicationWrite::from_bytes(payload)?,
-            )),
+            87 => {
+                if payload.len() < 8 {
+                    return None;
+                }
+                let request_id = u64::from_be_bytes(payload[..8].try_into().ok()?);
+                let write = ReplicationWrite::from_bytes(&payload[8..])?;
+                Some(ClusterMessage::UniqueReplicate { request_id, write })
+            }
+            88 => {
+                let (ack, _) = UniqueReplicateAck::try_from_be_bytes(payload).ok()?;
+                Some(ClusterMessage::UniqueReplicateAck(ack))
+            }
             _ => None,
         }
     }

--- a/crates/mqdb-core/Cargo.toml
+++ b/crates/mqdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-core"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-core/src/constraint.rs
+++ b/crates/mqdb-core/src/constraint.rs
@@ -215,7 +215,7 @@ impl ConstraintManager {
     pub fn validate_create(
         &self,
         entity: &Entity,
-        _batch: &mut BatchWriter,
+        batch: &mut BatchWriter,
         storage: &Storage,
     ) -> Result<()> {
         let constraints = self.get_constraints(&entity.name);
@@ -223,7 +223,10 @@ impl ConstraintManager {
         for constraint in constraints {
             match constraint {
                 Constraint::NotNull(c) => Self::validate_not_null(entity, c)?,
-                Constraint::Unique(c) => Self::validate_unique(entity, c, storage)?,
+                Constraint::Unique(c) => {
+                    Self::validate_unique(entity, c, storage)?;
+                    Self::stage_unique_guards(entity, c, batch)?;
+                }
                 Constraint::ForeignKey(c) => Self::validate_foreign_key(entity, c, storage)?,
             }
         }
@@ -237,7 +240,7 @@ impl ConstraintManager {
         &self,
         entity: &Entity,
         old_entity: &Entity,
-        _batch: &mut BatchWriter,
+        batch: &mut BatchWriter,
         storage: &Storage,
     ) -> Result<()> {
         let constraints = self.get_constraints(&entity.name);
@@ -247,11 +250,79 @@ impl ConstraintManager {
                 Constraint::NotNull(c) => Self::validate_not_null(entity, c)?,
                 Constraint::Unique(c) => {
                     Self::validate_unique_update(entity, old_entity, c, storage)?;
+                    Self::stage_unique_guards_update(entity, old_entity, c, batch)?;
                 }
                 Constraint::ForeignKey(c) => Self::validate_foreign_key(entity, c, storage)?,
             }
         }
 
+        Ok(())
+    }
+
+    fn stage_unique_guards(
+        entity: &Entity,
+        constraint: &UniqueConstraint,
+        batch: &mut BatchWriter,
+    ) -> Result<()> {
+        for field in &constraint.fields {
+            if let Some(value) = entity.get_field(field) {
+                let value_bytes = keys::encode_value_for_index(value)?;
+                let guard = keys::encode_unique_guard_key(&entity.name, field, &value_bytes);
+                batch.expect_absent(guard.clone());
+                batch.insert(guard, entity.id.as_bytes().to_vec());
+            }
+        }
+        Ok(())
+    }
+
+    fn stage_unique_guards_update(
+        entity: &Entity,
+        old_entity: &Entity,
+        constraint: &UniqueConstraint,
+        batch: &mut BatchWriter,
+    ) -> Result<()> {
+        for field in &constraint.fields {
+            let new_bytes = match entity.get_field(field) {
+                Some(v) => Some(keys::encode_value_for_index(v)?),
+                None => None,
+            };
+            let old_bytes = match old_entity.get_field(field) {
+                Some(v) => Some(keys::encode_value_for_index(v)?),
+                None => None,
+            };
+            if new_bytes == old_bytes {
+                continue;
+            }
+            if let Some(nb) = &new_bytes {
+                let guard_new = keys::encode_unique_guard_key(&entity.name, field, nb);
+                batch.expect_absent(guard_new.clone());
+                batch.insert(guard_new, entity.id.as_bytes().to_vec());
+            }
+            if let Some(ob) = &old_bytes {
+                let guard_old = keys::encode_unique_guard_key(&entity.name, field, ob);
+                batch.remove(guard_old);
+            }
+        }
+        Ok(())
+    }
+
+    /// Stages removal of every unique-guard key owned by `entity` (for deletes).
+    ///
+    /// # Errors
+    /// Returns an error if a value fails index encoding.
+    pub fn release_unique_guards(&self, entity: &Entity, batch: &mut BatchWriter) -> Result<()> {
+        for constraint in self.get_constraints(&entity.name) {
+            if let Constraint::Unique(c) = constraint {
+                for field in &c.fields {
+                    if let Some(value) = entity.get_field(field) {
+                        let value_bytes = keys::encode_value_for_index(value)?;
+                        let guard =
+                            keys::encode_unique_guard_key(&entity.name, field, &value_bytes);
+                        batch.remove(guard);
+                    }
+                }
+            }
+        }
         Ok(())
     }
 

--- a/crates/mqdb-core/src/error.rs
+++ b/crates/mqdb-core/src/error.rs
@@ -42,6 +42,9 @@ pub enum Error {
     #[error("concurrent modification conflict: {0}")]
     Conflict(String),
 
+    #[error("absent precondition violated for key")]
+    AbsentPreconditionViolated(Vec<u8>),
+
     #[error("schema validation failed: {entity}.{field} - {reason}")]
     SchemaViolation {
         entity: String,

--- a/crates/mqdb-core/src/keys.rs
+++ b/crates/mqdb-core/src/keys.rs
@@ -6,6 +6,7 @@ use crate::error::{Error, Result};
 pub const SEPARATOR: u8 = b'/';
 pub const DATA_PREFIX: &[u8] = b"data";
 pub const INDEX_PREFIX: &[u8] = b"idx";
+pub const UNIQUE_GUARD_PREFIX: &[u8] = b"uniq";
 pub const WASM_INDEX_PREFIX: &str = "index";
 pub const SUB_PREFIX: &[u8] = b"sub";
 pub const DEDUP_PREFIX: &[u8] = b"dedup";
@@ -71,6 +72,33 @@ pub fn encode_index_prefix(entity: &str, field: &str, value: Option<&[u8]>) -> V
     }
 
     key
+}
+
+#[must_use]
+pub fn encode_unique_guard_key(entity: &str, field: &str, value: &[u8]) -> Vec<u8> {
+    let mut key = Vec::with_capacity(
+        UNIQUE_GUARD_PREFIX.len() + 3 + entity.len() + field.len() + value.len(),
+    );
+    key.extend_from_slice(UNIQUE_GUARD_PREFIX);
+    key.push(SEPARATOR);
+    key.extend_from_slice(entity.as_bytes());
+    key.push(SEPARATOR);
+    key.extend_from_slice(field.as_bytes());
+    key.push(SEPARATOR);
+    key.extend_from_slice(value);
+    key
+}
+
+#[must_use]
+pub fn decode_unique_guard_key(key: &[u8]) -> Option<(String, String, Vec<u8>)> {
+    let mut parts = key.splitn(4, |&b| b == SEPARATOR);
+    if parts.next()? != UNIQUE_GUARD_PREFIX {
+        return None;
+    }
+    let entity = std::str::from_utf8(parts.next()?).ok()?.to_string();
+    let field = std::str::from_utf8(parts.next()?).ok()?.to_string();
+    let value = parts.next()?.to_vec();
+    Some((entity, field, value))
 }
 
 #[must_use]

--- a/crates/mqdb-core/src/storage/backend.rs
+++ b/crates/mqdb-core/src/storage/backend.rs
@@ -70,6 +70,16 @@ pub trait StorageBackend: Send + Sync {
     /// # Errors
     /// Returns an error if the flush operation fails.
     fn flush(&self) -> Result<()>;
+
+    /// Durably persists pending writes (fsync), unconditionally — independent of the
+    /// configured durability mode. Used for correctness-critical writes that must survive
+    /// a crash before the operation is acknowledged.
+    ///
+    /// # Errors
+    /// Returns an error if the sync operation fails.
+    fn sync(&self) -> Result<()> {
+        self.flush()
+    }
 }
 
 /// Batch operations for atomic writes.

--- a/crates/mqdb-core/src/storage/backend.rs
+++ b/crates/mqdb-core/src/storage/backend.rs
@@ -83,6 +83,9 @@ pub trait BatchOperations: Send {
     /// Sets an expected value for optimistic concurrency.
     fn expect_value(&mut self, key: Vec<u8>, expected_value: Vec<u8>);
 
+    /// Requires that `key` is absent at commit time (compare-and-set on absence).
+    fn expect_absent(&mut self, key: Vec<u8>);
+
     /// Commits all queued operations atomically.
     ///
     /// # Errors

--- a/crates/mqdb-core/src/storage/encrypted_backend.rs
+++ b/crates/mqdb-core/src/storage/encrypted_backend.rs
@@ -117,6 +117,10 @@ impl StorageBackend for EncryptedBackend {
     fn flush(&self) -> Result<()> {
         self.inner.flush()
     }
+
+    fn sync(&self) -> Result<()> {
+        self.inner.sync()
+    }
 }
 
 struct EncryptedBatch {

--- a/crates/mqdb-core/src/storage/encrypted_backend.rs
+++ b/crates/mqdb-core/src/storage/encrypted_backend.rs
@@ -142,6 +142,10 @@ impl BatchOperations for EncryptedBatch {
         self.pending_expects.push((key, expected_value));
     }
 
+    fn expect_absent(&mut self, key: Vec<u8>) {
+        self.inner.expect_absent(key);
+    }
+
     fn commit(mut self: Box<Self>) -> Result<()> {
         for (key, expected_plaintext) in &self.pending_expects {
             let stored = self.backend.get(key)?;

--- a/crates/mqdb-core/src/storage/fjall_backend.rs
+++ b/crates/mqdb-core/src/storage/fjall_backend.rs
@@ -140,6 +140,11 @@ impl StorageBackend for FjallBackend {
     fn flush(&self) -> Result<()> {
         self.sync_if_needed()
     }
+
+    fn sync(&self) -> Result<()> {
+        self.db.persist(PersistMode::SyncAll)?;
+        Ok(())
+    }
 }
 
 enum BatchOp {

--- a/crates/mqdb-core/src/storage/fjall_backend.rs
+++ b/crates/mqdb-core/src/storage/fjall_backend.rs
@@ -147,9 +147,14 @@ enum BatchOp {
     Remove(Vec<u8>),
 }
 
-struct Precondition {
-    key: Vec<u8>,
-    expected_value: Vec<u8>,
+enum Precondition {
+    Equals {
+        key: Vec<u8>,
+        expected_value: Vec<u8>,
+    },
+    Absent {
+        key: Vec<u8>,
+    },
 }
 
 pub struct FjallBatch {
@@ -171,10 +176,14 @@ impl BatchOperations for FjallBatch {
     }
 
     fn expect_value(&mut self, key: Vec<u8>, expected_value: Vec<u8>) {
-        self.preconditions.push(Precondition {
+        self.preconditions.push(Precondition::Equals {
             key,
             expected_value,
         });
+    }
+
+    fn expect_absent(&mut self, key: Vec<u8>) {
+        self.preconditions.push(Precondition::Absent { key });
     }
 
     fn commit(self: Box<Self>) -> Result<()> {
@@ -186,13 +195,27 @@ impl BatchOperations for FjallBatch {
 
             let snapshot = self.db.snapshot();
             for precondition in &self.preconditions {
-                let actual: Option<Slice> = snapshot.get(&self.keyspace, &precondition.key)?;
-                match actual {
-                    Some(val) if val.as_ref() == precondition.expected_value.as_slice() => {}
-                    _ => {
-                        return Err(crate::error::Error::Conflict(
-                            "optimistic lock failed: value was modified".into(),
-                        ));
+                match precondition {
+                    Precondition::Equals {
+                        key,
+                        expected_value,
+                    } => {
+                        let actual: Option<Slice> = snapshot.get(&self.keyspace, key)?;
+                        match actual {
+                            Some(val) if val.as_ref() == expected_value.as_slice() => {}
+                            _ => {
+                                return Err(crate::error::Error::Conflict(
+                                    "optimistic lock failed: value was modified".into(),
+                                ));
+                            }
+                        }
+                    }
+                    Precondition::Absent { key } => {
+                        if snapshot.get(&self.keyspace, key)?.is_some() {
+                            return Err(crate::error::Error::AbsentPreconditionViolated(
+                                key.clone(),
+                            ));
+                        }
                     }
                 }
             }

--- a/crates/mqdb-core/src/storage/memory_backend.rs
+++ b/crates/mqdb-core/src/storage/memory_backend.rs
@@ -143,9 +143,14 @@ enum BatchOp {
     Remove(Vec<u8>),
 }
 
-struct Precondition {
-    key: Vec<u8>,
-    expected_value: Vec<u8>,
+enum Precondition {
+    Equals {
+        key: Vec<u8>,
+        expected_value: Vec<u8>,
+    },
+    Absent {
+        key: Vec<u8>,
+    },
 }
 
 pub struct MemoryBatch {
@@ -164,10 +169,14 @@ impl BatchOperations for MemoryBatch {
     }
 
     fn expect_value(&mut self, key: Vec<u8>, expected_value: Vec<u8>) {
-        self.preconditions.push(Precondition {
+        self.preconditions.push(Precondition::Equals {
             key,
             expected_value,
         });
+    }
+
+    fn expect_absent(&mut self, key: Vec<u8>) {
+        self.preconditions.push(Precondition::Absent { key });
     }
 
     fn commit(self: Box<Self>) -> Result<()> {
@@ -177,13 +186,22 @@ impl BatchOperations for MemoryBatch {
             .map_err(|e| Error::Internal(e.to_string()))?;
 
         for precondition in &self.preconditions {
-            let actual = data.get(&precondition.key);
-            match actual {
-                Some(val) if val.as_slice() == precondition.expected_value.as_slice() => {}
-                _ => {
-                    return Err(Error::Conflict(
-                        "optimistic lock failed: value was modified".into(),
-                    ));
+            match precondition {
+                Precondition::Equals {
+                    key,
+                    expected_value,
+                } => match data.get(key) {
+                    Some(val) if val.as_slice() == expected_value.as_slice() => {}
+                    _ => {
+                        return Err(Error::Conflict(
+                            "optimistic lock failed: value was modified".into(),
+                        ));
+                    }
+                },
+                Precondition::Absent { key } => {
+                    if data.contains_key(key) {
+                        return Err(Error::AbsentPreconditionViolated(key.clone()));
+                    }
                 }
             }
         }

--- a/crates/mqdb-core/src/storage/mod.rs
+++ b/crates/mqdb-core/src/storage/mod.rs
@@ -128,6 +128,14 @@ impl Storage {
     pub fn flush(&self) -> Result<()> {
         self.backend.flush()
     }
+
+    /// Durably persists pending writes (fsync), independent of the durability mode.
+    ///
+    /// # Errors
+    /// Returns an error if the sync operation fails.
+    pub fn sync(&self) -> Result<()> {
+        self.backend.sync()
+    }
 }
 
 pub struct BatchWriter {

--- a/crates/mqdb-core/src/storage/mod.rs
+++ b/crates/mqdb-core/src/storage/mod.rs
@@ -147,6 +147,10 @@ impl BatchWriter {
         self.inner.expect_value(key, expected_value);
     }
 
+    pub fn expect_absent(&mut self, key: Vec<u8>) {
+        self.inner.expect_absent(key);
+    }
+
     /// Commits all queued operations atomically.
     ///
     /// # Errors

--- a/crates/mqdb-wasm/Cargo.lock
+++ b/crates/mqdb-wasm/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -278,10 +278,14 @@ missed-reservation overwrite. **Both create paths are gated:** the primary MQTT 
 `unique_partition_sealed`).
 
 **Remaining polish (non-safety, diminishing value — backstopped by the reconciler + monotonic guard):**
-- The forwarded `db_ops` create path is **gated** but not yet **majority-awaited** (returns before the
-  async group-replicate reaches a majority); a crash in that narrow window is repaired/detected by the
-  reconciler. Full P2.c parity would thread `pending_quorum` through the `db_ops` phase1 +
-  `spawn_unique_completion`, mirroring Path 1.
+- The forwarded `db_ops` create path is now **gated and majority-awaited** for the common case:
+  `reserve_unique_local` threads `pending_quorum` into the `db_ops` create phase1, and
+  `spawn_unique_completion` awaits both `pending_remote` and `pending_quorum` (before acquiring the
+  lock — no deadlock). The **FK-then-unique continuations** (`complete_pending_fk_work`) run *holding*
+  the controller lock, so they can't await the quorum inline (the ack path needs the lock); those
+  rarer reserves stay gated + async-replicated, with the reconciler as the majority-durability
+  backstop. (Closing that would require restructuring `complete_pending_fk_work` to release the lock
+  around the await, like `spawn_unique_completion`.)
 - The fail-closed-while-unsealed reserve returns a **409** ("unique constraint violation"); during the
   brief post-promotion unsealed window this is misleading — a **503**/retry is more accurate (needs a
   distinct not-durable signal threaded through the reserve return type).

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -220,18 +220,23 @@ group. So the unique partitions must be replicated to **every group member** (ea
 - Tests: 3 `node_controller` unit tests (majority-ack resolves, timeout fails closed, single-node
   immediate) + prior P2.b tests. Full suite green (498+74+49), clippy clean.
 
-**Remaining P2.c gaps (→ P2.c-2, documented, not yet gated):**
-- **Remote-primary reserve** (coordinator ≠ value primary): `handle_unique_reserve_request` still
-  responds `Reserved` immediately (fire-and-forget group replicate), so that field isn't
-  majority-gated. Fix: defer the `UniqueReserveResponse` until the tracker completes (event-driven
-  completion = send-response), so the coordinator's existing `await_unique_reserves` becomes
-  majority-gated transparently.
-- **Secondary create path** (`db_ops` `reserve_unique_local` @ 1347/1630/1785 + the event-loop Path 2
-  completion): still P2.b fire-and-forget; `db_ops`:683 creates trackers via
-  `start_unique_constraint_check` but Path 2 never awaits `pending_quorum`.
+**P2.c-2 (remote-primary reserve) DONE:** `UniqueQuorumTracker.completion` is now an enum
+(`Local(oneshot)` vs `RemoteReserve { from, response_request_id }`). `handle_unique_reserve_request`
+on a fresh `Reserved` calls `replicate_unique_reserve_remote` and **returns without responding**; the
+tracker sends the deferred `UniqueReserveResponse` (Reserved on majority, Error on timeout via the
+async `sweep_unique_quorum`). The coordinator's existing `await_unique_reserves` therefore becomes
+majority-gated transparently. `record_unique_quorum_ack`/`sweep_unique_quorum` are now async and route
+through `fire_unique_quorum_completion`. Integration test `unique_constraint_cross_node_message_flow`
+drives the full flow (reserve → group-replicate → ack → deferred response). Both the local and remote
+primary reserve paths on the MQTT create path are now majority-durable.
+
+**Remaining P2.c gaps (small tail, documented, not yet gated):**
+- **Secondary create path** (`db_ops` `reserve_unique_local` @ 1347/1630/1785 + `spawn_unique_completion`
+  Path 2): still P2.b fire-and-forget; `db_ops`:683 creates trackers via `start_unique_constraint_check`
+  but Path 2 never awaits `pending_quorum`. Mirror the `combine_quorum` wiring here.
 - **Cosmetic:** a quorum-timeout reuses the 409 "unique constraint violation on field X" message via
-  `combine_quorum`; should be a 503 "reservation not durable". Fix when P2.c-2 threads a distinct
-  durability-failure signal.
+  `combine_quorum`; should be a 503 "reservation not durable" (needs a distinct durability-failure
+  signal into the completion functions).
 
 Then **P2.d+e** (seal + serve-gating).
 

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -273,9 +273,20 @@ Non-breaking — no serve-gate yet.
 **Together, the three P2 mechanisms close B:** (1) seal fences the old primary (epoch-promise at a
 majority ⇒ its stale-epoch group writes are rejected ⇒ its reserves fail closed); (2) the serve-gate
 stops a new primary serving before it has sealed; (3) the monotonic guard prevents any residual
-missed-reservation overwrite. Remaining polish (non-safety): the fail-closed-while-unsealed reserve
-returns a 409 (should be 503/retry), and the P2.c secondary `db_ops` create path is still ungated
-(both tracked in the P2.c tail above).
+missed-reservation overwrite. **Both create paths are gated:** the primary MQTT path
+(`json_ops`/`routing.rs`) and the forwarded cluster path (`db_ops` `reserve_unique_local`, gated on
+`unique_partition_sealed`).
+
+**Remaining polish (non-safety, diminishing value — backstopped by the reconciler + monotonic guard):**
+- The forwarded `db_ops` create path is **gated** but not yet **majority-awaited** (returns before the
+  async group-replicate reaches a majority); a crash in that narrow window is repaired/detected by the
+  reconciler. Full P2.c parity would thread `pending_quorum` through the `db_ops` phase1 +
+  `spawn_unique_completion`, mirroring Path 1.
+- The fail-closed-while-unsealed reserve returns a **409** ("unique constraint violation"); during the
+  brief post-promotion unsealed window this is misleading — a **503**/retry is more accurate (needs a
+  distinct not-durable signal threaded through the reserve return type).
+- Optional: TLA re-check treating the monotonic guard as the `leaderView` substitute; `mqdb dev`
+  multi-node oversell E2E tests (§8).
 
 - **P2.a — Quorum group + majority helpers.** `unique_quorum_group() -> Vec<NodeId>` and
   `unique_majority(n)`. Land together with their first consumer (P2.b) to avoid dead code.

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -313,7 +313,13 @@ the verified `ClusterUniqueQuorum.tla`. **Both create paths are gated:** the pri
   quorum-timeout is a transient 503 the client should retry. Counter-test:
   `unsealed_partition_reserve_is_retryable_not_a_conflict`.
 - **TLA re-check DONE** (caught the monotonic-guard gap → drove the d-2 seal-learning fix above).
-- Optional/remaining: `mqdb dev` multi-node oversell E2E tests (§8) — real-cluster validation.
+- **NoOversell integration test DONE.** `no_oversell_when_new_primary_missed_a_reservation` reproduces
+  the TLA counterexample in the sim cluster: node0 reserves a value for A but the replication reaches
+  only node2; node1 is promoted (epoch 2) and seals; the seal must *learn* A; node1's reserve for a
+  different record B must then Conflict — exactly one record holds the value. Verified as a real
+  regression guard: it **fails** if the d-2 seal-learning merge is removed. (A full-stack `mqdb dev`
+  E2E needs an Enterprise license unavailable in this environment; the sim harness + unit tests + TLA
+  cover the mechanics license-free.)
 
 - **P2.a — Quorum group + majority helpers.** `unique_quorum_group() -> Vec<NodeId>` and
   `unique_majority(n)`. Land together with their first consumer (P2.b) to avoid dead code.

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -26,24 +26,32 @@ Two branches, nothing pushed yet:
   `reassert` exists.
 - Review pass (`c5bc8cc`): fixed the one regression it surfaced (cross-node reserve test now expects
   the replication Write). All core/agent/cluster suites green; clippy clean.
+- Reconcile wiring (this session, all five remaining items — the record-driven reconciler, no
+  cross-partition query needed):
+  1. `UniqueReassertRequest` wire message (BeBytes, msg type 86) + `ClusterMessage` variant +
+     dispatch arm + fire-and-forget `handle_unique_reassert_request` on the value-primary calling
+     `reassert_replicated` + `write_or_forward` + `sync_unique_write` (mirrors `UniqueCommitRequest`).
+     Round-trip test in `protocol/tests.rs`.
+  2. `NodeController::reconcile_unique_claims` (`unique.rs`): iterates this node's durable records
+     for entities with unique constraints, reconciles only records whose *data* partition this node
+     is primary of (so each record is reconciled once); per `(field,value)` routes a reassert
+     (local `reassert_replicated` when value-primary is self, else the message). `Conflict` logged
+     as detected oversell.
+  3. Runs on a dedicated `unique_reconcile_interval` = **10s** (< the 30s reservation TTL) in the
+     cluster-agent event loop — this cadence is the Phase 1 safety condition (a lost commit is
+     re-committed before `cleanup_expired` can reclaim it).
+  4. `unique_cleanup_expired` moved out of the hourly `handle_session_cleanup` into the same 10s
+     `handle_unique_reconcile` handler, run **after** `reconcile_unique_claims` so repair always
+     precedes reclaim in a single tick. `cleanup_expired` still only reclaims *uncommitted*
+     reservations (`unique_store.rs`), so it never touches a committed/re-committed claim.
+  5. Four integration tests in `tests/cluster_integration_test.rs`: reassert re-establishes a lost
+     reservation from the record; reassert repairs a lost commit; abandoned (no record) survives
+     reconcile then is reclaimed by TTL; cross-node `UniqueReassertRequest` establishes on the
+     value-primary. All cluster suites green (615 tests); clippy clean.
 
-**Remaining (the reconcile wiring — the record-driven reconciler, no cross-partition query needed):**
-1. New `UniqueReassertRequest` wire message (BeBytes) + `ClusterMessage` variant + dispatch arm +
-   fire-and-forget handler on the value-primary calling `reassert_replicated` + `write_or_forward` +
-   `sync_unique_write` (mirror `UniqueCommitRequest`/`handle_unique_commit_request`, `unique.rs`).
-2. Reconcile loop: iterate this node's local records with unique fields; per `(field,value)` route a
-   reassert (local `reassert_replicated` when value-primary is self, else send the message); log
-   `ReassertResult::Conflict` as detected oversell.
-3. Wire into the event-loop tick at interval **< the 30s reservation TTL** (`unique.rs` reserves with
-   `ttl_ms: 30_000`) so a lost commit is re-committed before `cleanup_expired` can reclaim it —
-   this cadence is the Phase 1 safety condition.
-4. Step 5: `cleanup_expired` already only reclaims *uncommitted* reservations (`unique_store.rs`);
-   just shorten `CLEANUP_INTERVAL_SECS` (currently 3600, `cluster_agent/mod.rs:26`) to match.
-5. Multi-node integration tests: failover-loses-reservation → reassert re-establishes; lost-commit →
-   reassert repairs; abandoned (no record) → TTL reclaims. Add to `tests/cluster_integration_test.rs`.
-
-After Phase 1: **Phase 2** (epoch-fenced quorum reserve, closes dual-primary — §3/§4, verified in
-`specs/ClusterUniqueQuorum.tla`) and the E2E cluster tests + comprehensive test strategy.
+**Phase 1 is complete.** After Phase 1: **Phase 2** (epoch-fenced quorum reserve, closes dual-primary
+— §3/§4, verified in `specs/ClusterUniqueQuorum.tla`) and the E2E cluster tests + comprehensive test
+strategy.
 
 ## 1. Problem (verified)
 

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -4,6 +4,47 @@ Status: draft for review. Pairs with the TLA models in `specs/ClusterUniqueV2.tl
 (faithful current behaviour, reproduces oversell) and `specs/ClusterUniqueFix.tla`
 (the verified target: safety + liveness).
 
+## 0. Implementation status & resume point (2026-07)
+
+Two branches, nothing pushed yet:
+- `unique-guard-cas` — the **agent-mode** fix (separate, complete): `4cc7900` makes
+  `Database::create`/`update` atomic via an id-free `uniq/entity/field/value` CAS guard key +
+  `expect_absent` storage precondition (see `specs/UniqueGuard.tla`). Ready to PR on its own.
+  Also carries all the cluster TLA specs (`e104649`, `7816e9a`).
+- `cluster-unique-phase1` (branched off the above) — **cluster Phase 1**, in progress.
+
+**Done + tested on `cluster-unique-phase1`:**
+- Step 1 (`638eecf`): cross-node reserve/commit/release now persist + replicate (were in-memory-only).
+- Steps 2–3 (`fdd1a17`): unconditional `StorageBackend::sync()` fsync on durability-critical unique
+  writes (even `flush()` was a no-op under `PeriodicMs`); commit/release response dispatch arms.
+- Reconciler model (`27afb19`, `specs/ClusterUniqueReconciler.tla`): reclaim is a TOCTOU — safe only
+  with a claim-conditional record write (Phase 2) or deadline-gated reclaim (Phase 1). See §5.
+- Reconciler store ops (`b094227`): `UniqueStore::reassert` + `StoreManager::reassert_replicated`
+  (record-driven repair, 5 unit tests). `ReassertResult`: Established/Repaired/AlreadyCommitted/
+  Conflict(oversell)/Pending. **Keyed on record_id, not request_id** — the original create's
+  reservation has request_id=uuid, so a plain reserve+commit can't repair a lost commit; that's why
+  `reassert` exists.
+- Review pass (`c5bc8cc`): fixed the one regression it surfaced (cross-node reserve test now expects
+  the replication Write). All core/agent/cluster suites green; clippy clean.
+
+**Remaining (the reconcile wiring — the record-driven reconciler, no cross-partition query needed):**
+1. New `UniqueReassertRequest` wire message (BeBytes) + `ClusterMessage` variant + dispatch arm +
+   fire-and-forget handler on the value-primary calling `reassert_replicated` + `write_or_forward` +
+   `sync_unique_write` (mirror `UniqueCommitRequest`/`handle_unique_commit_request`, `unique.rs`).
+2. Reconcile loop: iterate this node's local records with unique fields; per `(field,value)` route a
+   reassert (local `reassert_replicated` when value-primary is self, else send the message); log
+   `ReassertResult::Conflict` as detected oversell.
+3. Wire into the event-loop tick at interval **< the 30s reservation TTL** (`unique.rs` reserves with
+   `ttl_ms: 30_000`) so a lost commit is re-committed before `cleanup_expired` can reclaim it —
+   this cadence is the Phase 1 safety condition.
+4. Step 5: `cleanup_expired` already only reclaims *uncommitted* reservations (`unique_store.rs`);
+   just shorten `CLEANUP_INTERVAL_SECS` (currently 3600, `cluster_agent/mod.rs:26`) to match.
+5. Multi-node integration tests: failover-loses-reservation → reassert re-establishes; lost-commit →
+   reassert repairs; abandoned (no record) → TTL reclaims. Add to `tests/cluster_integration_test.rs`.
+
+After Phase 1: **Phase 2** (epoch-fenced quorum reserve, closes dual-primary — §3/§4, verified in
+`specs/ClusterUniqueQuorum.tla`) and the E2E cluster tests + comprehensive test strategy.
+
 ## 1. Problem (verified)
 
 The cluster unique-constraint reservation is a fragile per-node in-memory lock,

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -273,17 +273,27 @@ Non-breaking — no serve-gate yet.
   the member holding the uncommitted claim permits the overwrite (guard is committed-only); both
   records get written. The verified model that holds NoOversell (`ClusterUniqueQuorum.tla`, 3076
   states) has `leaderView` — the seal reading + learning existing reservations. **So d-2 is required.**
+- **d-2 (seal-reservation-learning) — IMPLEMENTED (closes the residual).** An accepting member returns
+  its reservations for the partition in `UniqueSealResponse.reservations`
+  (`UniqueStore::export_for_partition`); the promoting primary merges them
+  (`UniqueStore::merge_for_seal`: learn an absent claim, upgrade uncommitted→committed, never
+  downgrade a committed claim nor change a committed owner) in `handle_unique_seal_response` **before**
+  the seal completes. Because the original reserve was majority-durable and the seal reads a majority,
+  the two quorums intersect, so the promoting primary always learns a reservation it missed — exactly
+  the verified `leaderView` step. Its local CAS then rejects a conflicting reserve. Tests:
+  `merge_for_seal_learns_missing_and_never_downgrades`, `seal_response_teaches_primary_a_missed_reservation`.
+  With this, the implementation matches `ClusterUniqueQuorum.tla`; **dual-primary B is fully closed.**
 - Tests: `unsealed_partition_fails_reserve_closed` (gate), `apply_replicated_rejects_reassigning_committed_value`
   + `apply_replicated_allows_recommit_by_same_record` (guard); `unique_constraint_cross_node_message_flow`
   updated to complete the seal handshake before reserving. Full suite green (506+75+49), clippy clean.
 
 **The three P2 mechanisms close B *except for one TLA-identified residual*:** (1) seal fences the old
 primary (epoch-promise at a majority ⇒ its stale-epoch group writes are rejected ⇒ its reserves fail
-closed); (2) the serve-gate stops a new primary serving before it has sealed; (3) the monotonic guard
-blocks missed-**committed**-reservation overwrite. **Residual (must fix — see the TLA correction
-above): d-2 seal-reservation-learning.** Without it, a new primary that missed an *uncommitted*
-reservation oversells; this is currently **detected** by the reconciler (two committed records →
-`Conflict`) but not **prevented**. **Both create paths are gated:** the primary MQTT path
+closed); (2) the serve-gate stops a new primary serving before it has sealed; (3) **d-2
+seal-reservation-learning** — the seal teaches a promoting primary any reservation it missed, so its
+CAS rejects a conflicting reserve (the `leaderView` step; the monotonic guard remains as a
+member-level backstop for committed values). All four are implemented; the implementation now matches
+the verified `ClusterUniqueQuorum.tla`. **Both create paths are gated:** the primary MQTT path
 (`json_ops`/`routing.rs`) and the forwarded cluster path (`db_ops` `reserve_unique_local`, gated on
 `unique_partition_sealed`).
 

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -179,6 +179,69 @@ first; Phase 2 adds the epoch/quorum/sealing machinery. Under network partition,
 prevents B — Phase 1 can *detect* a dual-commit but not prevent it, because both records are durable
 and committed (§5).
 
+### Phase 2 implementation plan (fixed quorum group) — decided 2026-07
+
+Chosen replica-set model (step 10): **fixed quorum group** — the unique keyspace is replicated to a
+fixed ≥3 group decoupled from data RF, not by raising RF per unique partition. Grounded against
+`specs/ClusterUniqueQuorum.tla`; the TLA→code mapping is:
+
+| TLA | Meaning | Code |
+|---|---|---|
+| `Nodes` | the fixed quorum group | new `unique_quorum_group()` — see membership decision below |
+| `Majorities` | `2·|Q| > |group|` | new `unique_majority()` helper |
+| `promised[n]` | highest epoch replica accepts | **exists**: `ReplicaState.epoch` fence in `handle_write` (`replication.rs:105`) already rejects `write.epoch < epoch` and adopts higher |
+| `actingEpoch[n]` | epoch node believes it's primary at | `ReplicaState.epoch` when role=Primary (from partition map) |
+| `accepted[n]` | reservation the replica holds | that node's `DB_UNIQUE` store content |
+| `sealedAt[n]` | epoch node has sealed | **new** `ReplicaState.sealed_epoch` |
+| `leaderView[n]` | owner the sealed primary learned | the reservation present in the primary's store after the seal-merge |
+| `Seal(n,Q)` | read-majority + epoch-promise before serving | **new** seal round on `become_primary` |
+| `Reserve/Commit(n,r,Q)` | quorum-accept at epoch, gated on sealed | quorum-durable unique write |
+
+**Load-bearing prerequisite (why order matters):** a seal's read-quorum can only *learn* an existing
+reservation, and an epoch-promise can only *land*, if reserve/commit already replicate to the quorum
+group. So the unique partitions must be replicated to **every group member** (each holds
+`ReplicaState` + `DB_UNIQUE` for them) before sealing is meaningful. That reorders the steps vs §4:
+
+- **P2.a — Quorum group + majority helpers.** `unique_quorum_group() -> Vec<NodeId>` and
+  `unique_majority(n)`. Land together with their first consumer (P2.b) to avoid dead code.
+- **P2.b — Replicate the `DB_UNIQUE` keyspace to the group.** **Structural fact (verified,
+  `mqdb-core/src/partition/functions.rs:31`):** `unique_partition(entity,field,value)` hashes into
+  the *same* 256-partition space as `data_partition` — unique reservations are the `DB_UNIQUE`
+  keyspace *within* the ordinary partitions, there is **no** separate set of "unique partitions." So
+  step 10 is not a per-partition RF bump; it is a **per-keyspace replication group**: `DB_UNIQUE`
+  writes for partition P must fan out to the fixed group (all members hold `DB_UNIQUE` for P), while
+  `DB_DATA`/other writes for P keep data RF=2. Consequences: (a) the replication target for a write
+  becomes keyspace-dependent (`entity == DB_UNIQUE` → group; else → partition replicas); (b) a group
+  member must accept a `DB_UNIQUE` write for P even when it is not a data replica of P — so
+  `handle_write`/`ReplicaState` gating (`replication.rs:100`, `replication_ops.rs:29`) must key
+  acceptance on group membership for the `DB_UNIQUE` keyspace, not only partition-replica role;
+  (c) sequence/epoch state for `DB_UNIQUE` must be tracked per (partition, keyspace=unique),
+  separate from the data `ReplicaState.sequence`. Still async, non-gating — a durability-breadth
+  change, but a substantial one (a keyspace-scoped replication group is new machinery).
+- **P2.c — Quorum-durable reserve/commit.** Switch the unique write path to a quorum-tracked send
+  over the group (`replicate_write` + `QuorumTracker`, `replication_ops.rs:213-262`); the create
+  flow returns `Reserved`/`Committed` only after **majority** ack. Fail-closed on no-majority.
+- **P2.d — Seal at promotion.** New `UniqueSealRequest`/`UniqueSealResponse` (BeBytes). On
+  `become_primary` for a unique partition (`mod.rs:503-509`): send seal to the group, collect a
+  **majority** of responses (each carries the replica's promised-epoch ack + its held reservations
+  for the partition), merge learned reservations into the local store, set `sealed_epoch =
+  actingEpoch`. `FenceOk`: a member refuses to promise if it already promised a higher epoch.
+- **P2.e — Gate serving (flips fencing on).** Reserve/commit handlers (`unique.rs:277-352`) fail
+  closed unless `sealed_epoch == actingEpoch` **and** this node is the current-epoch group primary
+  (step 9). Ship P2.d + P2.e together so gating never precedes a working seal (else all unique ops
+  fail closed). `leaderView ≠ NULL` (an existing reservation was learned) ⇒ reserve returns
+  `Conflict` — this is exactly what closes A′/B.
+
+Each of P2.b, P2.c, P2.{d+e} is independently shippable and testable; the model is the oracle for the
+multi-node tests (concurrent same-value create, primary-kill during reserve/commit, induced
+dual-primary partition). **Membership source (resolved):** use the **registered cluster membership**
+already tracked by `HeartbeatManager.nodes` (keyed by node id) plus `local_node` — stable (not the
+fluctuating alive set), reachable from `NodeController` today with no new cross-task plumbing, and
+equal to the metadata-Raft `cluster_members` set in practice (`raft/coordinator/mod.rs:138`). Add a
+`HeartbeatManager` accessor for the full registered set + a `NodeController::unique_quorum_group()`
+wrapper; `unique_majority()` = `⌊|group|/2⌋ + 1`. If the group must ever diverge from Raft
+membership, swap this one accessor.
+
 ## 5. The hard part — abandonment vs record existence, and why B needs prevention
 
 The reserve→record-write→commit sequence has a window: coordinator dies after reserve, maybe after

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -230,13 +230,14 @@ through `fire_unique_quorum_completion`. Integration test `unique_constraint_cro
 drives the full flow (reserve → group-replicate → ack → deferred response). Both the local and remote
 primary reserve paths on the MQTT create path are now majority-durable.
 
-**Remaining P2.c gaps (small tail, documented, not yet gated):**
-- **Secondary create path** (`db_ops` `reserve_unique_local` @ 1347/1630/1785 + `spawn_unique_completion`
-  Path 2): still P2.b fire-and-forget; `db_ops`:683 creates trackers via `start_unique_constraint_check`
-  but Path 2 never awaits `pending_quorum`. Mirror the `combine_quorum` wiring here.
-- **Cosmetic:** a quorum-timeout reuses the 409 "unique constraint violation on field X" message via
-  `combine_quorum`; should be a 503 "reservation not durable" (needs a distinct durability-failure
-  signal into the completion functions).
+**P2.c gaps at this snapshot — both since RESOLVED (see "Follow-ups — all resolved" below):**
+- **Secondary create path** (`db_ops` `reserve_unique_local` + `spawn_unique_completion` Path 2): was
+  P2.b fire-and-forget. Now `reserve_unique_local` threads `pending_quorum` into the `db_ops` create
+  phase1 and `spawn_unique_completion` awaits `await_unique_quorum` before acquiring the lock — gated
+  and majority-awaited on both create paths.
+- **Quorum-timeout status:** a quorum-timeout no longer reuses the 409 message. The
+  `ReserveFailure { Conflict(409), NotDurable(503) }` enum returns a retryable 503 for a not-yet-durable
+  reserve.
 
 **P2.d-1 (seal epoch-promise round) DONE:** `UniqueSealRequest`/`UniqueSealResponse` (types 89/94).
 `become_primary` queues a per-partition seal (`pending_seal_queue`); the event-loop tick drains it
@@ -321,6 +322,39 @@ the verified `ClusterUniqueQuorum.tla`. **Both create paths are gated:** the pri
   E2E needs an Enterprise license unavailable in this environment; the sim harness + unit tests + TLA
   cover the mechanics license-free.)
 
+## Open follow-ups (post-review, 2026-07-11)
+
+Verified by a 3-agent review quorum; none is a happy-path correctness regression. Fixed here:
+concurrent reserve/quorum await, and the remote-reserve timeout reservation leak.
+
+- **Remote-reserve timeout leaked a reservation — FIXED.** `handle_unique_reserve_request` deferred a
+  remote-coordinated reserve via `replicate_unique_reserve_remote`; on quorum timeout it sent `Error`
+  but never released the local reservation it held, wedging the value until its 30s TTL. The
+  `RemoteReserve` completion now carries the claim identity and `fire_unique_quorum_completion`
+  releases it on failure. Counter-test: `remote_reserve_quorum_timeout_releases_local_reservation`.
+- **Sequential reserve/quorum awaits — FIXED.** `combine_quorum` (`routing.rs`) and
+  `spawn_unique_completion` (`event_loop.rs`) awaited `await_unique_reserves` then `await_unique_quorum`
+  sequentially (each ~5s → ~10s worst-case create latency); neither short-circuited the quorum wait.
+  Both now `tokio::join!` the two rounds (max of the deadlines, ~5s). No behavior change — both results
+  were already awaited unconditionally.
+- **Reconciler full-scan cost — OPEN (perf follow-up).** `reconcile_unique_claims` calls
+  `db_data.list(entity)` (which clones every record of the entity, unbounded) and JSON-deserializes
+  each owned record every 10s, and `handle_unique_reconcile` holds the controller **write** lock across
+  the entire scan and its awaited reassert sends — blocking all DB ops on the node for the duration.
+  Cost is O(total records), independent of how many claims actually need repair (normally zero). Fix:
+  scope to owned partitions via `list_for_partition` before cloning, iterate without materializing the
+  full Vec, drop/reacquire the lock in chunks, and/or track a dirty-set instead of full scans.
+- **Dynamic reconfiguration — OPEN (known limitation, out of the verified model).** `unique_quorum_group()`
+  reads `HeartbeatManager::registered_nodes()`, which **grows at runtime**: `receive_heartbeat` inserts a
+  previously-unknown sender, so the group is not actually fixed and does not strictly equal the Raft
+  `cluster_members` set assumed above. If the group grows between a majority-durable reserve and a
+  post-failover seal, the reserve-write-majority and seal-read-majority can be **disjoint**, the new
+  primary never learns the reservation, and case B oversell reappears. The TLA models use a fixed
+  `Nodes` constant, so this is unmodeled. Fix (future): source the quorum group from the Raft
+  `cluster_members` set and gate membership changes through joint-consensus / epoch reconfiguration so no
+  reserve-majority and seal-majority can be disjoint; at minimum stop `receive_heartbeat` from silently
+  expanding the quorum basis.
+
 - **P2.a — Quorum group + majority helpers.** `unique_quorum_group() -> Vec<NodeId>` and
   `unique_majority(n)`. Land together with their first consumer (P2.b) to avoid dead code.
 - **P2.b — Replicate the `DB_UNIQUE` keyspace to the group.** **Structural fact (verified,
@@ -362,13 +396,16 @@ the verified `ClusterUniqueQuorum.tla`. **Both create paths are gated:** the pri
 
 Each of P2.b, P2.c, P2.{d+e} is independently shippable and testable; the model is the oracle for the
 multi-node tests (concurrent same-value create, primary-kill during reserve/commit, induced
-dual-primary partition). **Membership source (resolved):** use the **registered cluster membership**
-already tracked by `HeartbeatManager.nodes` (keyed by node id) plus `local_node` — stable (not the
-fluctuating alive set), reachable from `NodeController` today with no new cross-task plumbing, and
-equal to the metadata-Raft `cluster_members` set in practice (`raft/coordinator/mod.rs:138`). Add a
-`HeartbeatManager` accessor for the full registered set + a `NodeController::unique_quorum_group()`
-wrapper; `unique_majority()` = `⌊|group|/2⌋ + 1`. If the group must ever diverge from Raft
-membership, swap this one accessor.
+dual-primary partition). **Membership source:** use the **registered cluster membership** tracked by
+`HeartbeatManager.nodes` (keyed by node id) plus `local_node` — more stable than the fluctuating alive
+set, reachable from `NodeController` today with no new cross-task plumbing. Add a `HeartbeatManager`
+accessor for the full registered set + a `NodeController::unique_quorum_group()` wrapper;
+`unique_majority()` = `⌊|group|/2⌋ + 1`. **Caveat (not fully stable):** `registered_nodes()` is not a
+fixed set — `receive_heartbeat` inserts a previously-unknown sender, so the group can grow at runtime
+and does not strictly equal the metadata-Raft `cluster_members` set. That is safe under fixed
+membership (what the TLA model verifies) but admits a disjoint-majority oversell if the group grows
+across a reserve→failover-seal window — see "Open follow-ups → Dynamic reconfiguration" above. To close
+it, source the group from Raft `cluster_members` and gate reconfiguration through consensus.
 
 ## 5. The hard part — abandonment vs record existence, and why B needs prevention
 

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -238,7 +238,26 @@ primary reserve paths on the MQTT create path are now majority-durable.
   `combine_quorum`; should be a 503 "reservation not durable" (needs a distinct durability-failure
   signal into the completion functions).
 
-Then **P2.d+e** (seal + serve-gating).
+**P2.d-1 (seal epoch-promise round) DONE:** `UniqueSealRequest`/`UniqueSealResponse` (types 89/94).
+`become_primary` queues a per-partition seal (`pending_seal_queue`); the event-loop tick drains it
+(`drain_pending_seals`) — kept off `become_primary` so that stays sync. `initiate_unique_seal`
+promises this node's epoch for the partition and sends the seal to the group; a member accepts iff
+`epoch >= promised` (then promises it), else rejects (fence). The primary marks
+`unique_sealed[partition] = epoch` once a **majority** accepts (self counts); `sweep_unique_seals`
+retries timed-out seals (liveness). A rejected response means a member already promised a higher
+epoch → this node is superseded → abandon. **Effect:** combined with P2.c majority reserves, the
+epoch promise at a majority already **fences the old primary** — its stale-epoch group writes are
+rejected, so its reserves can't reach a majority and fail closed. Tests: 3 `node_controller` unit
+(single-node seal, majority seal, seal-request fencing) + 2 protocol round-trips + 1 integration
+(`unique_seal_fences_superseded_primary_reserve`). Full suite green (503+75+49), clippy clean.
+Non-breaking — no serve-gate yet.
+
+**P2.d-2 + P2.e remaining:** (d-2) the seal response should also carry the member's reservations so
+the new primary **learns existing owners** (`leaderView`) — needed so it doesn't re-reserve an
+already-taken value it happened to miss; (e) **flip serve-gating on** — the reserve path refuses
+unless `unique_sealed[partition] == acting_epoch` and the learned view shows no existing owner. P2.e
+breaks tests that reserve without sealing first, so ship d-2+e together and update those tests (or
+seal in the harness). This is the final step that fully closes B.
 
 - **P2.a — Quorum group + majority helpers.** `unique_quorum_group() -> Vec<NodeId>` and
   `unique_majority(n)`. Land together with their first consumer (P2.b) to avoid dead code.

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -202,6 +202,14 @@ reservation, and an epoch-promise can only *land*, if reserve/commit already rep
 group. So the unique partitions must be replicated to **every group member** (each holds
 `ReplicaState` + `DB_UNIQUE` for them) before sealing is meaningful. That reorders the steps vs §4:
 
+**Status:** P2.a + P2.b **DONE** (sequence-free group replication landed): `registered_nodes()` on
+`HeartbeatManager` + `unique_quorum_group()`; `UniqueReplicate` wire message (type 87);
+`replicate_unique_to_group` (fan-out on the value-primary, epoch-stamped from the partition
+`ReplicaState`) + epoch-fenced `handle_unique_replicate` receive path gated on per-partition
+`unique_promised`. Non-gating, non-breaking; full cluster suite green + 2 integration tests
+(fan-out, stale-epoch fence) + 1 heartbeat unit test. Next: P2.c (majority-ack) then P2.d+e (seal +
+gate). `unique_majority()` deferred to P2.c (its first consumer).
+
 - **P2.a — Quorum group + majority helpers.** `unique_quorum_group() -> Vec<NodeId>` and
   `unique_majority(n)`. Land together with their first consumer (P2.b) to avoid dead code.
 - **P2.b — Replicate the `DB_UNIQUE` keyspace to the group.** **Structural fact (verified,
@@ -212,15 +220,24 @@ group. So the unique partitions must be replicated to **every group member** (ea
   writes for partition P must fan out to the fixed group (all members hold `DB_UNIQUE` for P), while
   `DB_DATA`/other writes for P keep data RF=2. Consequences: (a) the replication target for a write
   becomes keyspace-dependent (`entity == DB_UNIQUE` → group; else → partition replicas); (b) a group
-  member must accept a `DB_UNIQUE` write for P even when it is not a data replica of P — so
-  `handle_write`/`ReplicaState` gating (`replication.rs:100`, `replication_ops.rs:29`) must key
-  acceptance on group membership for the `DB_UNIQUE` keyspace, not only partition-replica role;
-  (c) sequence/epoch state for `DB_UNIQUE` must be tracked per (partition, keyspace=unique),
-  separate from the data `ReplicaState.sequence`. Still async, non-gating — a durability-breadth
-  change, but a substantial one (a keyspace-scoped replication group is new machinery).
-- **P2.c — Quorum-durable reserve/commit.** Switch the unique write path to a quorum-tracked send
-  over the group (`replicate_write` + `QuorumTracker`, `replication_ops.rs:213-262`); the create
-  flow returns `Reserved`/`Committed` only after **majority** ack. Fail-closed on no-majority.
+  member must accept a `DB_UNIQUE` write for P even when it is not a data replica of P.
+
+  **Mechanism (refined — sequence-free, matches the model exactly).** `ClusterUniqueQuorum.tla` has
+  **no sequence numbers**: `accepted[m]` is just the latest reservation a member holds and
+  `promised[m]` is a pure epoch fence. So the group does **not** need the data path's
+  sequence/catchup/snapshot machinery. `DB_UNIQUE` replicates to the group as **idempotent,
+  epoch-fenced, order-independent** writes: each group member keeps a per-partition
+  `promised_epoch`, accepts a `DB_UNIQUE` write iff `write.epoch >= promised_epoch` (then bumps it),
+  and applies it last-writer-wins by epoch (commit/release are monotonic transitions on a key). A
+  member that misses a message is repaired by the **Phase-1 reconciler** (record-driven reassert) and
+  by the seal's majority read — no catchup/snapshot subsystem, no per-keyspace sequence. This is
+  strictly simpler than a second replication group and is what the verified model actually specifies.
+  New receive path (a `DB_UNIQUE`-keyspace apply that does the epoch-fence, distinct from
+  `ReplicaState::handle_write`'s sequence logic). Still async, non-gating in P2.b.
+- **P2.c — Quorum-durable reserve/commit.** Await a **majority** of group-member acks for the
+  reserve/commit before the create flow returns `Reserved`/`Committed` (a dedicated ack tracker over
+  the group; the sequence-free writes make this a simple per-request majority count, not the
+  sequence-keyed `QuorumTracker`). Fail-closed on no-majority.
 - **P2.d — Seal at promotion.** New `UniqueSealRequest`/`UniqueSealResponse` (BeBytes). On
   `become_primary` for a unique partition (`mod.rs:503-509`): send seal to the group, collect a
   **majority** of responses (each carries the replica's promised-epoch ack + its held reservations

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -1,0 +1,206 @@
+# Cluster Unique-Constraint Hardening — Implementation Plan
+
+Status: draft for review. Pairs with the TLA models in `specs/ClusterUniqueV2.tla`
+(faithful current behaviour, reproduces oversell) and `specs/ClusterUniqueFix.tla`
+(the verified target: safety + liveness).
+
+## 1. Problem (verified)
+
+The cluster unique-constraint reservation is a fragile per-node in-memory lock,
+decoupled from the durable+replicated record. It oversells (two committed records
+share one unique value) through four mechanisms, all reproduced or code-confirmed:
+
+- **A — durability/TTL loss.** Reservations are not fsync'd (`config.rs:20` `PeriodicMs(10)`),
+  async-replicated with no quorum (`session_ops.rs:133-203`), and **cross-node reserves/commits
+  are in-memory-only on the owner** (`unique.rs:299,329,349`, not persisted/replicated). TTL
+  cleanup is hourly and memory-only (`mod.rs:26`, `event_loop.rs:476`). A reservation vanishes
+  while the record persists → re-reserve → oversell.
+- **A′ — promotion gap.** A promoted replica lacks the old primary's unacked reservations.
+- **B — dual-primary.** Heartbeat-timeout failover with no lease (`transport.rs:493-499`): a
+  network-partitioned old primary keeps granting reserves (handler does no ownership/epoch check,
+  `unique.rs:277-316`) while a replica is promoted. Same window in planned rebalance handoff.
+- **commit-loss.** Commit is fire-and-forget, its response has no dispatch arm
+  (`mod.rs:1149-1170` catch-all), no retry, no rollback, no reconciler.
+
+## 2. Target (from `ClusterUniqueFix.tla`)
+
+The unique claim must be **both**:
+- **single-authoritative / consensus-fenced** — a partitioned minority or stale primary cannot
+  create a divergent claim (proven necessary: the unfenced per-node model oversells);
+- **durable** — survives crash/failover/handoff (proven necessary: the fenced-but-not-durable
+  variant oversells on crash).
+
+Plus: TTL becomes GC-of-abandoned-claims only (never reclaims an active/committed claim);
+commit is reliable; the existing **fail-closed on no-primary** behaviour is preserved
+(`unique.rs:111-113`). Liveness (`Resolves`) holds: no value wedges.
+
+## 3. The key decision — where fencing comes from (no per-create Raft)
+
+Constraint: **do not put per-unique-create load on the metadata Raft group.** It exists for rare
+membership/rebalance events; routing every unique claim through it (rejected Option A below) would
+turn a metadata-consensus group into a data-path bottleneck. The metadata Raft is used only for
+what it already does — electing one primary per partition and assigning a monotonic `epoch`.
+
+**Rejected — Option A: route claims through the metadata Raft log.** Correct, but couples
+per-create latency/throughput to the metadata group and total-orders all claims cluster-wide.
+
+**Rejected — Option B (naive): quorum-ack the per-partition replication as-is.** The unique
+partition's replica set is **RF=2**; a 2-of-2 quorum is not fault-tolerant and a 1-of-2 quorum
+cannot fence a partition. Insufficient by itself.
+
+**Recommended — Option C: epoch-fenced, quorum-durable primary-backup.** Fencing comes from the
+*already-Raft-elected* single primary plus an epoch token; durability comes from quorum
+replication — neither adds per-create Raft traffic.
+
+- **Single serializer (unchanged):** the value-partition primary is elected by metadata Raft
+  (`replication.rs:321-407`) and is the sole point that runs the reserve CAS. One primary per
+  epoch ⇒ its local order is authoritative; no multi-writer consensus per claim.
+- **Quorum-durable reserve/commit:** the primary replicates the reservation to a **majority** of
+  the unique-partition replica set and returns success only after majority ack (reuse the existing
+  `replicate_write` + `QuorumTracker`, `replication_ops.rs:213-262`, instead of the async
+  fire-and-forget `replicate_write_async_with_extra`). A minority-partitioned old primary cannot
+  reach a majority ⇒ its reserve **fails** (fenced), and the promoted primary is in the acking
+  majority so it already holds the reservation (closes A′).
+- **Epoch fence:** every reserve/commit carries the primary's epoch; replicas durably reject writes
+  with an epoch below the highest they have seen (today unique writes hardcode `Epoch::ZERO`,
+  `unique_ops.rs:32,61,93` — this must carry the real partition epoch, `map.rs:17`).
+- **Epoch sealing at promotion (the subtle part):** on failover the new primary must install its
+  epoch at a **majority** of replicas (which then reject the old epoch) *before serving reserves*.
+  This one-time, per-failover quorum round — not per create — closes the window where the old
+  primary could still gather a quorum at the stale epoch. Without it, epoch fencing has its own
+  propagation race (see §5).
+- **Replica set for unique partitions must be ≥3** for a meaningful majority (fencing + availability).
+  Either raise RF for unique partitions, or replicate the unique keyspace to a fixed quorum group
+  (e.g. the Raft members) decoupled from data RF. At RF=2 the scheme degrades to fail-closed under
+  partition — safe but less available.
+
+Option C satisfies the verified target — *single-authoritative* (Raft-elected primary + epoch
+fence: a minority/stale primary cannot win) and *durable* (majority quorum survives minority
+failure/failover) — while leaving the metadata Raft load unchanged. It is Option B done correctly.
+The cost is subtlety: it re-implements a slice of consensus (epochs + sealing + quorum) on the
+replication path, so it **must be TLA-modelled explicitly** before coding (§8).
+
+## 4. Phasing
+
+Deliberately incremental — each phase is independently shippable and testable.
+
+### Phase 1 — durability, reliable commit, reconciler (closes A, A′, commit-loss)
+
+Does **not** require consensus reserve; closes the common (single-partition failure / restart /
+timeout) classes and adds oversell *detection*. Leaves dual-primary (B) narrowed but not eliminated.
+
+1. **Persist + replicate every reserve/commit/release**, including the cross-node path. Make the
+   remote handlers (`unique.rs:277-356`) go through the replicated variants
+   (`unique_ops.rs:13-105`), not the in-memory-only ones. This alone removes "in-memory-only
+   remote reservation" (the worst durability gap).
+2. **fsync the unique keyspace** (or use `Immediate` for `DB_UNIQUE`), so a crash doesn't lose an
+   acknowledged reserve (`config.rs:20`, `fjall_backend.rs:34-42`).
+3. **Reliable commit.** Add dispatch arms for `UniqueCommitResponse`/`UniqueReleaseResponse`
+   (`mod.rs:1149-1170`), track acks, retry on timeout, and surface failure instead of dropping it
+   (`unique.rs:217-223,391-421`).
+4. **Reconciler** (new, leader-driven, periodic): for each uncommitted claim past a deadline, and
+   for each committed record lacking a committed claim, reconcile against the **durable record**
+   (the source of truth):
+   - uncommitted claim + record exists → promote claim to committed (repair a lost commit);
+   - uncommitted claim + no record → release (reclaim an abandoned claim);
+   - **two committed records for one value → emit a hard error/metric** (detected oversell; cannot
+     be auto-resolved — see §5).
+   This makes the reconciler the backstop that guarantees `record ⇒ committed-claim` and provides
+   the abandonment liveness the model's `Expire` abstracts.
+5. **Abandonment-based TTL.** Replace the hourly blind cleanup with the reconciler's
+   record-existence check; a claim is only reclaimed when its record is absent past the deadline.
+
+### Phase 2 — epoch-fenced quorum reserve (Option C, closes B)
+
+6. **Carry the real partition epoch** on every unique reserve/commit/release write (replace the
+   hardcoded `Epoch::ZERO`, `unique_ops.rs:32,61,93`); replicas durably reject stale-epoch writes.
+7. **Quorum-durable reserve/commit:** switch the unique write path from
+   `replicate_write_async_with_extra` to the quorum-tracked `replicate_write`
+   (`replication_ops.rs:213-262`); return success only on majority ack. Retire the in-memory-only
+   remote handlers.
+8. **Epoch sealing at promotion:** `become_primary` (`mod.rs:503-509`) must install the new epoch
+   at a majority of the unique-partition replicas and refuse to serve reserves until sealed.
+9. **Ownership check on handlers:** `handle_unique_reserve_request` (`unique.rs:277-316`) rejects if
+   the node is not the current-epoch primary. Not-primary / no-quorum → reserve fails → create
+   rejected (preserves fail-closed).
+10. **Replica set ≥3 for unique partitions** (raise RF or use a fixed quorum group).
+
+Rationale for splitting: Phase 1 removes the failure modes that need no fencing and is safe to ship
+first; Phase 2 adds the epoch/quorum/sealing machinery. Under network partition, only Phase 2
+prevents B — Phase 1 can *detect* a dual-commit but not prevent it, because both records are durable
+and committed (§5).
+
+## 5. The hard part — abandonment vs record existence, and why B needs prevention
+
+The reserve→record-write→commit sequence has a window: coordinator dies after reserve, maybe after
+the record write, before commit. Safety requires: **never reclaim a claim whose record exists**
+(else another claim oversells); liveness requires: **eventually reclaim a claim whose record does
+not exist** (else the value wedges). The only sound discriminator is the durable record itself, so
+reclamation must query the data partition (a different partition, `functions.rs:9,31`). Hence the
+reconciler is not optional — it is the mechanism that ties the fragile claim to the durable record.
+
+Dual-primary (B) cannot be repaired after the fact: two committed records for one value are both
+durable and both acknowledged to clients. Deleting one is destructive and unsafe. Therefore B must
+be **prevented** at reserve time by consensus — which is why Phase 2 (consensus reserve) is
+required for full correctness, and why quorum-over-RF=2 (Option B) is insufficient.
+
+## 6. Component change map
+
+| Component | File | Change |
+|---|---|---|
+| Reserve/commit/release ops | `store_manager/unique_ops.rs` | Phase 1: always persist+replicate. Phase 2: apply via Raft. |
+| Remote handlers | `node_controller/unique.rs:277-356` | Persist+replicate (P1); ownership/epoch check then retire (P2). |
+| Create continuation | `node_controller/mod.rs:1319-1392` | Reliable commit (P1); propose-to-Raft reserve/commit (P2). |
+| Message dispatch | `node_controller/mod.rs:1149-1170` | Add commit/release response arms (P1). |
+| Unique store | `db/unique_store.rs` | Reconciler hooks (P1); become Raft state machine (P2). |
+| Raft commands/apply | `raft/coordinator/replication.rs` | New `Unique*` commands + apply (P2). |
+| Reconciler | new (`store_manager` or `cluster_agent`) | Periodic leader-driven reconcile vs records (P1). |
+| TTL cleanup | `cluster_agent/event_loop.rs:461-493` | Replace hourly blind cleanup with reconciler (P1). |
+| Durability | `cluster_agent/config.rs:20` | fsync/Immediate for `DB_UNIQUE` (P1). |
+
+## 7. Migration & compatibility
+
+- On upgrade, existing on-disk `DB_UNIQUE` reservations are stale/incomplete. Rebuild committed
+  claims from the durable records via the reconciler on first boot (scan records with unique
+  fields, assert committed claims). Version the reservation record format (`UniqueReservation`
+  already carries `version` = 1, `unique_store.rs:13`).
+- Phase 2 changes the reservation authority from the per-partition store to the Raft state; provide
+  a one-time import from the rebuilt store into the Raft log.
+
+## 8. Testing (the model is the oracle)
+
+- Multi-node `mqdb dev` cluster tests driving: concurrent same-value creates; primary kill during
+  reserve/commit; induced network partition (dual-primary); rebalance during in-flight creates.
+  Assert exactly one committed record per value (the `NoOversell` invariant).
+- Reconciler unit tests for each branch (repair / reclaim / detect).
+- **Option C is modelled and verified** in `specs/ClusterUniqueQuorum.tla` (3 nodes, majority
+  quorums, per-node promised-epoch + accepted-reservation, promotion `Seal` = read-quorum +
+  epoch-promise, dual-primary via concurrent `NewEpoch`). Necessity matrix (MaxEpoch=2):
+  `Sealing ∧ Fence ∧ RequireMajority` → **NoOversell holds** (3076 states); dropping **any one**
+  reintroduces oversell — no-seal (promoted primary misses the existing reservation), no-fence
+  (superseded primary accepts at a stale epoch), no-majority (non-intersecting quorums). All three
+  pillars are independently load-bearing and jointly sufficient. Option C thus equals the verified
+  target (`ClusterUniqueFix`) with no per-create Raft.
+- Extend `ClusterUniqueQuorum.tla` toward implementation: model the reconciler's record-existence
+  check explicitly, and (optional) liveness under eventual stability (progress requires a period
+  without primary churn — the standard consensus caveat).
+- Extend the fix model to make the reconciler's record-existence check explicit rather than the
+  `Expire`/`Abandon` abstraction.
+
+## 9. Risks & open questions
+
+- **Option C re-implements a slice of consensus** (epochs + sealing + quorum) on the replication
+  path. This is the main risk: the sealing race (§5) and epoch monotonicity are exactly where such
+  schemes go subtly wrong. Mitigation: the mandatory TLA model (§8) with a "no-seal" negative
+  switch before any code; no per-create Raft is the deliberate trade for this added subtlety.
+- **Replica set size**: unique partitions need ≥3 members for a fault-tolerant, partition-fencing
+  majority. Decide: raise RF for unique partitions, or replicate the unique keyspace to a fixed
+  quorum group decoupled from data RF. At RF=2 the scheme is safe but fail-closed under partition.
+- **Latency**: reserve/commit gain a majority-ack round-trip on the value-partition (not a
+  cluster-wide consensus). Quantify; it only affects unique-constrained creates.
+- **Reconciler cross-partition queries**: cost of checking record existence on the data partition;
+  batch and rate-limit.
+- **Metadata Raft unchanged**: confirm the existing group already spans enough nodes to elect
+  primaries reliably — Option C leans on its epoch/election exactly as today, adding no new load.
+- **Scope**: Phase 1 is a meaningful, low-risk improvement on its own; decide whether Phase 2 is
+  committed up front or gated on Phase 1 results and measured partition-failure risk.

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -202,13 +202,38 @@ reservation, and an epoch-promise can only *land*, if reserve/commit already rep
 group. So the unique partitions must be replicated to **every group member** (each holds
 `ReplicaState` + `DB_UNIQUE` for them) before sealing is meaningful. That reorders the steps vs §4:
 
-**Status:** P2.a + P2.b **DONE** (sequence-free group replication landed): `registered_nodes()` on
-`HeartbeatManager` + `unique_quorum_group()`; `UniqueReplicate` wire message (type 87);
-`replicate_unique_to_group` (fan-out on the value-primary, epoch-stamped from the partition
-`ReplicaState`) + epoch-fenced `handle_unique_replicate` receive path gated on per-partition
-`unique_promised`. Non-gating, non-breaking; full cluster suite green + 2 integration tests
-(fan-out, stale-epoch fence) + 1 heartbeat unit test. Next: P2.c (majority-ack) then P2.d+e (seal +
-gate). `unique_majority()` deferred to P2.c (its first consumer).
+**Status:** P2.a + P2.b + P2.c-1 **DONE**.
+- P2.a/b (sequence-free group replication): `registered_nodes()` on `HeartbeatManager` +
+  `unique_quorum_group()`; `UniqueReplicate` wire message (now `{ request_id, write }`, type 87);
+  `send_unique_replicate` fan-out on the value-primary (epoch-stamped from the partition
+  `ReplicaState`) + epoch-fenced `handle_unique_replicate` receive path gated on per-partition
+  `unique_promised`.
+- P2.c-1 (majority-durable reserve, **primary MQTT create path** = `json_ops` + `routing.rs`):
+  `UniqueReplicateAck` (type 88); per-reserve `UniqueQuorumTracker` (acks/needed/deadline/responder)
+  in `pending_unique_quorum`; `replicate_unique_reserve` returns a `oneshot::Receiver<bool>` that
+  resolves `true` on majority (self counts as one) or `false` on the deadline sweep
+  (`sweep_unique_quorum`, wired into the tick). `start_unique_constraint_check` collects the receivers
+  into `phase1.pending_quorum`; the `json_ops` create/update paths route **any** reserve (mixed *or*
+  all-local) through the async completion (`|| !pending_quorum.is_empty()`); `routing.rs`'
+  `combine_quorum` folds a quorum failure into the existing reserve-failure path → release + reject
+  (fail-closed). Members ack in `handle_unique_replicate` when `request_id != 0`.
+- Tests: 3 `node_controller` unit tests (majority-ack resolves, timeout fails closed, single-node
+  immediate) + prior P2.b tests. Full suite green (498+74+49), clippy clean.
+
+**Remaining P2.c gaps (→ P2.c-2, documented, not yet gated):**
+- **Remote-primary reserve** (coordinator ≠ value primary): `handle_unique_reserve_request` still
+  responds `Reserved` immediately (fire-and-forget group replicate), so that field isn't
+  majority-gated. Fix: defer the `UniqueReserveResponse` until the tracker completes (event-driven
+  completion = send-response), so the coordinator's existing `await_unique_reserves` becomes
+  majority-gated transparently.
+- **Secondary create path** (`db_ops` `reserve_unique_local` @ 1347/1630/1785 + the event-loop Path 2
+  completion): still P2.b fire-and-forget; `db_ops`:683 creates trackers via
+  `start_unique_constraint_check` but Path 2 never awaits `pending_quorum`.
+- **Cosmetic:** a quorum-timeout reuses the 409 "unique constraint violation on field X" message via
+  `combine_quorum`; should be a 503 "reservation not durable". Fix when P2.c-2 threads a distinct
+  durability-failure signal.
+
+Then **P2.d+e** (seal + serve-gating).
 
 - **P2.a — Quorum group + majority helpers.** `unique_quorum_group() -> Vec<NodeId>` and
   `unique_majority(n)`. Land together with their first consumer (P2.b) to avoid dead code.

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -252,12 +252,30 @@ rejected, so its reserves can't reach a majority and fail closed. Tests: 3 `node
 (`unique_seal_fences_superseded_primary_reserve`). Full suite green (503+75+49), clippy clean.
 Non-breaking — no serve-gate yet.
 
-**P2.d-2 + P2.e remaining:** (d-2) the seal response should also carry the member's reservations so
-the new primary **learns existing owners** (`leaderView`) — needed so it doesn't re-reserve an
-already-taken value it happened to miss; (e) **flip serve-gating on** — the reserve path refuses
-unless `unique_sealed[partition] == acting_epoch` and the learned view shows no existing owner. P2.e
-breaks tests that reserve without sealing first, so ship d-2+e together and update those tests (or
-seal in the harness). This is the final step that fully closes B.
+**P2.e (serve-gate) + monotonic guard DONE — Phase 2 core complete, closes B:**
+- **Serve-gate:** both reserve paths (`start_unique_constraint_check` local branch,
+  `handle_unique_reserve_request` remote) refuse unless `unique_partition_sealed(part)` — i.e.
+  `unique_sealed[part] == acting_epoch`. A superseded primary is sealed only at its stale epoch, so
+  it fails closed. `become_primary` seals a single-node group synchronously (`seal_or_queue_unique`,
+  majority 1); multi-node queues, and `tick`/`send_tick_output` now emit the seal requests
+  (`collect_pending_seals` → `TickOutput.seal_requests`) so the handshake completes over normal
+  ticks (agent path uses the async `drain_pending_seals`; both share `prepare_unique_seal`).
+- **Monotonic guard (replaces the d-2 seal-transfer idea):** `UniqueStore::apply_replicated` rejects
+  any Insert/Update that would reassign a **committed** value to a *different* record
+  (`AlreadyCommitted`). This closes the "new primary missed a replicated reservation → higher-epoch
+  reserve LWW-overwrites a committed value" oversell at the **member** level — simpler than having
+  the seal transfer reservations for the primary to learn (`leaderView`), and achieves the same
+  guarantee. A committed claim is final; only its own record's release frees it.
+- Tests: `unsealed_partition_fails_reserve_closed` (gate), `apply_replicated_rejects_reassigning_committed_value`
+  + `apply_replicated_allows_recommit_by_same_record` (guard); `unique_constraint_cross_node_message_flow`
+  updated to complete the seal handshake before reserving. Full suite green (506+75+49), clippy clean.
+
+**Together, the three P2 mechanisms close B:** (1) seal fences the old primary (epoch-promise at a
+majority ⇒ its stale-epoch group writes are rejected ⇒ its reserves fail closed); (2) the serve-gate
+stops a new primary serving before it has sealed; (3) the monotonic guard prevents any residual
+missed-reservation overwrite. Remaining polish (non-safety): the fail-closed-while-unsealed reserve
+returns a 409 (should be 503/retry), and the P2.c secondary `db_ops` create path is still ungated
+(both tracked in the P2.c tail above).
 
 - **P2.a — Quorum group + majority helpers.** `unique_quorum_group() -> Vec<NodeId>` and
   `unique_majority(n)`. Land together with their first consumer (P2.b) to avoid dead code.

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -144,6 +144,21 @@ durable and both acknowledged to clients. Deleting one is destructive and unsafe
 be **prevented** at reserve time by consensus — which is why Phase 2 (consensus reserve) is
 required for full correctness, and why quorum-over-RF=2 (Option B) is insufficient.
 
+**Modelled finding (`specs/ClusterUniqueReconciler.tla`): the reconciler's reclaim is itself a
+TOCTOU.** If it reclaims an uncommitted, record-less claim while the coordinator is *about to* write
+the record, a late unconditional write oversells (verified: `ClaimConditionalWrite=FALSE` → oversell
+in 5 steps). The reclaim is safe **iff** the record write is fenced against a reclaimed claim.
+Two ways to fence it:
+- **Phase 2 (hard):** the record write is claim-conditional — it verifies the claim still holds
+  (CAS) before persisting. Under this, even an aggressive reconciler holds `NoOversell` (verified,
+  56 states).
+- **Phase 1 (deadline discipline):** the reconciler reclaims **only** reservations expired past a
+  safety margin (reuse the existing `expires_at`), and the create flow must abort — never write the
+  record — once its reservation could have expired. This is safe under the operational assumption
+  that a coordinator stalled past the margin aborts; the residual adversarial-stall window is closed
+  by the Phase 2 claim-conditional write. The Phase 1 reconciler is therefore **deadline-gated, not
+  aggressive.**
+
 ## 6. Component change map
 
 | Component | File | Change |
@@ -181,9 +196,12 @@ required for full correctness, and why quorum-over-RF=2 (Option B) is insufficie
   (superseded primary accepts at a stale epoch), no-majority (non-intersecting quorums). All three
   pillars are independently load-bearing and jointly sufficient. Option C thus equals the verified
   target (`ClusterUniqueFix`) with no per-create Raft.
-- Extend `ClusterUniqueQuorum.tla` toward implementation: model the reconciler's record-existence
-  check explicitly, and (optional) liveness under eventual stability (progress requires a period
-  without primary churn — the standard consensus caveat).
+- **Reconciler modelled** in `specs/ClusterUniqueReconciler.tla`: an aggressive reconciler holds
+  `NoOversell` iff the record write is claim-conditional (`ClaimConditionalWrite=TRUE` → 56 states
+  ok; `FALSE` → oversell). Drives the Phase 1 deadline-gated reclaim vs Phase 2 claim-conditional
+  write decision (see §5).
+- (Optional) liveness under eventual stability (progress requires a period without primary churn —
+  the standard consensus caveat).
 - Extend the fix model to make the reconciler's record-existence check explicit rather than the
   `Expire`/`Abandon` abstraction.
 

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -260,20 +260,30 @@ Non-breaking — no serve-gate yet.
   majority 1); multi-node queues, and `tick`/`send_tick_output` now emit the seal requests
   (`collect_pending_seals` → `TickOutput.seal_requests`) so the handshake completes over normal
   ticks (agent path uses the async `drain_pending_seals`; both share `prepare_unique_seal`).
-- **Monotonic guard (replaces the d-2 seal-transfer idea):** `UniqueStore::apply_replicated` rejects
-  any Insert/Update that would reassign a **committed** value to a *different* record
-  (`AlreadyCommitted`). This closes the "new primary missed a replicated reservation → higher-epoch
-  reserve LWW-overwrites a committed value" oversell at the **member** level — simpler than having
-  the seal transfer reservations for the primary to learn (`leaderView`), and achieves the same
-  guarantee. A committed claim is final; only its own record's release frees it.
+- **Monotonic guard:** `UniqueStore::apply_replicated` rejects any Insert/Update that would reassign
+  a **committed** value to a *different* record (`AlreadyCommitted`). A committed claim is final; only
+  its own record's release frees it. This closes the missed-**committed**-reservation overwrite.
+
+  ⚠ **TLA-verified correction (`specs/ClusterUniqueMonotonic.tla`):** the monotonic guard is **NOT** a
+  sufficient substitute for the seal-reservation-transfer (`leaderView` / d-2), contrary to the
+  initial claim. Model-checking the implemented design (seal promises the epoch but does *not* learn
+  reservations; primary serves from its local CAS; members apply under epoch-fence + monotonic guard)
+  **violates NoOversell** in 9 steps: a new primary that **missed an UNCOMMITTED reservation** for V
+  (it wasn't in that reserve's quorum, and the seal transfers nothing) grants V to a different record;
+  the member holding the uncommitted claim permits the overwrite (guard is committed-only); both
+  records get written. The verified model that holds NoOversell (`ClusterUniqueQuorum.tla`, 3076
+  states) has `leaderView` — the seal reading + learning existing reservations. **So d-2 is required.**
 - Tests: `unsealed_partition_fails_reserve_closed` (gate), `apply_replicated_rejects_reassigning_committed_value`
   + `apply_replicated_allows_recommit_by_same_record` (guard); `unique_constraint_cross_node_message_flow`
   updated to complete the seal handshake before reserving. Full suite green (506+75+49), clippy clean.
 
-**Together, the three P2 mechanisms close B:** (1) seal fences the old primary (epoch-promise at a
-majority ⇒ its stale-epoch group writes are rejected ⇒ its reserves fail closed); (2) the serve-gate
-stops a new primary serving before it has sealed; (3) the monotonic guard prevents any residual
-missed-reservation overwrite. **Both create paths are gated:** the primary MQTT path
+**The three P2 mechanisms close B *except for one TLA-identified residual*:** (1) seal fences the old
+primary (epoch-promise at a majority ⇒ its stale-epoch group writes are rejected ⇒ its reserves fail
+closed); (2) the serve-gate stops a new primary serving before it has sealed; (3) the monotonic guard
+blocks missed-**committed**-reservation overwrite. **Residual (must fix — see the TLA correction
+above): d-2 seal-reservation-learning.** Without it, a new primary that missed an *uncommitted*
+reservation oversells; this is currently **detected** by the reconciler (two committed records →
+`Conflict`) but not **prevented**. **Both create paths are gated:** the primary MQTT path
 (`json_ops`/`routing.rs`) and the forwarded cluster path (`db_ops` `reserve_unique_local`, gated on
 `unique_partition_sealed`).
 

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -297,20 +297,23 @@ the verified `ClusterUniqueQuorum.tla`. **Both create paths are gated:** the pri
 (`json_ops`/`routing.rs`) and the forwarded cluster path (`db_ops` `reserve_unique_local`, gated on
 `unique_partition_sealed`).
 
-**Remaining polish (non-safety, diminishing value — backstopped by the reconciler + monotonic guard):**
-- The forwarded `db_ops` create path is now **gated and majority-awaited** for the common case:
-  `reserve_unique_local` threads `pending_quorum` into the `db_ops` create phase1, and
-  `spawn_unique_completion` awaits both `pending_remote` and `pending_quorum` (before acquiring the
-  lock — no deadlock). The **FK-then-unique continuations** (`complete_pending_fk_work`) run *holding*
-  the controller lock, so they can't await the quorum inline (the ack path needs the lock); those
-  rarer reserves stay gated + async-replicated, with the reconciler as the majority-durability
-  backstop. (Closing that would require restructuring `complete_pending_fk_work` to release the lock
-  around the await, like `spawn_unique_completion`.)
-- The fail-closed-while-unsealed reserve returns a **409** ("unique constraint violation"); during the
-  brief post-promotion unsealed window this is misleading — a **503**/retry is more accurate (needs a
-  distinct not-durable signal threaded through the reserve return type).
-- Optional: TLA re-check treating the monotonic guard as the `leaderView` substitute; `mqdb dev`
-  multi-node oversell E2E tests (§8).
+**Follow-ups — all resolved:**
+- The forwarded `db_ops` create path is **gated and majority-awaited**: `reserve_unique_local` threads
+  `pending_quorum` into the `db_ops` create phase1, and `spawn_unique_completion` awaits both
+  `pending_remote` and `pending_quorum` *before* acquiring the lock (no deadlock).
+- **FK-then-unique continuations DONE.** `complete_pending_fk_work` no longer reserves inline under the
+  lock; it runs `start_unique_constraint_check` and returns `FkThenUniqueOutcome::NeedUnique(phase1)`,
+  and `spawn_fk_completion` drops the lock then drives it via `spawn_unique_completion` — so the
+  majority-await runs outside the lock (a deadlock inline; confirmed by a verification pass). This
+  unified the two divergent create paths and also removed a latent up-to-5s stall on the FK path's
+  inline remote-reserve await. Regression test: `fk_then_unique_defers_reserve_to_async_completion`.
+- **409→503 DONE.** A `ReserveFailure { Conflict(409), NotDurable(503) }` enum is threaded through
+  every reserve failure path (sync gate, forwarded path, and the async `await_unique_reserves` /
+  `combine_quorum` completion): a real conflict is a permanent 409, while unsealed / no-primary /
+  quorum-timeout is a transient 503 the client should retry. Counter-test:
+  `unsealed_partition_reserve_is_retryable_not_a_conflict`.
+- **TLA re-check DONE** (caught the monotonic-guard gap → drove the d-2 seal-learning fix above).
+- Optional/remaining: `mqdb dev` multi-node oversell E2E tests (§8) — real-cluster validation.
 
 - **P2.a — Quorum group + majority helpers.** `unique_quorum_group() -> Vec<NodeId>` and
   `unique_majority(n)`. Land together with their first consumer (P2.b) to avoid dead code.

--- a/docs/distributed-design.md
+++ b/docs/distributed-design.md
@@ -1041,6 +1041,11 @@ All cluster messages follow this format (`crates/mqdb-cluster/src/cluster/mqtt_t
 | 83 | `UniqueCommitResponse` | Unique commit response |
 | 84 | `UniqueReleaseRequest` | Release reserved unique value |
 | 85 | `UniqueReleaseResponse` | Unique release response |
+| 86 | `UniqueReassertRequest` | Reconciler: reassert a claim from the durable record |
+| 87 | `UniqueReplicate` | Replicate a `DB_UNIQUE` write to the quorum group (epoch-fenced) |
+| 88 | `UniqueReplicateAck` | Ack of a quorum-group unique write (majority durability) |
+| 89 | `UniqueSealRequest` | Promotion seal: promise epoch + read reservations |
+| 94 | `UniqueSealResponse` | Seal response: accept/reject + learned reservations |
 | 90 | `FkCheckRequest` | FK existence check (create/update) |
 | 91 | `FkCheckResponse` | FK existence check response |
 | 92 | `FkReverseLookupRequest` | FK reverse lookup (delete) |
@@ -2378,7 +2383,7 @@ The following sections may need documentation:
 | `crates/mqdb-cluster/src/cluster/node_controller/fk.rs` | Foreign key constraint protocol |
 | `crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs` | CascadeSideEffect enum, cascade execution, CAS guard |
 | `crates/mqdb-cluster/src/cluster/node_controller/pending.rs` | Pending constraint state tracking, cascade ack bookkeeping |
-| `crates/mqdb-cluster/src/cluster/node_controller/unique.rs` | Unique constraint 2-phase protocol |
+| `crates/mqdb-cluster/src/cluster/node_controller/unique.rs` | Unique constraint: epoch-fenced quorum reserve, promotion seal, and record-driven reconciler (see `docs/design/cluster-unique-hardening.md`) |
 | `crates/mqdb-cluster/src/cluster/store_manager/constraint_ops.rs` | FK reverse index integration, rebuild on constraint add |
 | `crates/mqdb-cluster/src/cluster/store_manager/outbox.rs` | CascadeOutboxPayload, CascadeRemoteOp, _cascade/ prefix |
 | `crates/mqdb-cluster/src/cluster/db/data_store.rs` | FkReverseIndex in-memory data structure |

--- a/specs/ClusterUnique.cfg
+++ b/specs/ClusterUnique.cfg
@@ -1,0 +1,11 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Values = {v1}
+    AllowLostCommit = FALSE
+
+INVARIANTS
+    TypeOK
+    NoDuplicateValue
+    CommittedIsExclusive

--- a/specs/ClusterUnique.tla
+++ b/specs/ClusterUnique.tla
@@ -1,0 +1,95 @@
+------------------------- MODULE ClusterUnique -------------------------
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS Records, Values, AllowLostCommit
+
+NULL == CHOOSE x : x \notin (Records \cup Values)
+
+VARIABLES
+    resvOwner,      \* Values -> Records \cup {NULL} : reservation holder at the value-primary
+    resvCommitted,  \* Values -> BOOLEAN : reservation promoted to permanent
+    recordVal,      \* Records -> Values \cup {NULL} : the record written on the id-primary
+    target,         \* Records -> Values \cup {NULL} : value this writer is claiming
+    phase           \* Records -> {"idle","reserved","written","done","failed"}
+
+vars == << resvOwner, resvCommitted, recordVal, target, phase >>
+
+Phases == {"idle", "reserved", "written", "done", "failed"}
+
+TypeOK ==
+    /\ resvOwner     \in [Values  -> Records \cup {NULL}]
+    /\ resvCommitted \in [Values  -> BOOLEAN]
+    /\ recordVal     \in [Records -> Values  \cup {NULL}]
+    /\ target        \in [Records -> Values  \cup {NULL}]
+    /\ phase         \in [Records -> Phases]
+
+Init ==
+    /\ resvOwner     = [v \in Values  |-> NULL]
+    /\ resvCommitted = [v \in Values  |-> FALSE]
+    /\ recordVal     = [r \in Records |-> NULL]
+    /\ target        = [r \in Records |-> NULL]
+    /\ phase         = [r \in Records |-> "idle"]
+
+Reserve(r, v) ==
+    /\ phase[r] = "idle"
+    /\ resvOwner[v] = NULL
+    /\ resvOwner' = [resvOwner EXCEPT ![v] = r]
+    /\ target'    = [target    EXCEPT ![r] = v]
+    /\ phase'     = [phase     EXCEPT ![r] = "reserved"]
+    /\ UNCHANGED << resvCommitted, recordVal >>
+
+ReserveConflict(r, v) ==
+    /\ phase[r] = "idle"
+    /\ resvOwner[v] # NULL
+    /\ phase' = [phase EXCEPT ![r] = "failed"]
+    /\ UNCHANGED << resvOwner, resvCommitted, recordVal, target >>
+
+WriteRecord(r) ==
+    /\ phase[r] = "reserved"
+    /\ recordVal' = [recordVal EXCEPT ![r] = target[r]]
+    /\ phase'     = [phase     EXCEPT ![r] = "written"]
+    /\ UNCHANGED << resvOwner, resvCommitted, target >>
+
+CommitArrive(r) ==
+    /\ phase[r] = "written"
+    /\ resvOwner[target[r]] = r
+    /\ ~resvCommitted[target[r]]
+    /\ resvCommitted' = [resvCommitted EXCEPT ![target[r]] = TRUE]
+    /\ phase'         = [phase         EXCEPT ![r] = "done"]
+    /\ UNCHANGED << resvOwner, recordVal, target >>
+
+CommitLost(r) ==
+    /\ phase[r] = "written"
+    /\ resvOwner[target[r]] # r
+    /\ phase' = [phase EXCEPT ![r] = "failed"]
+    /\ UNCHANGED << resvOwner, resvCommitted, recordVal, target >>
+
+CanExpire(v) ==
+    \/ AllowLostCommit
+    \/ \A r \in Records : (resvOwner[v] = r => phase[r] \notin {"reserved", "written"})
+
+Expire(v) ==
+    /\ resvOwner[v] # NULL
+    /\ ~resvCommitted[v]
+    /\ CanExpire(v)
+    /\ resvOwner' = [resvOwner EXCEPT ![v] = NULL]
+    /\ UNCHANGED << resvCommitted, recordVal, target, phase >>
+
+Next ==
+    \/ \E r \in Records, v \in Values : Reserve(r, v)
+    \/ \E r \in Records, v \in Values : ReserveConflict(r, v)
+    \/ \E r \in Records : WriteRecord(r)
+    \/ \E r \in Records : CommitArrive(r)
+    \/ \E r \in Records : CommitLost(r)
+    \/ \E v \in Values : Expire(v)
+
+Spec == Init /\ [][Next]_vars
+
+NoDuplicateValue ==
+    \A v \in Values : Cardinality({r \in Records : recordVal[r] = v}) <= 1
+
+CommittedIsExclusive ==
+    \A v \in Values : resvCommitted[v] =>
+        \A r \in Records : (recordVal[r] = v => resvOwner[v] = r)
+
+========================================================================

--- a/specs/ClusterUniqueFix.cfg
+++ b/specs/ClusterUniqueFix.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Values = {v1}
+    Nodes = {n1, n2}
+    Durable = TRUE
+
+INVARIANTS
+    TypeOK
+    NoOversell
+    CommittedExclusive

--- a/specs/ClusterUniqueFix.tla
+++ b/specs/ClusterUniqueFix.tla
@@ -1,0 +1,156 @@
+----------------------- MODULE ClusterUniqueFix -----------------------
+\* Proposed fix: the unique claim is a durable, single-authoritative, consensus-backed CAS
+\* (not a per-node in-memory lock). Node crash / failover / dual-belief no longer create
+\* divergent or lost claim state. TTL reclaims only ABANDONED claims (owner failed before a
+\* durable record), never an active or committed one.
+\*
+\* Same adversarial events as ClusterUniqueV2 (Crash, PromoteEmpty, DualBelieve, Expire) —
+\* the claim state is immune to them, so NoOversell must hold.
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS Records, Values, Nodes, Durable
+
+NULL == CHOOSE x : x \notin (Records \cup Values \cup Nodes)
+
+VARIABLES
+    believes,       \* [Nodes -> BOOLEAN] : node-local primary belief (adversarial; irrelevant to the claim)
+    claimOwner,     \* [Values -> Records \cup {NULL}] : single authoritative durable claim
+    claimCommitted, \* [Values -> BOOLEAN]
+    recordVal,      \* [Records -> Values \cup {NULL}] : durable record
+    target,         \* [Records -> Values \cup {NULL}]
+    phase           \* [Records -> {"idle","routed","written","done","failed"}]
+
+vars == << believes, claimOwner, claimCommitted, recordVal, target, phase >>
+
+Phases == {"idle", "routed", "written", "done", "failed"}
+
+TypeOK ==
+    /\ believes       \in [Nodes -> BOOLEAN]
+    /\ claimOwner      \in [Values -> Records \cup {NULL}]
+    /\ claimCommitted  \in [Values -> BOOLEAN]
+    /\ recordVal       \in [Records -> Values \cup {NULL}]
+    /\ target          \in [Records -> Values \cup {NULL}]
+    /\ phase           \in [Records -> Phases]
+
+InitialPrimary == CHOOSE n \in Nodes : TRUE
+
+Init ==
+    /\ believes       = [n \in Nodes |-> n = InitialPrimary]
+    /\ claimOwner      = [v \in Values |-> NULL]
+    /\ claimCommitted  = [v \in Values |-> FALSE]
+    /\ recordVal       = [r \in Records |-> NULL]
+    /\ target          = [r \in Records |-> NULL]
+    /\ phase           = [r \in Records |-> "idle"]
+
+\* Reserve is a consensus CAS on the single authoritative claim. A minority-partitioned node
+\* cannot complete it (no quorum) -> there is only ever one claim slot per value.
+Reserve(r, v) ==
+    /\ phase[r] = "idle"
+    /\ claimOwner[v] = NULL
+    /\ claimOwner' = [claimOwner EXCEPT ![v] = r]
+    /\ target'     = [target     EXCEPT ![r] = v]
+    /\ phase'      = [phase      EXCEPT ![r] = "routed"]
+    /\ UNCHANGED << believes, claimCommitted, recordVal >>
+
+ReserveConflict(r, v) ==
+    /\ phase[r] = "idle"
+    /\ claimOwner[v] # NULL
+    /\ phase' = [phase EXCEPT ![r] = "failed"]
+    /\ UNCHANGED << believes, claimOwner, claimCommitted, recordVal, target >>
+
+WriteRecord(r) ==
+    /\ phase[r] = "routed"
+    /\ recordVal' = [recordVal EXCEPT ![r] = target[r]]
+    /\ phase'     = [phase     EXCEPT ![r] = "written"]
+    /\ UNCHANGED << believes, claimOwner, claimCommitted, target >>
+
+\* Reliable commit through the same consensus object.
+Commit(r) ==
+    /\ phase[r] = "written"
+    /\ claimOwner[target[r]] = r
+    /\ ~claimCommitted[target[r]]
+    /\ claimCommitted' = [claimCommitted EXCEPT ![target[r]] = TRUE]
+    /\ phase'          = [phase EXCEPT ![r] = "done"]
+    /\ UNCHANGED << believes, claimOwner, recordVal, target >>
+
+\* Owner crashes AFTER reserve but BEFORE writing a durable record: the claim is abandoned.
+Abandon(r) ==
+    /\ phase[r] = "routed"
+    /\ phase' = [phase EXCEPT ![r] = "failed"]
+    /\ UNCHANGED << believes, claimOwner, claimCommitted, recordVal, target >>
+
+\* TTL reclaims ONLY an abandoned, uncommitted claim (owner failed with no durable record).
+\* It can never steal an active (routed/written) or committed claim.
+Expire(v) ==
+    /\ claimOwner[v] # NULL
+    /\ ~claimCommitted[v]
+    /\ phase[claimOwner[v]] = "failed"
+    /\ claimOwner' = [claimOwner EXCEPT ![v] = NULL]
+    /\ UNCHANGED << believes, claimCommitted, recordVal, target, phase >>
+
+\* --- Adversarial node events: manipulate belief only; claim state is consensus-durable. ---
+
+\* Durable=TRUE: the authoritative claim survives crash (consensus/quorum durability).
+\* Durable=FALSE: the claim is lost on crash (fenced but NOT durable) -- reintroduces class A.
+Crash(n) ==
+    /\ believes[n]
+    /\ believes' = [believes EXCEPT ![n] = FALSE]
+    /\ claimOwner'     = IF Durable THEN claimOwner ELSE [v \in Values |-> NULL]
+    /\ claimCommitted' = IF Durable THEN claimCommitted ELSE [v \in Values |-> FALSE]
+    /\ UNCHANGED << recordVal, target, phase >>
+
+PromoteEmpty(n) ==
+    /\ ~believes[n]
+    /\ believes' = [believes EXCEPT ![n] = TRUE]
+    /\ UNCHANGED << claimOwner, claimCommitted, recordVal, target, phase >>
+
+DualBelieve(n) ==
+    /\ ~believes[n]
+    /\ \E m \in Nodes : m # n /\ believes[m]
+    /\ believes' = [believes EXCEPT ![n] = TRUE]
+    /\ UNCHANGED << claimOwner, claimCommitted, recordVal, target, phase >>
+
+Next ==
+    \/ \E r \in Records, v \in Values : Reserve(r, v)
+    \/ \E r \in Records, v \in Values : ReserveConflict(r, v)
+    \/ \E r \in Records : WriteRecord(r)
+    \/ \E r \in Records : Commit(r)
+    \/ \E r \in Records : Abandon(r)
+    \/ \E v \in Values : Expire(v)
+    \/ \E n \in Nodes : Crash(n)
+    \/ \E n \in Nodes : PromoteEmpty(n)
+    \/ \E n \in Nodes : DualBelieve(n)
+
+Spec == Init /\ [][Next]_vars
+
+NoOversell ==
+    \A v \in Values : Cardinality({r \in Records : recordVal[r] = v}) <= 1
+
+\* A committed claim implies its record is the unique holder of that value.
+CommittedExclusive ==
+    \A v \in Values : claimCommitted[v] =>
+        \A r \in Records : (recordVal[r] = v => claimOwner[v] = r)
+
+\* --- Liveness: no value is wedged forever ---
+\* The system makes progress (records write + commit) and the GC reaps abandoned claims.
+\* Crash/Promote/DualBelieve/Abandon are failure events and are deliberately NOT forced.
+Fairness ==
+    /\ WF_vars(\E r \in Records : WriteRecord(r))
+    /\ WF_vars(\E r \in Records : Commit(r))
+    /\ WF_vars(\E v \in Values : Expire(v))
+
+FairSpec == Init /\ [][Next]_vars /\ Fairness
+
+\* Every claimed-but-uncommitted value eventually either commits or is released.
+Resolves ==
+    \A v \in Values :
+        (claimOwner[v] # NULL /\ ~claimCommitted[v])
+            ~> (claimCommitted[v] \/ claimOwner[v] = NULL)
+
+\* Negative control: a free value need NOT ever become committed (nobody is forced to claim).
+\* This MUST be reported as a liveness violation, proving leads-to is really being evaluated.
+NegControl ==
+    \A v \in Values : (claimOwner[v] = NULL) ~> claimCommitted[v]
+
+========================================================================

--- a/specs/ClusterUniqueFix_live.cfg
+++ b/specs/ClusterUniqueFix_live.cfg
@@ -1,0 +1,10 @@
+SPECIFICATION FairSpec
+
+CONSTANTS
+    Records = {r1, r2}
+    Values = {v1}
+    Nodes = {n1, n2}
+    Durable = TRUE
+
+PROPERTIES
+    Resolves

--- a/specs/ClusterUniqueFix_neg.cfg
+++ b/specs/ClusterUniqueFix_neg.cfg
@@ -1,0 +1,10 @@
+SPECIFICATION FairSpec
+
+CONSTANTS
+    Records = {r1, r2}
+    Values = {v1}
+    Nodes = {n1, n2}
+    Durable = TRUE
+
+PROPERTIES
+    NegControl

--- a/specs/ClusterUniqueMonotonic.cfg
+++ b/specs/ClusterUniqueMonotonic.cfg
@@ -1,0 +1,10 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Nodes = {n1, n2, n3}
+    MaxEpoch = 2
+
+INVARIANTS
+    TypeOK
+    NoOversell

--- a/specs/ClusterUniqueMonotonic.tla
+++ b/specs/ClusterUniqueMonotonic.tla
@@ -1,0 +1,134 @@
+---------------------- MODULE ClusterUniqueMonotonic ----------------------
+\* Faithful model of the IMPLEMENTED Phase 2 (no leaderView seal-transfer):
+\*   - Seal promises the epoch at a majority but does NOT learn/merge reservations.
+\*   - The primary serves a reserve using only its LOCAL view (its own accepted slot):
+\*       PrimaryCasOk(n,r): the primary's slot is empty or already owned by r.
+\*     A new primary that MISSED an earlier reserve has accepted[n]=NULL -> CAS passes.
+\*   - Members apply under the epoch fence PLUS the monotonic-committed guard
+\*       MonotonicOk(Q,r): no member in Q holds a COMMITTED claim for a different owner.
+\* Question: is (seal-promise + primary-local-CAS + epoch-fence + monotonic-committed guard),
+\* WITHOUT leaderView reservation-learning, enough for NoOversell?
+\*
+\* RESULT: NO. NoOversell is VIOLATED even with `n \in Q` (primary applies locally). Counterexample:
+\*   n1@e1 reserves r1 at {n1,n3}; n2 promoted to e2, seals at {n1,n2} but MISSED r1 (not in its
+\*   quorum) and the seal does not transfer reservations; n2 reserves r2 at {n1,n2} -- its local CAS
+\*   sees NULL and n1 holds r1 only UNCOMMITTED so the monotonic guard permits the overwrite; both
+\*   records are written. This proves the seal MUST learn existing reservations (leaderView / the
+\*   d-2 seal-reservation-transfer). The monotonic-committed guard alone is NOT a sufficient
+\*   substitute; ClusterUniqueQuorum.tla (with leaderView) is the model that holds NoOversell.
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS Records, Nodes, MaxEpoch
+
+NULL == CHOOSE x : x \notin (Records \cup Nodes)
+
+Majorities == {Q \in SUBSET Nodes : 2 * Cardinality(Q) > Cardinality(Nodes)}
+
+VARIABLES
+    promised,     \* [Nodes -> 0..MaxEpoch]
+    accepted,     \* [Nodes -> NULL | [epoch, owner, committed]]
+    actingEpoch,  \* [Nodes -> 0..MaxEpoch]
+    sealedAt,     \* [Nodes -> 0..MaxEpoch]
+    curEpoch,
+    recordHeld,
+    phase
+
+vars == << promised, accepted, actingEpoch, sealedAt, curEpoch, recordHeld, phase >>
+
+Phases == {"idle", "routed", "written", "done", "failed"}
+ResvType == [epoch : 1..MaxEpoch, owner : Records, committed : BOOLEAN]
+
+TypeOK ==
+    /\ promised     \in [Nodes -> 0..MaxEpoch]
+    /\ accepted     \in [Nodes -> (ResvType \cup {NULL})]
+    /\ actingEpoch  \in [Nodes -> 0..MaxEpoch]
+    /\ sealedAt     \in [Nodes -> 0..MaxEpoch]
+    /\ curEpoch     \in 0..MaxEpoch
+    /\ recordHeld   \in [Records -> BOOLEAN]
+    /\ phase        \in [Records -> Phases]
+
+Init ==
+    /\ promised     = [n \in Nodes |-> 0]
+    /\ accepted     = [n \in Nodes |-> NULL]
+    /\ actingEpoch  = [n \in Nodes |-> 0]
+    /\ sealedAt     = [n \in Nodes |-> 0]
+    /\ curEpoch     = 0
+    /\ recordHeld   = [r \in Records |-> FALSE]
+    /\ phase        = [r \in Records |-> "idle"]
+
+FenceOk(Q, e) == \A q \in Q : promised[q] <= e
+
+\* Primary's local CAS: its own slot must be free or already its own claim (missed writes => NULL).
+PrimaryCasOk(n, r) == accepted[n] = NULL \/ accepted[n].owner = r
+
+\* Member monotonic guard: a member never lets a COMMITTED value be reassigned to a different owner.
+MonotonicOk(Q, r) ==
+    \A m \in Q : accepted[m] = NULL \/ ~accepted[m].committed \/ accepted[m].owner = r
+
+NewEpoch(n) ==
+    /\ curEpoch < MaxEpoch
+    /\ curEpoch' = curEpoch + 1
+    /\ actingEpoch' = [actingEpoch EXCEPT ![n] = curEpoch + 1]
+    /\ UNCHANGED << promised, accepted, sealedAt, recordHeld, phase >>
+
+\* Seal: promise this epoch at a majority. NO reservation learning (unlike ClusterUniqueQuorum).
+Seal(n, Q) ==
+    /\ actingEpoch[n] > 0
+    /\ sealedAt[n] < actingEpoch[n]
+    /\ Q \in Majorities
+    /\ FenceOk(Q, actingEpoch[n])
+    /\ promised'   = [m \in Nodes |-> IF m \in Q THEN actingEpoch[n] ELSE promised[m]]
+    /\ sealedAt'   = [sealedAt EXCEPT ![n] = actingEpoch[n]]
+    /\ UNCHANGED << accepted, actingEpoch, curEpoch, recordHeld, phase >>
+
+Reserve(n, r, Q) ==
+    /\ phase[r] = "idle"
+    /\ actingEpoch[n] > 0
+    /\ sealedAt[n] = actingEpoch[n]
+    /\ n \in Q
+    /\ PrimaryCasOk(n, r)
+    /\ Q \in Majorities
+    /\ FenceOk(Q, actingEpoch[n])
+    /\ MonotonicOk(Q, r)
+    /\ accepted'   = [m \in Nodes |-> IF m \in Q
+                          THEN [epoch |-> actingEpoch[n], owner |-> r, committed |-> FALSE]
+                          ELSE accepted[m]]
+    /\ promised'   = [m \in Nodes |-> IF m \in Q THEN actingEpoch[n] ELSE promised[m]]
+    /\ phase'      = [phase EXCEPT ![r] = "routed"]
+    /\ UNCHANGED << actingEpoch, sealedAt, curEpoch, recordHeld >>
+
+WriteRecord(r) ==
+    /\ phase[r] = "routed"
+    /\ recordHeld' = [recordHeld EXCEPT ![r] = TRUE]
+    /\ phase'      = [phase EXCEPT ![r] = "written"]
+    /\ UNCHANGED << promised, accepted, actingEpoch, sealedAt, curEpoch >>
+
+Commit(n, r, Q) ==
+    /\ phase[r] = "written"
+    /\ actingEpoch[n] > 0
+    /\ sealedAt[n] = actingEpoch[n]
+    /\ n \in Q
+    /\ PrimaryCasOk(n, r)
+    /\ Q \in Majorities
+    /\ FenceOk(Q, actingEpoch[n])
+    /\ MonotonicOk(Q, r)
+    /\ accepted' = [m \in Nodes |-> IF m \in Q
+                        THEN [epoch |-> actingEpoch[n], owner |-> r, committed |-> TRUE]
+                        ELSE accepted[m]]
+    /\ promised' = [m \in Nodes |-> IF m \in Q THEN actingEpoch[n] ELSE promised[m]]
+    /\ phase'    = [phase EXCEPT ![r] = "done"]
+    /\ UNCHANGED << actingEpoch, sealedAt, curEpoch, recordHeld >>
+
+Next ==
+    \/ \E n \in Nodes : NewEpoch(n)
+    \/ \E n \in Nodes, Q \in Majorities : Seal(n, Q)
+    \/ \E n \in Nodes, r \in Records, Q \in Majorities : Reserve(n, r, Q)
+    \/ \E r \in Records : WriteRecord(r)
+    \/ \E n \in Nodes, r \in Records, Q \in Majorities : Commit(n, r, Q)
+
+Spec == Init /\ [][Next]_vars
+
+NoOversell == Cardinality({r \in Records : recordHeld[r]}) <= 1
+
+========================================================================

--- a/specs/ClusterUniqueQuorum.cfg
+++ b/specs/ClusterUniqueQuorum.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Nodes = {n1, n2, n3}
+    MaxEpoch = 2
+    Sealing = TRUE
+    Fence = TRUE
+    RequireMajority = TRUE
+
+INVARIANTS
+    TypeOK
+    NoOversell

--- a/specs/ClusterUniqueQuorum.tla
+++ b/specs/ClusterUniqueQuorum.tla
@@ -1,0 +1,141 @@
+---------------------- MODULE ClusterUniqueQuorum ----------------------
+\* Option C: epoch-fenced, quorum-durable primary-backup for the unique claim.
+\* No per-create Raft: the metadata layer (abstracted by NewEpoch) only hands a single
+\* primary a fresh monotonic epoch. Fencing + durability come from the replication path:
+\*   - a primary must SEAL at promotion (read a majority + promise its epoch) before serving;
+\*   - reserve/commit are quorum-durable (a majority accept, gated by the epoch promise).
+\* Single contended value (v1) modelled implicitly. Records = concurrent claimers.
+\*
+\* Sealing = TRUE  -> the full mechanism: expect NoOversell to hold.
+\* Sealing = FALSE -> primaries serve without the read-quorum seal: expect oversell
+\*                    (a promoted primary never learns the existing reservation).
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS Records, Nodes, MaxEpoch, Sealing, Fence, RequireMajority
+
+NULL == CHOOSE x : x \notin (Records \cup Nodes)
+
+Majorities == {Q \in SUBSET Nodes : 2 * Cardinality(Q) > Cardinality(Nodes)}
+
+\* The eligible quorum sets. RequireMajority=FALSE lets any non-empty set act as a "quorum"
+\* (non-intersecting quorums) -- used to show majority intersection is load-bearing.
+QuorumSets == IF RequireMajority THEN Majorities ELSE {Q \in SUBSET Nodes : Q # {}}
+
+VARIABLES
+    promised,     \* [Nodes -> 0..MaxEpoch] : highest epoch a replica has promised
+    accepted,     \* [Nodes -> NULL | [epoch, owner, committed]] : reservation the replica holds
+    actingEpoch,  \* [Nodes -> 0..MaxEpoch] : epoch at which a node believes itself primary (0 = none)
+    sealedAt,     \* [Nodes -> 0..MaxEpoch] : epoch a node has sealed (read-quorum + promise)
+    leaderView,   \* [Nodes -> Records | NULL] : owner the sealed primary believes holds v1
+    curEpoch,     \* 0..MaxEpoch : highest epoch handed out by the metadata layer
+    recordHeld,   \* [Records -> BOOLEAN] : durable record written for v1
+    phase         \* [Records -> {"idle","routed","written","done","failed"}]
+
+vars == << promised, accepted, actingEpoch, sealedAt, leaderView, curEpoch, recordHeld, phase >>
+
+Phases == {"idle", "routed", "written", "done", "failed"}
+ResvType == [epoch : 1..MaxEpoch, owner : Records, committed : BOOLEAN]
+
+TypeOK ==
+    /\ promised     \in [Nodes -> 0..MaxEpoch]
+    /\ accepted     \in [Nodes -> (ResvType \cup {NULL})]
+    /\ actingEpoch  \in [Nodes -> 0..MaxEpoch]
+    /\ sealedAt     \in [Nodes -> 0..MaxEpoch]
+    /\ leaderView   \in [Nodes -> Records \cup {NULL}]
+    /\ curEpoch     \in 0..MaxEpoch
+    /\ recordHeld   \in [Records -> BOOLEAN]
+    /\ phase        \in [Records -> Phases]
+
+Init ==
+    /\ promised     = [n \in Nodes |-> 0]
+    /\ accepted     = [n \in Nodes |-> NULL]
+    /\ actingEpoch  = [n \in Nodes |-> 0]
+    /\ sealedAt     = [n \in Nodes |-> 0]
+    /\ leaderView   = [n \in Nodes |-> NULL]
+    /\ curEpoch     = 0
+    /\ recordHeld   = [r \in Records |-> FALSE]
+    /\ phase        = [r \in Records |-> "idle"]
+
+\* The epoch-fence guard: an accept/seal at epoch e is allowed only if no node in Q has
+\* promised a higher epoch. Fence=FALSE drops it -- used to show fencing is load-bearing.
+FenceOk(Q, e) == Fence => (\A q \in Q : promised[q] <= e)
+
+\* Highest-epoch reservation a read-quorum Q discovers (the Paxos "learn" step).
+Owner(q) == IF accepted[q] = NULL THEN NULL ELSE accepted[q].owner
+Ep(q)    == IF accepted[q] = NULL THEN 0    ELSE accepted[q].epoch
+
+LearnView(Q) ==
+    LET S == {q \in Q : accepted[q] # NULL}
+    IN IF S = {} THEN NULL
+       ELSE Owner(CHOOSE q \in S : \A o \in S : Ep(q) >= Ep(o))
+
+\* Metadata layer elects n as primary at a fresh, strictly-higher epoch.
+NewEpoch(n) ==
+    /\ curEpoch < MaxEpoch
+    /\ curEpoch' = curEpoch + 1
+    /\ actingEpoch' = [actingEpoch EXCEPT ![n] = curEpoch + 1]
+    /\ UNCHANGED << promised, accepted, sealedAt, leaderView, recordHeld, phase >>
+
+\* Promotion seal: read a majority + promise this epoch, before serving.
+Seal(n, Q) ==
+    /\ Sealing
+    /\ actingEpoch[n] > 0
+    /\ sealedAt[n] < actingEpoch[n]
+    /\ Q \in QuorumSets
+    /\ FenceOk(Q, actingEpoch[n])
+    /\ promised'   = [m \in Nodes |-> IF m \in Q THEN actingEpoch[n] ELSE promised[m]]
+    /\ leaderView' = [leaderView EXCEPT ![n] = LearnView(Q)]
+    /\ sealedAt'   = [sealedAt EXCEPT ![n] = actingEpoch[n]]
+    /\ UNCHANGED << accepted, actingEpoch, curEpoch, recordHeld, phase >>
+
+\* Reserve v1 for record r: quorum accept at the primary's epoch.
+Reserve(n, r, Q) ==
+    /\ phase[r] = "idle"
+    /\ actingEpoch[n] > 0
+    /\ (Sealing => sealedAt[n] = actingEpoch[n])
+    /\ leaderView[n] = NULL
+    /\ Q \in QuorumSets
+    /\ FenceOk(Q, actingEpoch[n])
+    /\ accepted'   = [m \in Nodes |-> IF m \in Q
+                          THEN [epoch |-> actingEpoch[n], owner |-> r, committed |-> FALSE]
+                          ELSE accepted[m]]
+    /\ promised'   = [m \in Nodes |-> IF m \in Q THEN actingEpoch[n] ELSE promised[m]]
+    /\ leaderView' = [leaderView EXCEPT ![n] = r]
+    /\ phase'      = [phase EXCEPT ![r] = "routed"]
+    /\ UNCHANGED << actingEpoch, sealedAt, curEpoch, recordHeld >>
+
+\* The durable record is written only after a successful majority reserve.
+WriteRecord(r) ==
+    /\ phase[r] = "routed"
+    /\ recordHeld' = [recordHeld EXCEPT ![r] = TRUE]
+    /\ phase'      = [phase EXCEPT ![r] = "written"]
+    /\ UNCHANGED << promised, accepted, actingEpoch, sealedAt, leaderView, curEpoch >>
+
+\* Commit promotes the reservation to permanent via a quorum accept.
+Commit(n, r, Q) ==
+    /\ phase[r] = "written"
+    /\ actingEpoch[n] > 0
+    /\ (Sealing => sealedAt[n] = actingEpoch[n])
+    /\ leaderView[n] = r
+    /\ Q \in QuorumSets
+    /\ FenceOk(Q, actingEpoch[n])
+    /\ accepted' = [m \in Nodes |-> IF m \in Q
+                        THEN [epoch |-> actingEpoch[n], owner |-> r, committed |-> TRUE]
+                        ELSE accepted[m]]
+    /\ promised' = [m \in Nodes |-> IF m \in Q THEN actingEpoch[n] ELSE promised[m]]
+    /\ phase'    = [phase EXCEPT ![r] = "done"]
+    /\ UNCHANGED << actingEpoch, sealedAt, leaderView, curEpoch, recordHeld >>
+
+Next ==
+    \/ \E n \in Nodes : NewEpoch(n)
+    \/ \E n \in Nodes, Q \in QuorumSets : Seal(n, Q)
+    \/ \E n \in Nodes, r \in Records, Q \in QuorumSets : Reserve(n, r, Q)
+    \/ \E r \in Records : WriteRecord(r)
+    \/ \E n \in Nodes, r \in Records, Q \in QuorumSets : Commit(n, r, Q)
+
+Spec == Init /\ [][Next]_vars
+
+NoOversell == Cardinality({r \in Records : recordHeld[r]}) <= 1
+
+========================================================================

--- a/specs/ClusterUniqueReconciler.cfg
+++ b/specs/ClusterUniqueReconciler.cfg
@@ -1,0 +1,10 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    ClaimConditionalWrite = TRUE
+
+INVARIANTS
+    TypeOK
+    NoOversell
+    CommittedConsistent

--- a/specs/ClusterUniqueReconciler.tla
+++ b/specs/ClusterUniqueReconciler.tla
@@ -1,0 +1,119 @@
+--------------------- MODULE ClusterUniqueReconciler ---------------------
+\* Models the Phase 1 reconciler: a leader-driven repair loop that reconciles the
+\* (durable) unique claim against the durable record. Focus: the reconciler must NEVER
+\* cause oversell. Its subtle hazard is a TOCTOU -- reclaiming an uncommitted, record-less
+\* claim exactly while the coordinator is about to write the record.
+\*
+\* Switch ClaimConditionalWrite:
+\*   TRUE  -> the record write verifies the claim is still held (CAS): expect NoOversell to hold
+\*            even under an aggressive reconciler.
+\*   FALSE -> the record write is unconditional (today's db_create): expect oversell.
+\*
+\* Single contended value, modelled implicitly. Records = concurrent claimers.
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS Records, ClaimConditionalWrite
+
+NULL == CHOOSE x : x \notin Records
+
+VARIABLES
+    claimOwner,      \* Records \cup {NULL} : holder of the (durable) claim for the value
+    claimCommitted,  \* BOOLEAN : claim promoted to permanent
+    recordExists,    \* [Records -> BOOLEAN] : durable record written on the data partition
+    phase            \* [Records -> {"idle","reserved","recorded","done","failed","abandoned"}]
+
+vars == << claimOwner, claimCommitted, recordExists, phase >>
+
+Phases == {"idle", "reserved", "recorded", "done", "failed", "abandoned"}
+
+TypeOK ==
+    /\ claimOwner     \in Records \cup {NULL}
+    /\ claimCommitted \in BOOLEAN
+    /\ recordExists   \in [Records -> BOOLEAN]
+    /\ phase          \in [Records -> Phases]
+
+Init ==
+    /\ claimOwner     = NULL
+    /\ claimCommitted = FALSE
+    /\ recordExists   = [r \in Records |-> FALSE]
+    /\ phase          = [r \in Records |-> "idle"]
+
+Reserve(r) ==
+    /\ phase[r] = "idle"
+    /\ claimOwner = NULL
+    /\ claimOwner' = r
+    /\ phase'      = [phase EXCEPT ![r] = "reserved"]
+    /\ UNCHANGED << claimCommitted, recordExists >>
+
+\* The record write. Claim-conditional (CAS) when the switch is on: it only persists the
+\* record if this record still holds the claim -- so a reconciler that reclaimed the claim
+\* fences a late write.
+WriteRecord(r) ==
+    /\ phase[r] = "reserved"
+    /\ (ClaimConditionalWrite => claimOwner = r)
+    /\ recordExists' = [recordExists EXCEPT ![r] = TRUE]
+    /\ phase'        = [phase EXCEPT ![r] = "recorded"]
+    /\ UNCHANGED << claimOwner, claimCommitted >>
+
+\* The claim-conditional write refused: the claim was reclaimed out from under it.
+WriteRecordFenced(r) ==
+    /\ ClaimConditionalWrite
+    /\ phase[r] = "reserved"
+    /\ claimOwner # r
+    /\ phase' = [phase EXCEPT ![r] = "failed"]
+    /\ UNCHANGED << claimOwner, claimCommitted, recordExists >>
+
+Commit(r) ==
+    /\ phase[r] = "recorded"
+    /\ claimOwner = r
+    /\ ~claimCommitted
+    /\ claimCommitted' = TRUE
+    /\ phase'          = [phase EXCEPT ![r] = "done"]
+    /\ UNCHANGED << claimOwner, recordExists >>
+
+\* Coordinator dies after reserving, before writing the record.
+Abandon(r) ==
+    /\ phase[r] = "reserved"
+    /\ phase' = [phase EXCEPT ![r] = "abandoned"]
+    /\ UNCHANGED << claimOwner, claimCommitted, recordExists >>
+
+\* --- Reconciler (leader-driven), reconciling the claim to the durable record ---
+
+\* Repair a lost commit: an uncommitted claim whose record exists is promoted.
+ReconcilePromote ==
+    /\ claimOwner # NULL
+    /\ ~claimCommitted
+    /\ recordExists[claimOwner]
+    /\ claimCommitted' = TRUE
+    /\ UNCHANGED << claimOwner, recordExists, phase >>
+
+\* Reclaim an abandoned claim: uncommitted, with no durable record for the owner.
+\* Modelled AGGRESSIVELY -- allowed regardless of the owner's phase (worst case: fires
+\* while the owner is still "reserved", racing a late WriteRecord).
+ReconcileReclaim ==
+    /\ claimOwner # NULL
+    /\ ~claimCommitted
+    /\ ~recordExists[claimOwner]
+    /\ claimOwner' = NULL
+    /\ UNCHANGED << claimCommitted, recordExists, phase >>
+
+Next ==
+    \/ \E r \in Records : Reserve(r)
+    \/ \E r \in Records : WriteRecord(r)
+    \/ \E r \in Records : WriteRecordFenced(r)
+    \/ \E r \in Records : Commit(r)
+    \/ \E r \in Records : Abandon(r)
+    \/ ReconcilePromote
+    \/ ReconcileReclaim
+
+Spec == Init /\ [][Next]_vars
+
+NoOversell == Cardinality({r \in Records : recordExists[r]}) <= 1
+
+\* A committed claim's owner is the unique record holder.
+CommittedConsistent ==
+    claimCommitted /\ claimOwner # NULL =>
+        \A r \in Records : (recordExists[r] => r = claimOwner)
+
+==========================================================================

--- a/specs/ClusterUniqueV2.cfg
+++ b/specs/ClusterUniqueV2.cfg
@@ -1,0 +1,10 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Values = {v1}
+    Nodes = {n1, n2}
+
+INVARIANTS
+    TypeOK
+    NoOversell

--- a/specs/ClusterUniqueV2.tla
+++ b/specs/ClusterUniqueV2.tla
@@ -1,0 +1,140 @@
+------------------------ MODULE ClusterUniqueV2 ------------------------
+\* Faithful model of the CURRENT cluster unique-constraint protocol.
+\* Reservation = fragile per-node in-memory lock, decoupled from the durable record.
+\* Reproduces oversell class A (durability/TTL loss) and class B (dual-primary / handoff).
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS Records, Values, Nodes
+
+NULL == CHOOSE x : x \notin (Records \cup Values \cup Nodes)
+
+VARIABLES
+    believes,       \* [Nodes -> BOOLEAN] : node currently acts as primary for the value-partition
+    resvOwner,      \* [Nodes -> [Values -> Records \cup {NULL}]] : per-node in-memory reservation holder
+    resvCommitted,  \* [Nodes -> [Values -> BOOLEAN]] : per-node committed flag
+    recordVal,      \* [Records -> Values \cup {NULL}] : durable, replicated record (data partition)
+    target,         \* [Records -> Values \cup {NULL}] : value the record is claiming
+    resvNode,       \* [Records -> Nodes \cup {NULL}] : node the record reserved on
+    phase           \* [Records -> {"idle","routed","written","done","failed"}]
+
+vars == << believes, resvOwner, resvCommitted, recordVal, target, resvNode, phase >>
+
+Phases == {"idle", "routed", "written", "done", "failed"}
+
+TypeOK ==
+    /\ believes      \in [Nodes -> BOOLEAN]
+    /\ resvOwner     \in [Nodes -> [Values -> Records \cup {NULL}]]
+    /\ resvCommitted \in [Nodes -> [Values -> BOOLEAN]]
+    /\ recordVal     \in [Records -> Values \cup {NULL}]
+    /\ target        \in [Records -> Values \cup {NULL}]
+    /\ resvNode      \in [Records -> Nodes \cup {NULL}]
+    /\ phase         \in [Records -> Phases]
+
+InitialPrimary == CHOOSE n \in Nodes : TRUE
+
+Init ==
+    /\ believes      = [n \in Nodes |-> n = InitialPrimary]
+    /\ resvOwner     = [n \in Nodes |-> [v \in Values |-> NULL]]
+    /\ resvCommitted = [n \in Nodes |-> [v \in Values |-> FALSE]]
+    /\ recordVal     = [r \in Records |-> NULL]
+    /\ target        = [r \in Records |-> NULL]
+    /\ resvNode      = [r \in Records |-> NULL]
+    /\ phase         = [r \in Records |-> "idle"]
+
+\* A create routes to a node it believes is primary and reserves there (atomic check-and-set,
+\* but only against THAT node's local store).
+Reserve(r, v, n) ==
+    /\ phase[r] = "idle"
+    /\ believes[n]
+    /\ resvOwner[n][v] = NULL
+    /\ resvOwner'  = [resvOwner  EXCEPT ![n][v] = r]
+    /\ target'     = [target     EXCEPT ![r] = v]
+    /\ resvNode'   = [resvNode   EXCEPT ![r] = n]
+    /\ phase'      = [phase      EXCEPT ![r] = "routed"]
+    /\ UNCHANGED << believes, resvCommitted, recordVal >>
+
+ReserveConflict(r, v, n) ==
+    /\ phase[r] = "idle"
+    /\ believes[n]
+    /\ resvOwner[n][v] # NULL
+    /\ phase' = [phase EXCEPT ![r] = "failed"]
+    /\ UNCHANGED << believes, resvOwner, resvCommitted, recordVal, target, resvNode >>
+
+\* The durable record is written on the data partition (persisted + replicated).
+WriteRecord(r) ==
+    /\ phase[r] = "routed"
+    /\ recordVal' = [recordVal EXCEPT ![r] = target[r]]
+    /\ phase'     = [phase     EXCEPT ![r] = "written"]
+    /\ UNCHANGED << believes, resvOwner, resvCommitted, target, resvNode >>
+
+\* Commit succeeds only if the reservation is still held by this record on its node.
+Commit(r) ==
+    /\ phase[r] = "written"
+    /\ resvNode[r] # NULL
+    /\ resvOwner[resvNode[r]][target[r]] = r
+    /\ ~resvCommitted[resvNode[r]][target[r]]
+    /\ resvCommitted' = [resvCommitted EXCEPT ![resvNode[r]][target[r]] = TRUE]
+    /\ phase'         = [phase EXCEPT ![r] = "done"]
+    /\ UNCHANGED << believes, resvOwner, recordVal, target, resvNode >>
+
+\* Commit lands but the reservation was lost/taken: fire-and-forget, silently dropped.
+\* The durable record REMAINS (never rolled back).
+CommitLost(r) ==
+    /\ phase[r] = "written"
+    /\ resvNode[r] # NULL
+    /\ resvOwner[resvNode[r]][target[r]] # r
+    /\ phase' = [phase EXCEPT ![r] = "failed"]
+    /\ UNCHANGED << believes, resvOwner, resvCommitted, recordVal, target, resvNode >>
+
+\* --- Failure / distributed events ---
+
+\* TTL expiry of an uncommitted reservation (hourly cleanup, in-memory).
+Expire(n, v) ==
+    /\ resvOwner[n][v] # NULL
+    /\ ~resvCommitted[n][v]
+    /\ resvOwner' = [resvOwner EXCEPT ![n][v] = NULL]
+    /\ UNCHANGED << believes, resvCommitted, recordVal, target, resvNode, phase >>
+
+\* Node crash: in-memory reservations lost (not durable / not fsync'd / not replicated),
+\* node stops believing it is primary.
+Crash(n) ==
+    /\ believes[n]
+    /\ resvOwner'     = [resvOwner     EXCEPT ![n] = [v \in Values |-> NULL]]
+    /\ resvCommitted' = [resvCommitted EXCEPT ![n] = [v \in Values |-> FALSE]]
+    /\ believes'      = [believes      EXCEPT ![n] = FALSE]
+    /\ UNCHANGED << recordVal, target, resvNode, phase >>
+
+\* Failover / rebalance grants primary belief to another node WITHOUT transferring
+\* the (async-replicated / in-memory) reservation state: promotion gap.
+PromoteEmpty(n) ==
+    /\ ~believes[n]
+    /\ believes' = [believes EXCEPT ![n] = TRUE]
+    /\ UNCHANGED << resvOwner, resvCommitted, recordVal, target, resvNode, phase >>
+
+\* Stale-map / partition window: a second node also believes it is primary (dual-primary),
+\* while the first still believes. No reservation state is shared between them.
+DualBelieve(n) ==
+    /\ ~believes[n]
+    /\ \E m \in Nodes : m # n /\ believes[m]
+    /\ believes' = [believes EXCEPT ![n] = TRUE]
+    /\ UNCHANGED << resvOwner, resvCommitted, recordVal, target, resvNode, phase >>
+
+Next ==
+    \/ \E r \in Records, v \in Values, n \in Nodes : Reserve(r, v, n)
+    \/ \E r \in Records, v \in Values, n \in Nodes : ReserveConflict(r, v, n)
+    \/ \E r \in Records : WriteRecord(r)
+    \/ \E r \in Records : Commit(r)
+    \/ \E r \in Records : CommitLost(r)
+    \/ \E n \in Nodes, v \in Values : Expire(n, v)
+    \/ \E n \in Nodes : Crash(n)
+    \/ \E n \in Nodes : PromoteEmpty(n)
+    \/ \E n \in Nodes : DualBelieve(n)
+
+Spec == Init /\ [][Next]_vars
+
+\* At most one durable record per unique value.
+NoOversell ==
+    \A v \in Values : Cardinality({r \in Records : recordVal[r] = v}) <= 1
+
+========================================================================

--- a/specs/UniqueGuard.cfg
+++ b/specs/UniqueGuard.cfg
@@ -1,0 +1,11 @@
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Values = {v1, v2}
+    AtomicUpdate = TRUE
+
+INVARIANTS
+    TypeOK
+    NoDoubleClaim
+    GuardMatchesData

--- a/specs/UniqueGuard.tla
+++ b/specs/UniqueGuard.tla
@@ -1,0 +1,85 @@
+-------------------------- MODULE UniqueGuard --------------------------
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS Records, Values, AtomicUpdate
+
+NULL == CHOOSE x : x \notin (Records \cup Values)
+
+VARIABLES
+    guard,      \* Values -> Records \cup {NULL} : owner of each unique-value guard key
+    recordVal,  \* Records -> Values \cup {NULL} : value each row's data declares (NULL = row absent)
+    obs         \* Records -> Values \cup {NULL} : a non-atomic update's observed-free target
+
+vars == << guard, recordVal, obs >>
+
+TypeOK ==
+    /\ guard     \in [Values  -> Records \cup {NULL}]
+    /\ recordVal \in [Records -> Values  \cup {NULL}]
+    /\ obs       \in [Records -> Values  \cup {NULL}]
+
+Init ==
+    /\ guard     = [v \in Values  |-> NULL]
+    /\ recordVal = [r \in Records |-> NULL]
+    /\ obs       = [r \in Records |-> NULL]
+
+Exists(r) == recordVal[r] # NULL
+
+Create(r, v) ==
+    /\ ~Exists(r)
+    /\ obs[r] = NULL
+    /\ guard[v] = NULL
+    /\ guard'     = [guard     EXCEPT ![v] = r]
+    /\ recordVal' = [recordVal EXCEPT ![r] = v]
+    /\ UNCHANGED obs
+
+Delete(r) ==
+    /\ Exists(r)
+    /\ obs[r] = NULL
+    /\ guard'     = [guard     EXCEPT ![recordVal[r]] = NULL]
+    /\ recordVal' = [recordVal EXCEPT ![r] = NULL]
+    /\ UNCHANGED obs
+
+UpdateAtomic(r, vNew) ==
+    /\ AtomicUpdate
+    /\ Exists(r)
+    /\ obs[r] = NULL
+    /\ vNew # recordVal[r]
+    /\ guard[vNew] = NULL
+    /\ guard'     = [guard EXCEPT ![vNew] = r, ![recordVal[r]] = NULL]
+    /\ recordVal' = [recordVal EXCEPT ![r] = vNew]
+    /\ UNCHANGED obs
+
+ObserveNew(r, vNew) ==
+    /\ ~AtomicUpdate
+    /\ Exists(r)
+    /\ obs[r] = NULL
+    /\ vNew # recordVal[r]
+    /\ guard[vNew] = NULL
+    /\ obs' = [obs EXCEPT ![r] = vNew]
+    /\ UNCHANGED << guard, recordVal >>
+
+CommitUpdate(r) ==
+    /\ ~AtomicUpdate
+    /\ obs[r] # NULL
+    /\ Exists(r)
+    /\ guard'     = [guard EXCEPT ![obs[r]] = r, ![recordVal[r]] = NULL]
+    /\ recordVal' = [recordVal EXCEPT ![r] = obs[r]]
+    /\ obs'       = [obs EXCEPT ![r] = NULL]
+
+Next ==
+    \/ \E r \in Records, v \in Values : Create(r, v)
+    \/ \E r \in Records : Delete(r)
+    \/ \E r \in Records, v \in Values : UpdateAtomic(r, v)
+    \/ \E r \in Records, v \in Values : ObserveNew(r, v)
+    \/ \E r \in Records : CommitUpdate(r)
+
+Spec == Init /\ [][Next]_vars
+
+NoDoubleClaim ==
+    \A v \in Values : Cardinality({r \in Records : recordVal[r] = v}) <= 1
+
+GuardMatchesData ==
+    /\ \A r \in Records : Exists(r) => guard[recordVal[r]] = r
+    /\ \A v \in Values  : guard[v] # NULL => recordVal[guard[v]] = v
+
+========================================================================


### PR DESCRIPTION
## Summary

- close agent-mode unique oversell: create/update are atomic via an id-free `uniq/{entity}/{field}/{value}` CAS guard key + a new `expect_absent` storage precondition
- close cluster-mode dual-primary oversell with an epoch-fenced, quorum-durable, seal-on-promotion protocol: reserve/commit replicate to a fixed quorum group and return only on majority; a promoted primary seals (promises its epoch at a majority and learns any reservation it missed) before serving; a member never reassigns a committed value
- add a record-driven reconciler that repairs claims lost to failover/restart or lost commits, and reclaims abandoned claims by TTL only when the record is absent
- return a retryable 503 (not a misleading 409) while a partition is briefly unsealed after promotion
- verify in TLA+ (`ClusterUniqueQuorum`, `ClusterUniqueMonotonic` shows the seal reservation-learning is required, `UniqueGuard`); add a sim NoOversell regression test that fails if the seal-learning is removed
- bump mqdb-core 0.7.4, mqdb-agent 0.8.12, mqdb-cluster 0.4.0, mqdb-cli 0.8.15; update CHANGELOG, README, distributed-design

## Review fixes

- release the local reservation when a remote-coordinated reserve fails its quorum, so a transient timeout no longer wedges the value until its 30s TTL; counter-test fails against the pre-fix code
- await the remote-reserve and local-quorum rounds concurrently (`tokio::join!`) on both create paths, halving worst-case create latency from ~10s to ~5s
- `await_unique_quorum` returns the fields confirmed majority-durable instead of `()`
- add the FK message ids (90-93) to the `MessageType` enum so `UniqueSealResponse = 94` is contiguous
- reconcile the design doc's stale "remaining gaps" and "stable membership" notes; document two open follow-ups (reconciler full-scan cost, and a dynamic-reconfiguration oversell when the quorum group grows across a reserve/seal window — out of the fixed-Nodes model)

## Test plan

- [x] cargo make clippy
- [x] cargo make test — mqdb-cluster 511 lib + 76 integration + 49; mqdb-agent 141
- [x] TLA: ClusterUniqueQuorum holds NoOversell; ClusterUniqueMonotonic reproduces the oversell without seal-learning
