### PR TITLE
release unique claims on delete and fence reasserts against failover reorder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@ Each entry lists the date and the crate versions that were released.
 
 ### Changed
 
-- **Unique reassert/release carry a data-partition epoch fence.** Across a data-partition-primary failover, a deposed primary's in-flight reassert could reorder past the new primary's release and re-establish a committed claim for a deleted record. `UniqueReassertRequest`/`UniqueReleaseRequest` now carry the data-partition epoch (wire version 2); the value site keeps a per-data-partition high-water mark and rejects reasserts below it, while releases always apply (they only touch their own record's claim) and bump the mark. The design is model-checked in `specs/ClusterUniqueReconcilerFence.tla`. A mixed-version cluster during a rolling upgrade is a known limitation.
+- **Unique reassert/release carry a data-partition epoch fence.** Across a data-partition-primary failover, a deposed primary's in-flight reassert could reorder past the new primary's release and re-establish a committed claim for a deleted record. `UniqueReassertRequest`/`UniqueReleaseRequest` now carry the data-partition epoch (wire version 2); the value site keeps a per-data-partition high-water mark and rejects reasserts below it, while releases always apply (they only touch their own record's claim) and bump the mark. The design is model-checked in `specs/ClusterUniqueReconcilerFence.tla`. For rolling upgrades, a version-2 node decodes a version-1 sender's reassert/release by treating it as unfenced (epoch 0), so mixed-version messages are applied rather than dropped.
+
+## 2026-07-12 — mqdb-cli 0.8.16, mqdb-cluster 0.4.1, mqdb-core 0.7.5
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
-## 2026-07-12 — mqdb-cli 0.8.16, mqdb-cluster 0.4.1, mqdb-core 0.7.5
+## 2026-07-19 — mqdb-cli 0.8.17, mqdb-cluster 0.4.2
+
+### Fixed
+
+- **Deleting a record now releases its unique claim (cluster mode).** A cluster-mode record delete removed only the durable record and the FK reverse index, never the record's committed unique claim, so the value was leaked permanently — a new create for it hit a conflict forever (TTL only reclaims *uncommitted* claims, and the record-driven reconciler never revisits a deleted record). Agent mode already released on delete; this closes the parity gap. Every record-delete site — direct, binary, the db_ops parent delete, and FK cascade children — now releases via a shared `release_unique_for_deleted_record` helper.
+
+### Changed
+
+- **Unique reassert/release carry a data-partition epoch fence.** Across a data-partition-primary failover, a deposed primary's in-flight reassert could reorder past the new primary's release and re-establish a committed claim for a deleted record. `UniqueReassertRequest`/`UniqueReleaseRequest` now carry the data-partition epoch (wire version 2); the value site keeps a per-data-partition high-water mark and rejects reasserts below it, while releases always apply (they only touch their own record's claim) and bump the mark. The design is model-checked in `specs/ClusterUniqueReconcilerFence.tla`. A mixed-version cluster during a rolling upgrade is a known limitation.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [
  "base64",
  "bebytes",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cluster"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.16"
+version = "0.8.17"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/Cargo.toml
+++ b/crates/mqdb-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cluster"
-version = "0.4.1"
+version = "0.4.2"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/src/cluster/db/unique_store.rs
+++ b/crates/mqdb-cluster/src/cluster/db/unique_store.rs
@@ -173,6 +173,12 @@ pub struct UniqueReserveParams<'a> {
 pub struct UniqueStore {
     node_id: NodeId,
     reservations: RwLock<HashMap<String, UniqueReservation>>,
+    /// Per data-partition high-water mark of the highest data-partition epoch this value site has
+    /// applied. A reassert stamped with an epoch below the mark is from a deposed data-partition
+    /// primary (superseded by a failover) and is rejected, closing the reassert/release reorder
+    /// wedge. Releases always apply (they only touch their own record's claim) but still bump the
+    /// mark. Keyed by `PartitionId::get()`; bounded by the fixed partition count.
+    fence_epochs: RwLock<HashMap<u16, u64>>,
 }
 
 impl UniqueStore {
@@ -181,6 +187,31 @@ impl UniqueStore {
         Self {
             node_id,
             reservations: RwLock::new(HashMap::new()),
+            fence_epochs: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Whether a reassert stamped with `epoch` for `data_partition` is current (>= the high-water
+    /// mark). A stale reassert from a superseded primary is rejected.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned.
+    #[must_use]
+    pub fn fence_accepts(&self, data_partition: PartitionId, epoch: u64) -> bool {
+        let fences = self.fence_epochs.read().unwrap();
+        epoch >= fences.get(&data_partition.get()).copied().unwrap_or(0)
+    }
+
+    /// Raise the high-water mark for `data_partition` to `epoch` if higher. Called on every applied
+    /// reassert and every release.
+    ///
+    /// # Panics
+    /// Panics if the internal lock is poisoned.
+    pub fn fence_bump(&self, data_partition: PartitionId, epoch: u64) {
+        let mut fences = self.fence_epochs.write().unwrap();
+        let slot = fences.entry(data_partition.get()).or_insert(0);
+        if epoch > *slot {
+            *slot = epoch;
         }
     }
 
@@ -1028,6 +1059,35 @@ mod tests {
         let r = store.get("users", "email", b"a@x.com").unwrap();
         assert!(r.is_committed());
         assert_eq!(r.record_id_str(), "u1");
+    }
+
+    #[test]
+    fn fence_rejects_stale_epoch_per_data_partition() {
+        let store = UniqueStore::new(node(1));
+        let p = partition(5);
+        let other = partition(6);
+
+        assert!(
+            store.fence_accepts(p, 1),
+            "an unseen partition accepts any epoch"
+        );
+        store.fence_bump(p, 2);
+        assert!(
+            !store.fence_accepts(p, 1),
+            "an epoch below the high-water mark is from a superseded data-partition primary"
+        );
+        assert!(store.fence_accepts(p, 2), "the current epoch is accepted");
+        assert!(store.fence_accepts(p, 3), "a newer epoch is accepted");
+        assert!(
+            store.fence_accepts(other, 1),
+            "the fence is tracked independently per data-partition"
+        );
+
+        store.fence_bump(p, 1);
+        assert!(
+            !store.fence_accepts(p, 1),
+            "the high-water mark never regresses"
+        );
     }
 
     #[test]

--- a/crates/mqdb-cluster/src/cluster/db_handler/binary_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/db_handler/binary_ops.rs
@@ -13,6 +13,7 @@ use super::super::node_controller::NodeController;
 use super::super::transport::ClusterTransport;
 use super::DbRequestHandler;
 use bebytes::BeBytes;
+use serde_json::Value;
 
 #[allow(clippy::unused_self)]
 impl DbRequestHandler {
@@ -161,7 +162,13 @@ impl DbRequestHandler {
         }
 
         match controller.db_delete(entity, id).await {
-            Ok(db_entity) => DbResponse::ok(&db_entity.to_be_bytes()).to_be_bytes(),
+            Ok(db_entity) => {
+                let data: Value = serde_json::from_slice(&db_entity.data).unwrap_or(Value::Null);
+                controller
+                    .release_unique_for_deleted_record(entity, id, &data)
+                    .await;
+                DbResponse::ok(&db_entity.to_be_bytes()).to_be_bytes()
+            }
             Err(db::DbDataStoreError::NotFound) => {
                 DbResponse::error(DbStatus::NotFound).to_be_bytes()
             }

--- a/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
@@ -991,7 +991,7 @@ impl DbRequestHandler {
         match controller.db_delete_prepare(entity, id) {
             Ok((db_entity, write)) => {
                 let data: Value = serde_json::from_slice(&db_entity.data).unwrap_or(Value::Null);
-                let event = ChangeEvent::delete(entity.to_string(), id.to_string(), data)
+                let event = ChangeEvent::delete(entity.to_string(), id.to_string(), data.clone())
                     .with_sender(sender.map(str::to_string))
                     .with_client_id(client_id.map(str::to_string))
                     .with_scope(pre_delete_scope);
@@ -1003,6 +1003,9 @@ impl DbRequestHandler {
                 } else {
                     controller.db_commit(write, outbox.clone()).await;
                 }
+                controller
+                    .release_unique_for_deleted_record(entity, id, &data)
+                    .await;
                 self.publish_change_event_and_deliver(controller, event, &outbox.operation_id)
                     .await;
                 if let Some(cas) = cascade {

--- a/crates/mqdb-cluster/src/cluster/db_handler/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/db_handler/tests.rs
@@ -546,6 +546,51 @@ async fn json_delete_allowed_for_owner() {
 }
 
 #[tokio::test]
+async fn delete_releases_unique_claim() {
+    use super::super::db::ClusterConstraint;
+
+    let node1 = NodeId::validated(1).unwrap();
+    let handler = DbRequestHandler::new(node1);
+    let mut ctrl = setup_controller_all_partitions();
+    ctrl.constraint_add(&ClusterConstraint::unique("users", "uniq_email", "email"))
+        .await
+        .unwrap();
+
+    // A durable record owning a committed unique claim, as it would be after a create+commit.
+    let data_bytes = serde_json::to_vec(&serde_json::json!({"email": "a@x.com"})).unwrap();
+    let rec = ctrl
+        .db_create("users", "u1", &data_bytes, 1000)
+        .await
+        .unwrap();
+    let value = serde_json::to_vec(&serde_json::json!("a@x.com")).unwrap();
+    ctrl.stores()
+        .db_unique
+        .reassert("users", "email", &value, "u1", rec.partition(), 1000);
+    assert!(
+        ctrl.stores().unique_get("users", "email", &value).is_some(),
+        "committed claim exists before delete"
+    );
+
+    let ctx = MqttRequestContext {
+        response_topic: Some("resp/t"),
+        correlation_data: None,
+        sender: None,
+        client_id: None,
+    };
+    let resp = handler
+        .handle_publish(&mut ctrl, "$DB/users/u1/delete", &[], &ctx)
+        .await
+        .unwrap();
+    assert_eq!(parse_json_response(&resp.payload)["data"]["deleted"], true);
+
+    assert!(
+        ctrl.stores().unique_get("users", "email", &value).is_none(),
+        "deleting the record must release its committed unique claim, else the value is wedged \
+         forever (TTL never reclaims a committed claim)"
+    );
+}
+
+#[tokio::test]
 async fn json_update_bypasses_ownership_when_no_sender() {
     let node1 = NodeId::validated(1).unwrap();
     let ownership = ownership_config("diagrams", "userId");
@@ -1295,6 +1340,73 @@ async fn fk_delete_cascade_removes_children() {
     assert!(ctrl.db_get("users", "u1").is_none());
     assert!(ctrl.db_get("posts", "p1").is_none());
     assert!(ctrl.db_get("posts", "p2").is_none());
+}
+
+#[tokio::test]
+async fn cascade_delete_releases_child_unique_claim() {
+    use super::super::db::{ClusterConstraint, OnDeleteAction};
+
+    let node1 = NodeId::validated(1).unwrap();
+    let handler = DbRequestHandler::new(node1);
+    let mut ctrl = setup_controller_all_partitions();
+
+    ctrl.db_create(
+        "users",
+        "u1",
+        &serde_json::to_vec(&serde_json::json!({"name": "Alice"})).unwrap(),
+        1000,
+    )
+    .await
+    .unwrap();
+
+    let post = serde_json::to_vec(
+        &serde_json::json!({"title": "P1", "author_id": "u1", "slug": "post-1"}),
+    )
+    .unwrap();
+    let rec = ctrl.db_create("posts", "p1", &post, 1000).await.unwrap();
+
+    // The child post owns a committed unique claim on its slug, as it would after create+commit.
+    let slug = serde_json::to_vec(&serde_json::json!("post-1")).unwrap();
+    ctrl.stores()
+        .db_unique
+        .reassert("posts", "slug", &slug, "p1", rec.partition(), 1000);
+    assert!(ctrl.stores().unique_get("posts", "slug", &slug).is_some());
+
+    ctrl.constraint_add(&ClusterConstraint::unique("posts", "posts_slug", "slug"))
+        .await
+        .unwrap();
+    ctrl.constraint_add(&ClusterConstraint::foreign_key(
+        "posts",
+        "posts_author_fk",
+        "author_id",
+        "users",
+        "id",
+        OnDeleteAction::Cascade,
+    ))
+    .await
+    .unwrap();
+
+    let resp = handler
+        .handle_publish(
+            &mut ctrl,
+            "$DB/users/u1/delete",
+            &[],
+            &MqttRequestContext {
+                response_topic: Some("resp/t"),
+                correlation_data: None,
+                sender: None,
+                client_id: None,
+            },
+        )
+        .await
+        .unwrap();
+    assert_eq!(parse_json_response(&resp.payload)["data"]["deleted"], true);
+
+    assert!(ctrl.db_get("posts", "p1").is_none(), "child cascaded away");
+    assert!(
+        ctrl.stores().unique_get("posts", "slug", &slug).is_none(),
+        "cascade-deleting a child must release its committed unique claim, else its value is wedged"
+    );
 }
 
 #[tokio::test]

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -850,7 +850,7 @@ impl<T: ClusterTransport> NodeController<T> {
         match self.db_delete_prepare(entity, id) {
             Ok((db_entity, write)) => {
                 let data: Value = serde_json::from_slice(&db_entity.data).unwrap_or(Value::Null);
-                let event = ChangeEvent::delete(entity.to_string(), id.to_string(), data);
+                let event = ChangeEvent::delete(entity.to_string(), id.to_string(), data.clone());
                 let outbox = build_change_event_outbox(&event);
                 if let Some(cas) = cascade {
                     self.db_commit_with_cascade(write, outbox.clone(), cas)
@@ -858,6 +858,8 @@ impl<T: ClusterTransport> NodeController<T> {
                 } else {
                     self.db_commit(write, outbox.clone()).await;
                 }
+                self.release_unique_for_deleted_record(entity, id, &data)
+                    .await;
                 self.publish_and_deliver_change_event(event, &outbox.operation_id)
                     .await;
                 if let Some(cas) = cascade {
@@ -978,9 +980,11 @@ impl<T: ClusterTransport> NodeController<T> {
                     if let Ok((db_entity, write)) = self.db_delete_prepare(entity, id) {
                         let data: Value =
                             serde_json::from_slice(&db_entity.data).unwrap_or(Value::Null);
-                        let event = ChangeEvent::delete(entity.clone(), id.clone(), data);
+                        let event = ChangeEvent::delete(entity.clone(), id.clone(), data.clone());
                         let outbox = build_change_event_outbox(&event);
                         self.db_commit(write, outbox.clone()).await;
+                        self.release_unique_for_deleted_record(entity, id, &data)
+                            .await;
                         self.publish_and_deliver_change_event(event, &outbox.operation_id)
                             .await;
                     }
@@ -1045,9 +1049,12 @@ impl<T: ClusterTransport> NodeController<T> {
                         if let Ok((db_entity, write)) = self.db_delete_prepare(entity, id) {
                             let data: Value =
                                 serde_json::from_slice(&db_entity.data).unwrap_or(Value::Null);
-                            let event = ChangeEvent::delete(entity.clone(), id.clone(), data);
+                            let event =
+                                ChangeEvent::delete(entity.clone(), id.clone(), data.clone());
                             let outbox = build_change_event_outbox(&event);
                             self.db_commit(write, outbox.clone()).await;
+                            self.release_unique_for_deleted_record(entity, id, &data)
+                                .await;
                             self.publish_and_deliver_change_event(event, &outbox.operation_id)
                                 .await;
                         }
@@ -1541,7 +1548,7 @@ impl<T: ClusterTransport> NodeController<T> {
             }
         }
         for (f, v, target) in remote_reserved {
-            self.send_unique_release_fire_and_forget(*target, entity, f, v, request_id)
+            self.send_unique_release_fire_and_forget(*target, entity, f, v, request_id, None)
                 .await;
         }
     }

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -348,6 +348,48 @@ async fn reconcile_apply_skips_record_deleted_after_collection() {
 }
 
 #[tokio::test]
+async fn reassert_replicated_rejects_stale_epoch_below_the_fence() {
+    use crate::cluster::db::ReassertResult;
+
+    let node1 = NodeId::validated(1).unwrap();
+    let ctrl = create_test_controller(node1, MockTransport::new(node1));
+    let p = PartitionId::new(5).unwrap();
+    let value = serde_json::to_vec(&serde_json::json!("a@x.com")).unwrap();
+
+    // The value site has seen data-partition epoch 3 (e.g. a release from the current primary).
+    ctrl.stores().db_unique.fence_bump(p, 3);
+
+    // A reassert stamped with epoch 2 (< 3) is from a superseded primary: dropped, no claim, no write.
+    let (result, write) = ctrl
+        .stores()
+        .reassert_replicated("users", "email", &value, "u1", p, 2, 1000);
+    assert_eq!(
+        result,
+        ReassertResult::Pending,
+        "stale-epoch reassert is fenced out"
+    );
+    assert!(
+        write.is_none(),
+        "a fenced-out reassert emits no replication write"
+    );
+    assert!(
+        ctrl.stores().unique_get("users", "email", &value).is_none(),
+        "a stale reassert must not establish a committed claim"
+    );
+
+    // A current-epoch reassert (3 >= 3) passes the fence and establishes the claim.
+    let (result, write) = ctrl
+        .stores()
+        .reassert_replicated("users", "email", &value, "u1", p, 3, 1000);
+    assert_eq!(result, ReassertResult::Established);
+    assert!(write.is_some());
+    assert!(
+        ctrl.stores().unique_get("users", "email", &value).is_some(),
+        "a current-epoch reassert establishes the claim"
+    );
+}
+
+#[tokio::test]
 async fn project_reconcile_work_skips_key_deleted_after_gather() {
     use crate::cluster::db::ClusterConstraint;
 

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -209,7 +209,7 @@ impl<T: ClusterTransport> NodeController<T> {
             }
         }
         for (f, v, target) in confirmed_remotes {
-            self.send_unique_release_fire_and_forget(*target, entity, f, v, request_id)
+            self.send_unique_release_fire_and_forget(*target, entity, f, v, request_id, None)
                 .await;
         }
     }
@@ -295,16 +295,32 @@ impl<T: ClusterTransport> NodeController<T> {
         }
     }
 
+    /// Release every unique claim held by a record being deleted, so the value is reusable. The
+    /// data-partition is derived from the record id and the record id is the release key (committed
+    /// claims are keyed by `record_id`). A no-op if the entity has no unique fields. Call at every
+    /// record-delete site — direct, binary, cascade parent, and cascade child.
+    pub(crate) async fn release_unique_for_deleted_record(
+        &mut self,
+        entity: &str,
+        id: &str,
+        data: &serde_json::Value,
+    ) {
+        let partition = super::super::db::data_partition(entity, id);
+        self.release_unique_constraints(entity, id, data, partition, id, Self::current_time_ms())
+            .await;
+    }
+
     pub async fn release_unique_constraints(
         &mut self,
         entity: &str,
         _id: &str,
         data: &serde_json::Value,
-        _data_partition: PartitionId,
+        data_partition: PartitionId,
         request_id: &str,
         _now_ms: u64,
     ) {
         let unique_fields = self.stores.constraint_get_unique_fields(entity);
+        let epoch = self.partition_map.epoch(data_partition).get();
 
         for field in &unique_fields {
             let value = match data.get(field) {
@@ -322,6 +338,9 @@ impl<T: ClusterTransport> NodeController<T> {
                 {
                     self.write_or_forward(w).await;
                 }
+                // Releasing a committed claim raises the value site's fence so a stale reassert from
+                // a superseded data-partition primary is rejected (see ClusterUniqueReconcilerFence).
+                self.stores.db_unique.fence_bump(data_partition, epoch);
             } else if let Some(target_node) = primary {
                 self.send_unique_release_fire_and_forget(
                     target_node,
@@ -329,6 +348,7 @@ impl<T: ClusterTransport> NodeController<T> {
                     field,
                     &value,
                     request_id,
+                    Some(data_partition),
                 )
                 .await;
             }
@@ -449,6 +469,15 @@ impl<T: ClusterTransport> NodeController<T> {
         {
             self.write_or_forward(w).await;
         }
+        // A committed-claim release (epoch > 0) raises the fence so a later stale reassert from a
+        // superseded data-partition primary is rejected; uncommitted releases stamp epoch 0.
+        if req.data_partition_epoch > 0
+            && let Some(dp) = req.data_partition()
+        {
+            self.stores
+                .db_unique
+                .fence_bump(dp, req.data_partition_epoch);
+        }
 
         let response = super::UniqueReleaseResponse::create(req.request_id, true);
         let _ = self
@@ -467,6 +496,7 @@ impl<T: ClusterTransport> NodeController<T> {
             &req.value,
             req.record_id_str(),
             data_partition,
+            req.data_partition_epoch,
         )
         .await;
     }
@@ -478,6 +508,7 @@ impl<T: ClusterTransport> NodeController<T> {
         value: &[u8],
         record_id: &str,
         data_partition: PartitionId,
+        epoch: u64,
     ) {
         let (result, write) = self.stores.reassert_replicated(
             entity,
@@ -485,6 +516,7 @@ impl<T: ClusterTransport> NodeController<T> {
             value,
             record_id,
             data_partition,
+            epoch,
             Self::current_time_ms(),
         );
         if let Some(w) = write {
@@ -565,8 +597,24 @@ impl<T: ClusterTransport> NodeController<T> {
         field: &str,
         value: &[u8],
         idempotency_key: &str,
+        fence: Option<PartitionId>,
     ) {
-        let request = UniqueReleaseRequest::create(0, entity, field, value, idempotency_key);
+        // A committed-claim release carries its data-partition + epoch so the value site raises its
+        // fence high-water mark; an uncommitted-reservation release (fence = None) stamps epoch 0,
+        // which never bumps the fence and needs no reassert protection.
+        let (data_partition, epoch) = match fence {
+            Some(dp) => (dp.get(), self.partition_map.epoch(dp).get()),
+            None => (0, 0),
+        };
+        let request = UniqueReleaseRequest::create(
+            0,
+            entity,
+            field,
+            value,
+            idempotency_key,
+            PartitionId::new(data_partition).unwrap_or(PartitionId::ZERO),
+            epoch,
+        );
 
         let _ = self
             .transport
@@ -1068,8 +1116,15 @@ impl<T: ClusterTransport> NodeController<T> {
         record_id: &str,
         data_partition: PartitionId,
     ) {
-        let request =
-            UniqueReassertRequest::create(0, entity, field, value, record_id, data_partition);
+        let request = UniqueReassertRequest::create(
+            0,
+            entity,
+            field,
+            value,
+            record_id,
+            data_partition,
+            self.partition_map.epoch(data_partition).get(),
+        );
 
         let _ = self
             .transport
@@ -1185,12 +1240,14 @@ impl<T: ClusterTransport> NodeController<T> {
                 super::super::db::unique_partition(&item.entity, &item.field, &item.value);
             match self.partition_map.primary(unique_part) {
                 Some(primary) if primary == self.node_id => {
+                    let epoch = self.partition_map.epoch(item.data_partition).get();
                     self.reassert_unique_claim(
                         &item.entity,
                         &item.field,
                         &item.value,
                         &item.record_id,
                         item.data_partition,
+                        epoch,
                     )
                     .await;
                 }

--- a/crates/mqdb-cluster/src/cluster/protocol/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/tests.rs
@@ -411,7 +411,15 @@ fn unique_commit_response_roundtrip() {
 
 #[test]
 fn unique_release_request_roundtrip() {
-    let req = UniqueReleaseRequest::create(777, "orders", "order_id", b"ORD-001", "req-xyz");
+    let req = UniqueReleaseRequest::create(
+        777,
+        "orders",
+        "order_id",
+        b"ORD-001",
+        "req-xyz",
+        PartitionId::new(11).unwrap(),
+        4,
+    );
 
     let bytes = req.to_be_bytes();
     let (decoded, _) = UniqueReleaseRequest::try_from_be_bytes(&bytes).unwrap();
@@ -421,6 +429,8 @@ fn unique_release_request_roundtrip() {
     assert_eq!(decoded.field_str(), "order_id");
     assert_eq!(decoded.value, b"ORD-001");
     assert_eq!(decoded.idempotency_key_str(), "req-xyz");
+    assert_eq!(decoded.data_partition(), PartitionId::new(11));
+    assert_eq!(decoded.data_partition_epoch, 4);
 }
 
 #[test]
@@ -465,6 +475,7 @@ fn unique_reassert_request_roundtrip() {
         b"a@x.com",
         "u1",
         PartitionId::new(7).unwrap(),
+        6,
     );
 
     let bytes = req.to_be_bytes();
@@ -475,5 +486,6 @@ fn unique_reassert_request_roundtrip() {
     assert_eq!(decoded.field_str(), "email");
     assert_eq!(decoded.value, b"a@x.com");
     assert_eq!(decoded.record_id_str(), "u1");
+    assert_eq!(decoded.data_partition_epoch, 6);
     assert_eq!(decoded.data_partition(), PartitionId::new(7));
 }

--- a/crates/mqdb-cluster/src/cluster/protocol/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/tests.rs
@@ -489,3 +489,70 @@ fn unique_reassert_request_roundtrip() {
     assert_eq!(decoded.data_partition_epoch, 6);
     assert_eq!(decoded.data_partition(), PartitionId::new(7));
 }
+
+#[test]
+fn unique_release_request_decode_compat_reads_v1() {
+    let v2 = UniqueReleaseRequest::create(
+        9,
+        "users",
+        "email",
+        b"a@x.com",
+        "req-1",
+        PartitionId::new(3).unwrap(),
+        7,
+    );
+
+    // A version-1 sender's bytes are the version-2 layout minus the trailing data_partition + epoch.
+    let mut v1 = v2.to_be_bytes();
+    v1.truncate(v1.len() - 10);
+    v1[0] = 1;
+
+    let decoded =
+        UniqueReleaseRequest::decode_compat(&v1).expect("a v1 release must decode, not drop");
+    assert_eq!(decoded.entity_str(), "users");
+    assert_eq!(decoded.field_str(), "email");
+    assert_eq!(decoded.value, b"a@x.com");
+    assert_eq!(decoded.idempotency_key_str(), "req-1");
+    assert_eq!(
+        decoded.data_partition_epoch, 0,
+        "a v1 sender is treated as unfenced"
+    );
+    assert_eq!(decoded.data_partition, 0);
+
+    // A version-2 message still decodes with its fields intact.
+    let d2 = UniqueReleaseRequest::decode_compat(&v2.to_be_bytes()).unwrap();
+    assert_eq!(d2.data_partition_epoch, 7);
+    assert_eq!(d2.data_partition, 3);
+}
+
+#[test]
+fn unique_reassert_request_decode_compat_reads_v1() {
+    let v2 = UniqueReassertRequest::create(
+        5,
+        "users",
+        "email",
+        b"a@x.com",
+        "u1",
+        PartitionId::new(4).unwrap(),
+        6,
+    );
+
+    // A version-1 reassert already carried data_partition; only the trailing epoch is missing.
+    let mut v1 = v2.to_be_bytes();
+    v1.truncate(v1.len() - 8);
+    v1[0] = 1;
+
+    let decoded =
+        UniqueReassertRequest::decode_compat(&v1).expect("a v1 reassert must decode, not drop");
+    assert_eq!(decoded.entity_str(), "users");
+    assert_eq!(decoded.record_id_str(), "u1");
+    assert_eq!(
+        decoded.data_partition(),
+        PartitionId::new(4),
+        "a v1 sender's data_partition is preserved"
+    );
+    assert_eq!(
+        decoded.data_partition_epoch, 0,
+        "a v1 sender is treated as unfenced"
+    );
+}

--- a/crates/mqdb-cluster/src/cluster/protocol/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/unique.rs
@@ -277,6 +277,22 @@ impl UniqueReleaseRequest {
         PartitionId::new(self.data_partition)
     }
 
+    /// Decode across the version-1 → version-2 wire change. A version-1 sender omits the trailing
+    /// `data_partition` (u16) + `data_partition_epoch` (u64), so zero-fill them (epoch 0 = unfenced,
+    /// never bumps the fence) instead of dropping the message during a rolling upgrade.
+    #[must_use]
+    pub fn decode_compat(bytes: &[u8]) -> Option<Self> {
+        let decode = |b: &[u8]| Self::try_from_be_bytes(b).ok().map(|(r, _)| r);
+        if bytes.first().copied() == Some(1) {
+            let mut padded = Vec::with_capacity(bytes.len() + 10);
+            padded.extend_from_slice(bytes);
+            padded.extend_from_slice(&[0u8; 10]);
+            decode(&padded)
+        } else {
+            decode(bytes)
+        }
+    }
+
     #[must_use]
     pub fn entity_str(&self) -> &str {
         std::str::from_utf8(&self.entity).unwrap_or("")
@@ -386,6 +402,22 @@ impl UniqueReassertRequest {
     #[must_use]
     pub fn data_partition(&self) -> Option<PartitionId> {
         PartitionId::new(self.data_partition)
+    }
+
+    /// Decode across the version-1 → version-2 wire change. A version-1 sender omits the trailing
+    /// `data_partition_epoch` (u64), so zero-fill it (epoch 0 = unfenced) instead of dropping the
+    /// message during a rolling upgrade.
+    #[must_use]
+    pub fn decode_compat(bytes: &[u8]) -> Option<Self> {
+        let decode = |b: &[u8]| Self::try_from_be_bytes(b).ok().map(|(r, _)| r);
+        if bytes.first().copied() == Some(1) {
+            let mut padded = Vec::with_capacity(bytes.len() + 8);
+            padded.extend_from_slice(bytes);
+            padded.extend_from_slice(&[0u8; 8]);
+            decode(&padded)
+        } else {
+            decode(bytes)
+        }
     }
 }
 

--- a/crates/mqdb-cluster/src/cluster/protocol/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/protocol/unique.rs
@@ -238,10 +238,12 @@ pub struct UniqueReleaseRequest {
     pub idempotency_key_len: u16,
     #[FromField(idempotency_key_len)]
     pub idempotency_key: Vec<u8>,
+    pub data_partition: u16,
+    pub data_partition_epoch: u64,
 }
 
 impl UniqueReleaseRequest {
-    pub const VERSION: u8 = 1;
+    pub const VERSION: u8 = 2;
 
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
@@ -251,6 +253,8 @@ impl UniqueReleaseRequest {
         field: &str,
         value: &[u8],
         idempotency_key: &str,
+        data_partition: PartitionId,
+        data_partition_epoch: u64,
     ) -> Self {
         Self {
             version: Self::VERSION,
@@ -263,7 +267,14 @@ impl UniqueReleaseRequest {
             value: value.to_vec(),
             idempotency_key_len: idempotency_key.len() as u16,
             idempotency_key: idempotency_key.as_bytes().to_vec(),
+            data_partition: data_partition.get(),
+            data_partition_epoch,
         }
+    }
+
+    #[must_use]
+    pub fn data_partition(&self) -> Option<PartitionId> {
+        PartitionId::new(self.data_partition)
     }
 
     #[must_use]
@@ -324,10 +335,11 @@ pub struct UniqueReassertRequest {
     #[FromField(record_id_len)]
     pub record_id: Vec<u8>,
     pub data_partition: u16,
+    pub data_partition_epoch: u64,
 }
 
 impl UniqueReassertRequest {
-    pub const VERSION: u8 = 1;
+    pub const VERSION: u8 = 2;
 
     #[must_use]
     #[allow(clippy::cast_possible_truncation)]
@@ -338,6 +350,7 @@ impl UniqueReassertRequest {
         value: &[u8],
         record_id: &str,
         data_partition: PartitionId,
+        data_partition_epoch: u64,
     ) -> Self {
         Self {
             version: Self::VERSION,
@@ -351,6 +364,7 @@ impl UniqueReassertRequest {
             record_id_len: record_id.len() as u16,
             record_id: record_id.as_bytes().to_vec(),
             data_partition: data_partition.get(),
+            data_partition_epoch,
         }
     }
 

--- a/crates/mqdb-cluster/src/cluster/store_manager/unique_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/store_manager/unique_ops.rs
@@ -13,6 +13,7 @@ impl StoreManager {
     /// Reconcile a durable record against its unique claim (record-driven repair). On a
     /// state change (`Established`/`Repaired`), returns the write to persist + replicate.
     #[must_use]
+    #[allow(clippy::too_many_arguments)]
     pub fn reassert_replicated(
         &self,
         entity: &str,
@@ -20,8 +21,16 @@ impl StoreManager {
         value: &[u8],
         record_id: &str,
         data_partition: PartitionId,
+        epoch: u64,
         now: u64,
     ) -> (ReassertResult, Option<ReplicationWrite>) {
+        // Reject a reassert stamped with an epoch below the fence: it is from a data-partition
+        // primary that a failover has superseded, and applying it could re-Establish a committed
+        // claim for a record the new primary has since deleted (see ClusterUniqueReconcilerFence).
+        if !self.db_unique.fence_accepts(data_partition, epoch) {
+            return (ReassertResult::Pending, None);
+        }
+        self.db_unique.fence_bump(data_partition, epoch);
         let result = self
             .db_unique
             .reassert(entity, field, value, record_id, data_partition, now);

--- a/crates/mqdb-cluster/src/cluster/store_manager/unique_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/store_manager/unique_ops.rs
@@ -28,6 +28,14 @@ impl StoreManager {
         // primary that a failover has superseded, and applying it could re-Establish a committed
         // claim for a record the new primary has since deleted (see ClusterUniqueReconcilerFence).
         if !self.db_unique.fence_accepts(data_partition, epoch) {
+            tracing::debug!(
+                entity,
+                field,
+                record_id,
+                epoch,
+                data_partition = data_partition.get(),
+                "unique reassert fenced out: epoch below the data-partition high-water mark (superseded primary)"
+            );
             return (ReassertResult::Pending, None);
         }
         self.db_unique.fence_bump(data_partition, epoch);

--- a/crates/mqdb-cluster/src/cluster/transport.rs
+++ b/crates/mqdb-cluster/src/cluster/transport.rs
@@ -316,7 +316,7 @@ impl ClusterMessage {
                 Some(Self::UniqueCommitResponse(resp))
             }
             84 => {
-                let (req, _) = UniqueReleaseRequest::try_from_be_bytes(data).ok()?;
+                let req = UniqueReleaseRequest::decode_compat(data)?;
                 Some(Self::UniqueReleaseRequest(req))
             }
             85 => {
@@ -324,7 +324,7 @@ impl ClusterMessage {
                 Some(Self::UniqueReleaseResponse(resp))
             }
             86 => {
-                let (req, _) = UniqueReassertRequest::try_from_be_bytes(data).ok()?;
+                let req = UniqueReassertRequest::decode_compat(data)?;
                 Some(Self::UniqueReassertRequest(req))
             }
             87 => {

--- a/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/event_loop.rs
@@ -901,13 +901,15 @@ async fn execute_local_cascade_work(
                         let event = mqdb_core::events::ChangeEvent::delete(
                             entity.clone(),
                             id.clone(),
-                            data,
+                            data.clone(),
                         );
                         let outbox =
                             crate::cluster::node_controller::db_ops::build_change_event_outbox(
                                 &event,
                             );
                         ctrl.db_commit(write, outbox.clone()).await;
+                        ctrl.release_unique_for_deleted_record(entity, id, &data)
+                            .await;
                         ctrl.publish_and_deliver_change_event(event, &outbox.operation_id)
                             .await;
                     }

--- a/crates/mqdb-cluster/tests/cluster_integration_test.rs
+++ b/crates/mqdb-cluster/tests/cluster_integration_test.rs
@@ -4290,6 +4290,7 @@ async fn unique_reassert_request_cross_node_establishes() {
         &value,
         "product-9",
         PartitionId::new(5).unwrap(),
+        1,
     );
 
     let node2_id = cluster.nodes[1].id;

--- a/specs/ClusterUniqueReconcilerChunked.cfg
+++ b/specs/ClusterUniqueReconcilerChunked.cfg
@@ -1,0 +1,16 @@
+\* LOCAL reconcile path: value site == data site, recheck on. Expect: SAFE (chunked collect adds
+\* no wedge; the apply-time recheck closes the widened collect->apply window).
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Colocated = TRUE
+    RecheckOwnership = TRUE
+    DeleteReleases = TRUE
+
+INVARIANTS
+    TypeOK
+    NoOversell
+    ClaimBackedOrReleasing
+
+CHECK_DEADLOCK FALSE

--- a/specs/ClusterUniqueReconcilerChunked.tla
+++ b/specs/ClusterUniqueReconcilerChunked.tla
@@ -1,0 +1,214 @@
+------------------ MODULE ClusterUniqueReconcilerChunked ------------------
+\* Distributed model of the unique reconciler's collect->apply staleness, built to answer one
+\* question: is making COLLECT yield its lock periodically (chunked collect) safe?
+\*
+\* The reconciler has TWO sites for a given (record, value):
+\*   * the DATA site  -- holds the durable record; runs collect + the record_owns_value recheck
+\*                       (crates/.../node_controller/unique.rs:1101-1179).
+\*   * the VALUE site  -- holds the unique claim (keyed by value); applies reasserts with NO recheck
+\*                       (unique.rs:451-463 handle_unique_reassert_request -> reassert_unique_claim).
+\* They are the SAME node only when unique_partition(value) == data_partition(record). Because those
+\* hash independently, the cross-site case is the common one.
+\*
+\* Both the reconciler's reassert AND a record delete's claim release travel DATA->VALUE and can be
+\* REORDERED (fire-and-forget / forwarded writes, no mutual FIFO). reassertMsgs / releaseMsgs are the
+\* in-flight sets, delivered in any order.
+\*
+\* Modeling the collect->apply staleness (the thing chunking changes): a hint may be CAPTURED
+\* (CollectHint) whenever the record owns the value, and APPLIED (ApplyHint) later after arbitrary
+\* interleaving. That nondeterministic gap is a superset of atomic-collect (today) and chunked-collect
+\* (proposed). ApplyHint re-runs the recheck on the DATA site (under the write lock, so recheck+send
+\* are atomic w.r.t. local writes) -- exactly record_owns_value before the reassert.
+\*
+\* Switches:
+\*   Colocated = TRUE  -> value site == data site: recheck and reassert are one atomic step, and a
+\*                        delete's release is applied inline. This is the LOCAL reconcile path.
+\*             = FALSE -> separate sites: recheck on data, reassert crosses the network to the value
+\*                        site (applied with no recheck), release also crosses and may reorder.
+\*   RecheckOwnership = TRUE -> ApplyHint drops a hint whose record no longer owns the value
+\*                              (record_owns_value). FALSE = negative control.
+\*
+\* Result (see the three .cfg files):
+\*   local  (Colocated=TRUE,  Recheck=TRUE)  -> SAFE: chunking the collect adds no wedge; the
+\*                                              apply-time recheck (under the controller write lock,
+\*                                              atomic with the send decision) closes the widened
+\*                                              collect->apply gap. This is the answer to the fix.
+\*   norecheck (Colocated=TRUE, Recheck=FALSE) -> WEDGE: the recheck is load-bearing.
+\*   remote (Colocated=FALSE, Recheck=TRUE)  -> WEDGE reachable IN THE MODEL: a release overtakes an
+\*                                              in-flight reassert, re-Establishing a committed claim
+\*                                              for a value the record no longer owns.
+\*
+\* Quorum resolution of the remote case (what the code actually does):
+\*   - reassert and release for a value travel DATA->VALUE and, for a STABLE primary, over the SAME
+\*     ordered per-peer QUIC stream, sent from the same single-threaded controller loop -> FIFO, so a
+\*     later release cannot overtake an earlier reassert. The remote wedge as traced is therefore an
+\*     ARTIFACT for a stable primary (the "no mutual FIFO" premise below is only true across a
+\*     primary FAILOVER, where the two messages come from different source nodes and there is no
+\*     epoch fence on handle_unique_reassert_request/handle_unique_release_request). So the remote
+\*     cfg documents a real FRAGILITY -- the value site has no recheck and no epoch fence, and only
+\*     message ordering prevents the wedge -- exercisable only under failover of the data primary.
+\*   - The reorder trigger via record DELETE does not exist at all: cluster-mode delete
+\*     (db_delete_replicated) emits NO unique release. That is a SEPARATE, confirmed pre-existing bug
+\*     (agent mode releases on delete via release_unique_guards + test delete_releases_unique_guard;
+\*     the cluster delete path never does), which permanently leaks the unique value. DeleteRecord
+\*     below therefore models UPDATE-AWAY / agent-mode-delete release semantics, not cluster delete.
+\*   - Neither the fragility nor the delete-leak is caused or widened by chunking the collect: the
+\*     send->deliver gap is independent of the data-node-local collect->apply window.
+\*
+\* Single contended value V, modelled implicitly. Create is collapsed to one atomic step (reserve
+\* only when the claim is free, then write+commit) -- the reserve/write/commit/CAS interleavings and
+\* their oversell are covered by ClusterUniqueReconciler.tla; here the focus is the reconciler wedge.
+
+EXTENDS Naturals, FiniteSets
+
+\* DeleteReleases = FALSE reproduces the confirmed cluster bug (delete never releases the claim);
+\* TRUE models the fix (delete emits a release, as agent mode and update-away already do).
+CONSTANTS Records, Colocated, RecheckOwnership, DeleteReleases
+
+NULL == CHOOSE x : x \notin Records
+
+VARIABLES
+    recordExists,    \* [Records -> BOOLEAN] : durable record present (DATA site)
+    hasV,            \* [Records -> BOOLEAN] : record's unique field currently equals V (DATA site)
+    claimOwner,      \* Records \cup {NULL}  : owner of the claim for V (VALUE site)
+    claimCommitted,  \* BOOLEAN              : claim promoted to permanent (VALUE site)
+    pendingHints,    \* SUBSET Records : reassert hints captured by collect, not yet applied (DATA)
+    reassertMsgs,    \* SUBSET Records : in-flight reassert(r) requests DATA->VALUE
+    releaseMsgs      \* SUBSET Records : in-flight release(r) requests DATA->VALUE (from delete/update)
+
+vars == << recordExists, hasV, claimOwner, claimCommitted,
+           pendingHints, reassertMsgs, releaseMsgs >>
+
+Owns(r) == recordExists[r] /\ hasV[r]
+
+\* Effect of reassert(V, r) on the claim (UniqueStore::reassert, unique_store.rs:287-312):
+\*   absent -> Establish committed(r); owned-by-r -> commit; owned-by-other -> no-op (Conflict/Pending).
+ReassertOwner(r)     == IF claimOwner = NULL THEN r ELSE claimOwner
+ReassertCommitted(r) == IF claimOwner = NULL \/ claimOwner = r THEN TRUE ELSE claimCommitted
+
+\* Effect of release(V, r): removes the claim iff owned by r (unique_store.rs:252-267).
+ReleaseOwner(r)     == IF claimOwner = r THEN NULL  ELSE claimOwner
+ReleaseCommitted(r) == IF claimOwner = r THEN FALSE ELSE claimCommitted
+
+TypeOK ==
+    /\ recordExists   \in [Records -> BOOLEAN]
+    /\ hasV           \in [Records -> BOOLEAN]
+    /\ claimOwner     \in Records \cup {NULL}
+    /\ claimCommitted \in BOOLEAN
+    /\ pendingHints   \in SUBSET Records
+    /\ reassertMsgs   \in SUBSET Records
+    /\ releaseMsgs    \in SUBSET Records
+
+Init ==
+    /\ recordExists   = [r \in Records |-> FALSE]
+    /\ hasV           = [r \in Records |-> FALSE]
+    /\ claimOwner     = NULL
+    /\ claimCommitted = FALSE
+    /\ pendingHints   = {}
+    /\ reassertMsgs   = {}
+    /\ releaseMsgs    = {}
+
+\* Create r: succeeds only when the claim for V is free (reserve would otherwise Conflict). Collapses
+\* reserve->write->commit into one atomic step (see header). Establishes record + committed claim.
+CreateRecord(r) ==
+    /\ ~recordExists[r]
+    /\ claimOwner = NULL
+    /\ recordExists'   = [recordExists EXCEPT ![r] = TRUE]
+    /\ hasV'           = [hasV EXCEPT ![r] = TRUE]
+    /\ claimOwner'     = r
+    /\ claimCommitted' = TRUE
+    /\ UNCHANGED << pendingHints, reassertMsgs, releaseMsgs >>
+
+\* Delete r: remove the record, then release its claim for V. Inline when co-located, else the release
+\* is forwarded to the value site (may reorder vs a reassert).
+DeleteRecord(r) ==
+    /\ recordExists[r]
+    /\ recordExists' = [recordExists EXCEPT ![r] = FALSE]
+    /\ hasV'         = [hasV EXCEPT ![r] = FALSE]
+    /\ IF ~DeleteReleases
+         THEN UNCHANGED << claimOwner, claimCommitted, releaseMsgs >>  \* current cluster bug: no release
+         ELSE IF Colocated
+           THEN /\ claimOwner'     = ReleaseOwner(r)
+                /\ claimCommitted' = ReleaseCommitted(r)
+                /\ UNCHANGED releaseMsgs
+           ELSE /\ releaseMsgs' = releaseMsgs \cup {r}
+                /\ UNCHANGED << claimOwner, claimCommitted >>
+    /\ UNCHANGED << pendingHints, reassertMsgs >>
+
+\* Update r's unique field away from V: record persists, releases r's claim for V (same routing).
+UpdateAway(r) ==
+    /\ recordExists[r]
+    /\ hasV[r]
+    /\ hasV' = [hasV EXCEPT ![r] = FALSE]
+    /\ IF Colocated
+         THEN /\ claimOwner'     = ReleaseOwner(r)
+              /\ claimCommitted' = ReleaseCommitted(r)
+              /\ UNCHANGED releaseMsgs
+         ELSE /\ releaseMsgs' = releaseMsgs \cup {r}
+              /\ UNCHANGED << claimOwner, claimCommitted >>
+    /\ UNCHANGED << recordExists, pendingHints, reassertMsgs >>
+
+\* Reconciler COLLECT: capture one hint whenever the record currently owns V (staggered capture across
+\* records = the yielding collect). Data-site read only.
+CollectHint(r) ==
+    /\ Owns(r)
+    /\ r \notin pendingHints
+    /\ pendingHints' = pendingHints \cup {r}
+    /\ UNCHANGED << recordExists, hasV, claimOwner, claimCommitted, reassertMsgs, releaseMsgs >>
+
+\* Reconciler APPLY: record_owns_value recheck on the DATA site. If it passes (or the recheck is
+\* switched off), reassert -- inline when co-located, else send to the value site.
+ApplyHint(r) ==
+    /\ r \in pendingHints
+    /\ pendingHints' = pendingHints \ {r}
+    /\ IF RecheckOwnership /\ ~Owns(r)
+         THEN UNCHANGED << claimOwner, claimCommitted, reassertMsgs >>      \* recheck skip
+         ELSE IF Colocated
+                THEN /\ claimOwner'     = ReassertOwner(r)                  \* recheck+reassert atomic
+                     /\ claimCommitted' = ReassertCommitted(r)
+                     /\ UNCHANGED reassertMsgs
+                ELSE /\ reassertMsgs' = reassertMsgs \cup {r}               \* crosses network, no recheck there
+                     /\ UNCHANGED << claimOwner, claimCommitted >>
+    /\ UNCHANGED << recordExists, hasV, releaseMsgs >>
+
+\* VALUE site applies a delivered reassert -- NO recheck (it holds no record).
+DeliverReassert(r) ==
+    /\ r \in reassertMsgs
+    /\ reassertMsgs' = reassertMsgs \ {r}
+    /\ claimOwner'     = ReassertOwner(r)
+    /\ claimCommitted' = ReassertCommitted(r)
+    /\ UNCHANGED << recordExists, hasV, pendingHints, releaseMsgs >>
+
+\* VALUE site applies a delivered release.
+DeliverRelease(r) ==
+    /\ r \in releaseMsgs
+    /\ releaseMsgs' = releaseMsgs \ {r}
+    /\ claimOwner'     = ReleaseOwner(r)
+    /\ claimCommitted' = ReleaseCommitted(r)
+    /\ UNCHANGED << recordExists, hasV, pendingHints, reassertMsgs >>
+
+Next ==
+    \/ \E r \in Records : CreateRecord(r)
+    \/ \E r \in Records : DeleteRecord(r)
+    \/ \E r \in Records : UpdateAway(r)
+    \/ \E r \in Records : CollectHint(r)
+    \/ \E r \in Records : ApplyHint(r)
+    \/ \E r \in Records : DeliverReassert(r)
+    \/ \E r \in Records : DeliverRelease(r)
+
+Spec == Init /\ [][Next]_vars
+
+\* ---- Invariants ----
+
+\* At most one durable record holds value V (the unique constraint itself).
+NoOversell == Cardinality({r \in Records : Owns(r)}) <= 1
+
+\* A committed claim must be backed by a live record that owns V, OR a release for its owner must be
+\* in flight that will clean it up. A state that commits a claim for a non-owning record with NO
+\* pending release is a PERMANENT wedge: TTL never reclaims a committed claim, and the record-driven
+\* reconciler will never revisit a gone record. This is the property the apply-time recheck protects.
+ClaimBackedOrReleasing ==
+    (claimCommitted /\ claimOwner # NULL /\ ~Owns(claimOwner))
+        => (claimOwner \in releaseMsgs)
+
+===========================================================================

--- a/specs/ClusterUniqueReconcilerChunked_deleteleak.cfg
+++ b/specs/ClusterUniqueReconcilerChunked_deleteleak.cfg
@@ -1,0 +1,19 @@
+\* CONFIRMED PRE-EXISTING BUG: cluster-mode record delete never releases the record's committed
+\* unique claim (db_delete_replicated touches only db_data + FK index; agent mode releases via
+\* release_unique_guards). Co-located and recheck ON to isolate the leak from any reorder. Expect:
+\* ClaimBackedOrReleasing VIOLATED -- after a delete, the committed claim outlives its record with no
+\* release to clean it up, so the unique value is permanently unusable.
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Colocated = TRUE
+    RecheckOwnership = TRUE
+    DeleteReleases = FALSE
+
+INVARIANTS
+    TypeOK
+    NoOversell
+    ClaimBackedOrReleasing
+
+CHECK_DEADLOCK FALSE

--- a/specs/ClusterUniqueReconcilerChunked_norecheck.cfg
+++ b/specs/ClusterUniqueReconcilerChunked_norecheck.cfg
@@ -1,0 +1,16 @@
+\* NEGATIVE CONTROL: co-located, recheck OFF. Expect: ClaimBackedOrReleasing VIOLATED -- proves the
+\* apply-time record_owns_value recheck is load-bearing even on the local path.
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Colocated = TRUE
+    RecheckOwnership = FALSE
+    DeleteReleases = TRUE
+
+INVARIANTS
+    TypeOK
+    NoOversell
+    ClaimBackedOrReleasing
+
+CHECK_DEADLOCK FALSE

--- a/specs/ClusterUniqueReconcilerChunked_remote.cfg
+++ b/specs/ClusterUniqueReconcilerChunked_remote.cfg
@@ -1,0 +1,18 @@
+\* REMOTE reconcile path: value site != data site, recheck on. Expect: ClaimBackedOrReleasing
+\* VIOLATED -- a delete's release overtakes an in-flight reassert, which re-Establishes a committed
+\* claim for the deleted record (permanent wedge). PRE-EXISTING in the local-recheck/remote-apply
+\* design; independent of collect chunking (the send->deliver gap does not depend on it).
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Colocated = FALSE
+    RecheckOwnership = TRUE
+    DeleteReleases = TRUE
+
+INVARIANTS
+    TypeOK
+    NoOversell
+    ClaimBackedOrReleasing
+
+CHECK_DEADLOCK FALSE

--- a/specs/ClusterUniqueReconcilerFence.cfg
+++ b/specs/ClusterUniqueReconcilerFence.cfg
@@ -1,0 +1,16 @@
+\* Epoch fence ON. Expect: SAFE across the full state space, including data-primary failover -- a
+\* stale reassert from a deposed primary is rejected once the new primary's higher-epoch release is
+\* applied. Repair is preserved (LoseClaim + a current-epoch reassert re-establishes a backed claim).
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Fenced = TRUE
+    MaxEpoch = 3
+
+INVARIANTS
+    TypeOK
+    NoOversell
+    ClaimBackedOrReleasing
+
+CHECK_DEADLOCK FALSE

--- a/specs/ClusterUniqueReconcilerFence.tla
+++ b/specs/ClusterUniqueReconcilerFence.tla
@@ -1,0 +1,184 @@
+-------------------- MODULE ClusterUniqueReconcilerFence --------------------
+\* Models the epoch fence that closes the failover reorder wedge left open by
+\* ClusterUniqueReconcilerChunked.tla (remote cfg).
+\*
+\* The wedge: the reconciler's reassert (data-partition primary -> value-partition primary) and a
+\* delete/update's release travel as independent fire-and-forget messages. For a STABLE primary they
+\* share one FIFO stream so they cannot reorder; across a data-primary FAILOVER the in-flight reassert
+\* (from the deposed primary) and the release (from the new primary) take different streams and can
+\* reorder, so the stale reassert lands after the release and re-Establishes a committed claim for a
+\* record that is gone -> permanent wedge. The value site applies both with NO recheck and NO fence
+\* today (handle_unique_reassert_request / handle_unique_release_request).
+\*
+\* The fence: stamp every claim-mutating message with the DATA-PARTITION EPOCH at send time. The value
+\* site keeps a per-partition high-water mark (fenceEpoch) and rejects any message whose epoch is
+\* BELOW it, bumping it to the max on every accepted message. A deposed primary's reassert carries the
+\* old epoch and is dropped once the new primary's higher-epoch release has been applied. Repair is
+\* preserved: the periodic reconciler re-issues a current-epoch reassert on its next cycle.
+\*
+\* Fenced = TRUE models the fix; FALSE reproduces today's unfenced reorder wedge.
+\* Single contended value V and single data partition (one monotonic epoch lineage), modelled
+\* implicitly. Records = claimers. Create is atomic co-located (its oversell is covered elsewhere);
+\* the focus is the reassert/release reorder across failover.
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANTS Records, Fenced, MaxEpoch
+
+NULL == CHOOSE x : x \notin Records
+
+VARIABLES
+    recordExists,    \* [Records -> BOOLEAN] : durable record present (data site)
+    hasV,            \* [Records -> BOOLEAN] : record's unique field currently equals V (data site)
+    claimOwner,      \* Records \cup {NULL}  : owner of the claim for V (value site)
+    claimCommitted,  \* BOOLEAN              : claim promoted to permanent (value site)
+    dataEpoch,       \* 1..MaxEpoch : current epoch of the data partition (bumped by failover)
+    fenceEpoch,      \* 0..MaxEpoch : value site's per-partition high-water mark
+    pendingHints,    \* SUBSET Records : reassert hints captured by collect, not yet applied
+    reassertMsgs,    \* SUBSET (Records \X (1..MaxEpoch)) : in-flight epoch-stamped reasserts
+    releaseMsgs      \* SUBSET (Records \X (1..MaxEpoch)) : in-flight epoch-stamped releases
+
+vars == << recordExists, hasV, claimOwner, claimCommitted, dataEpoch, fenceEpoch,
+           pendingHints, reassertMsgs, releaseMsgs >>
+
+Owns(r) == recordExists[r] /\ hasV[r]
+Epochs  == 1..MaxEpoch
+
+ReassertOwner(r)     == IF claimOwner = NULL THEN r ELSE claimOwner
+ReassertCommitted(r) == IF claimOwner = NULL \/ claimOwner = r THEN TRUE ELSE claimCommitted
+ReleaseOwner(r)      == IF claimOwner = r THEN NULL  ELSE claimOwner
+ReleaseCommitted(r)  == IF claimOwner = r THEN FALSE ELSE claimCommitted
+
+\* A message is accepted iff the fence is off or its epoch is at least the high-water mark.
+Accept(e) == (~Fenced) \/ (e >= fenceEpoch)
+Bump(e)   == IF e > fenceEpoch THEN e ELSE fenceEpoch
+
+TypeOK ==
+    /\ recordExists   \in [Records -> BOOLEAN]
+    /\ hasV           \in [Records -> BOOLEAN]
+    /\ claimOwner     \in Records \cup {NULL}
+    /\ claimCommitted \in BOOLEAN
+    /\ dataEpoch      \in Epochs
+    /\ fenceEpoch     \in 0..MaxEpoch
+    /\ pendingHints   \in SUBSET Records
+    /\ reassertMsgs   \in SUBSET (Records \X Epochs)
+    /\ releaseMsgs    \in SUBSET (Records \X Epochs)
+
+Init ==
+    /\ recordExists   = [r \in Records |-> FALSE]
+    /\ hasV           = [r \in Records |-> FALSE]
+    /\ claimOwner     = NULL
+    /\ claimCommitted = FALSE
+    /\ dataEpoch      = 1
+    /\ fenceEpoch     = 0
+    /\ pendingHints   = {}
+    /\ reassertMsgs   = {}
+    /\ releaseMsgs    = {}
+
+\* Atomic co-located create: only when the claim for V is free AND no durable record already owns V
+\* (the data-layer unique constraint; a claim lost to value-primary failover does not license a
+\* second owner -- that claim-loss/oversell hazard is out of this spec's scope).
+CreateRecord(r) ==
+    /\ ~recordExists[r]
+    /\ claimOwner = NULL
+    /\ \A other \in Records : ~Owns(other)
+    /\ recordExists'   = [recordExists EXCEPT ![r] = TRUE]
+    /\ hasV'           = [hasV EXCEPT ![r] = TRUE]
+    /\ claimOwner'     = r
+    /\ claimCommitted' = TRUE
+    /\ UNCHANGED << dataEpoch, fenceEpoch, pendingHints, reassertMsgs, releaseMsgs >>
+
+\* Value-primary failover drops the claim while the durable record persists -- the exact state a
+\* reassert Establish is meant to repair.
+LoseClaim ==
+    /\ claimOwner # NULL
+    /\ Owns(claimOwner)
+    /\ claimOwner'     = NULL
+    /\ claimCommitted' = FALSE
+    /\ UNCHANGED << recordExists, hasV, dataEpoch, fenceEpoch, pendingHints, reassertMsgs, releaseMsgs >>
+
+\* Delete r: record gone; release forwarded to the value site, stamped with the current epoch.
+DeleteRecord(r) ==
+    /\ recordExists[r]
+    /\ recordExists' = [recordExists EXCEPT ![r] = FALSE]
+    /\ hasV'         = [hasV EXCEPT ![r] = FALSE]
+    /\ releaseMsgs'  = releaseMsgs \cup {<<r, dataEpoch>>}
+    /\ UNCHANGED << claimOwner, claimCommitted, dataEpoch, fenceEpoch, pendingHints, reassertMsgs >>
+
+\* Update r's field away from V: record persists, releases V, stamped with the current epoch.
+UpdateAway(r) ==
+    /\ recordExists[r]
+    /\ hasV[r]
+    /\ hasV'        = [hasV EXCEPT ![r] = FALSE]
+    /\ releaseMsgs' = releaseMsgs \cup {<<r, dataEpoch>>}
+    /\ UNCHANGED << recordExists, claimOwner, claimCommitted, dataEpoch, fenceEpoch, pendingHints, reassertMsgs >>
+
+\* Data-primary failover bumps the partition epoch.
+Failover ==
+    /\ dataEpoch < MaxEpoch
+    /\ dataEpoch' = dataEpoch + 1
+    /\ UNCHANGED << recordExists, hasV, claimOwner, claimCommitted, fenceEpoch, pendingHints, reassertMsgs, releaseMsgs >>
+
+CollectHint(r) ==
+    /\ Owns(r)
+    /\ r \notin pendingHints
+    /\ pendingHints' = pendingHints \cup {r}
+    /\ UNCHANGED << recordExists, hasV, claimOwner, claimCommitted, dataEpoch, fenceEpoch, reassertMsgs, releaseMsgs >>
+
+\* Apply: record_owns_value recheck on the data site; if it passes, send an epoch-stamped reassert.
+ApplyHint(r) ==
+    /\ r \in pendingHints
+    /\ pendingHints' = pendingHints \ {r}
+    /\ IF Owns(r)
+         THEN reassertMsgs' = reassertMsgs \cup {<<r, dataEpoch>>}
+         ELSE UNCHANGED reassertMsgs
+    /\ UNCHANGED << recordExists, hasV, claimOwner, claimCommitted, dataEpoch, fenceEpoch, releaseMsgs >>
+
+\* Value site applies a delivered reassert -- no record recheck, only the epoch fence.
+DeliverReassert(r, e) ==
+    /\ <<r, e>> \in reassertMsgs
+    /\ reassertMsgs' = reassertMsgs \ {<<r, e>>}
+    /\ IF Accept(e)
+         THEN /\ claimOwner'     = ReassertOwner(r)
+              /\ claimCommitted' = ReassertCommitted(r)
+              /\ fenceEpoch'     = Bump(e)
+         ELSE UNCHANGED << claimOwner, claimCommitted, fenceEpoch >>
+    /\ UNCHANGED << recordExists, hasV, dataEpoch, pendingHints, releaseMsgs >>
+
+\* Value site applies a delivered release. A release is ALWAYS applied and is NOT fenced: it removes
+\* the claim only when the committed owner's record_id matches (ReleaseOwner), so a stale release for
+\* a superseded record is a harmless no-op and can never drop another record's claim. It still bumps
+\* the high-water mark so a later stale reassert is rejected. Same-epoch messages share one FIFO
+\* stream and the apply recheck forbids a reassert after the record's delete, so a same-(record,epoch)
+\* reassert was sent first and must be consumed first; only cross-epoch (failover) reorder remains.
+DeliverRelease(r, e) ==
+    /\ <<r, e>> \in releaseMsgs
+    /\ <<r, e>> \notin reassertMsgs
+    /\ releaseMsgs'    = releaseMsgs \ {<<r, e>>}
+    /\ claimOwner'     = ReleaseOwner(r)
+    /\ claimCommitted' = ReleaseCommitted(r)
+    /\ fenceEpoch'     = Bump(e)
+    /\ UNCHANGED << recordExists, hasV, dataEpoch, pendingHints, reassertMsgs >>
+
+Next ==
+    \/ \E r \in Records : CreateRecord(r)
+    \/ LoseClaim
+    \/ \E r \in Records : DeleteRecord(r)
+    \/ \E r \in Records : UpdateAway(r)
+    \/ Failover
+    \/ \E r \in Records : CollectHint(r)
+    \/ \E r \in Records : ApplyHint(r)
+    \/ \E r \in Records, e \in Epochs : DeliverReassert(r, e)
+    \/ \E r \in Records, e \in Epochs : DeliverRelease(r, e)
+
+Spec == Init /\ [][Next]_vars
+
+NoOversell == Cardinality({r \in Records : Owns(r)}) <= 1
+
+\* A committed claim for a record that no longer owns V is a permanent wedge unless a release for it
+\* is still in flight to clean it up.
+ClaimBackedOrReleasing ==
+    (claimCommitted /\ claimOwner # NULL /\ ~Owns(claimOwner))
+        => (\E e \in Epochs : <<claimOwner, e>> \in releaseMsgs)
+
+===========================================================================

--- a/specs/ClusterUniqueReconcilerFence_unfenced.cfg
+++ b/specs/ClusterUniqueReconcilerFence_unfenced.cfg
@@ -1,0 +1,16 @@
+\* Epoch fence OFF (today's behavior). Expect: ClaimBackedOrReleasing VIOLATED -- across a failover
+\* the release overtakes the in-flight reassert, which then re-Establishes a committed claim for the
+\* deleted record. This is the failover reorder wedge the fence closes.
+SPECIFICATION Spec
+
+CONSTANTS
+    Records = {r1, r2}
+    Fenced = FALSE
+    MaxEpoch = 3
+
+INVARIANTS
+    TypeOK
+    NoOversell
+    ClaimBackedOrReleasing
+
+CHECK_DEADLOCK FALSE


### PR DESCRIPTION
## Summary

- release a record's committed unique claim on delete (cluster mode). Deleting a record removed only the durable record and the FK reverse index, never its unique claim, so the value was leaked forever (a new create hit a conflict; TTL only reclaims uncommitted claims; the record-driven reconciler never revisits a deleted record). Agent mode already released on delete — this closes the parity gap at every delete site (direct, binary, db_ops parent, FK cascade children) via a shared `release_unique_for_deleted_record`
- fence unique reasserts by data-partition epoch. Across a data-partition-primary failover, a deposed primary's in-flight reassert could reorder past the new primary's release and re-establish a committed claim for a deleted record. Reassert/release now carry the data-partition epoch (wire version 2); the value site keeps a per-partition high-water mark and drops reasserts below it, while releases always apply (they only touch their own record's claim) and bump the mark
- add TLA specs: `ClusterUniqueReconcilerChunked` (collect/apply staleness + delete-leak) and `ClusterUniqueReconcilerFence` (epoch fence), each with negative controls
- rolling-upgrade safe: a version-2 node decodes a version-1 sender's reassert/release as unfenced (epoch 0) via `decode_compat` rather than dropping it (a dropped release would leak the claim)
- log fenced-out reasserts at `debug` (previously silent)
- bump mqdb-cluster 0.4.2, mqdb-cli 0.8.17; update CHANGELOG

Joint-consensus membership for a reserve/seal majority shift remains, tracked in #101.

## Test plan

- [x] cargo make clippy
- [x] cargo make test — mqdb-cluster 519 lib + 76 integration + 49 (pre-existing `test_cli_connect_timeout_against_silent_listener` mqdb-cli timing flake unrelated)
- [x] `delete_releases_unique_claim`, `cascade_delete_releases_child_unique_claim`, `fence_rejects_stale_epoch_per_data_partition`, `reassert_replicated_rejects_stale_epoch_below_the_fence`, `unique_{release,reassert}_request_decode_compat_reads_v1`
- [x] TLA: fenced spec ok over 698k states; unfenced / delete-leak / no-recheck controls violate as expected
