### PR TITLE
pace unique-voter removal to close correlated-loss oversell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-07-21 — mqdb-cli 0.8.18, mqdb-cluster 0.4.3
+
+### Fixed
+
+- **Membership-change unique oversell closed with raft-gated voters.** A cluster membership change between a unique reserve and a post-failover seal could shift the seal majority off the reservation's holders and oversell the value — the residual documented under the prior "Unique quorum group is now consensus-consistent" entry. The unique majority/seal quorum now uses a leader-authoritative **voter set** rather than the raw partition-map membership: a newly-joined node is a learner (it receives every reserve/replicate/seal write so it stays caught up) and does not count toward the majority/seal until the leader promotes it. The leader converges the voter set toward the current membership one node per interval (longer than the reserve quorum timeout), so any single membership change keeps every outstanding reservation a majority of the voter set. Modeled in `specs/ClusterUniqueReconfigV4/V5/V6.tla` (paced single-step admission is safe; eager re-replication and unpaced changes oversell).
+- **Correlated multi-node loss fails closed instead of overselling.** A departed voter is kept in the majority/seal denominator until the leader paces it out one node per interval, rather than being dropped the instant it leaves the partition map. Dropping it immediately could shrink the denominator by more than one node at once under a correlated failure (e.g. a dual-AZ outage stripping a reservation's holder majority within one window), letting a seal reach a majority that misses the holders. A departed voter cannot ack a reserve or seal, so keeping it counted only raises the quorum bar — the seal fails closed until pacing removes the surplus.
+
+### Changed
+
+- **Heartbeat wire bumped to version 3.** Heartbeats now carry the leader's unique-voter set (`voter_term`, `voter_seq`, and the voter node ids); receivers adopt a set with a strictly newer `(term, seq)`. For rolling upgrades, the trailer is appended after the existing bitmaps and the frame is self-delimited, so a version-2 node ignores it and a version-3 node reading a version-2 heartbeat treats it as carrying no voter set (falling back to the full membership) rather than dropping it.
+
 ## 2026-07-19 — mqdb-cli 0.8.17, mqdb-cluster 0.4.2
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.17"
+version = "0.8.18"
 dependencies = [
  "base64",
  "bebytes",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cluster"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.17"
+version = "0.8.18"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/Cargo.toml
+++ b/crates/mqdb-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cluster"
-version = "0.4.2"
+version = "0.4.3"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/mod.rs
@@ -651,6 +651,10 @@ impl<T: ClusterTransport> NodeController<T> {
         self.heartbeat.update_partition_map(map);
     }
 
+    /// Synchronous tick used only by tests (`send_tick_output` drives the collected output). The
+    /// production cluster-agent event loop uses its own async `handle_tick`, which additionally runs
+    /// `manage_unique_voters`, `sweep_unique_quorum`, and `sweep_unique_seals` — this path does NOT,
+    /// so a test exercising unique voter management must invoke those explicitly.
     pub fn tick(&mut self, now: u64) -> TickOutput {
         let start = std::time::Instant::now();
 

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -534,6 +534,53 @@ async fn manage_unique_voters_removes_departed_voter() {
 }
 
 #[tokio::test]
+async fn correlated_removal_does_not_collapse_voter_majority() {
+    // Finding-2 regression guard. A correlated multi-node loss must NOT instantly shrink the voter
+    // majority/seal denominator: removal is paced one node per interval (single-step safety, V6). If
+    // the denominator collapsed by 2 at once, a seal could reach a majority that misses a
+    // reservation's holder-majority and oversell (V6 unpaced). Departed voters stay counted until
+    // paced removal, so a seal must reach a majority of the FULL set — which still intersects any
+    // holder-majority — or fail closed.
+    let n = |i: u16| NodeId::validated(i).unwrap();
+    let mut ctrl = create_test_controller(n(1), MockTransport::new(n(1)));
+    set_unique_group(&mut ctrl, n(1), &[n(2), n(3), n(4), n(5)]);
+    ctrl.seed_unique_voters([n(1), n(2), n(3), n(4), n(5)].into_iter().collect());
+    assert_eq!(ctrl.unique_majority(), 3);
+    assert_eq!(
+        ctrl.unique_voter_group(),
+        vec![n(1), n(2), n(3), n(4), n(5)]
+    );
+
+    // Nodes 4 and 5 leave the partition map together (correlated failure), before the leader's paced
+    // removal has run. The voter denominator must stay at 5 (majority 3), not collapse to {1,2,3}.
+    set_unique_group(&mut ctrl, n(1), &[n(2), n(3)]);
+    assert_eq!(
+        ctrl.unique_majority(),
+        3,
+        "a correlated 2-node loss must not instantly collapse the voter majority"
+    );
+    assert_eq!(
+        ctrl.unique_voter_group(),
+        vec![n(1), n(2), n(3), n(4), n(5)],
+        "departed voters remain in the denominator until paced removal (fail-closed, not oversell)"
+    );
+
+    // The leader then paces them out one node per interval, converging to the surviving membership.
+    ctrl.manage_unique_voters(true, 1, super::unique::UNIQUE_VOTER_CHANGE_INTERVAL_MS + 1);
+    assert_eq!(
+        ctrl.unique_voter_group().len(),
+        4,
+        "exactly one departed voter is removed per interval"
+    );
+    ctrl.manage_unique_voters(
+        true,
+        1,
+        2 * super::unique::UNIQUE_VOTER_CHANGE_INTERVAL_MS + 2,
+    );
+    assert_eq!(ctrl.unique_voter_group(), vec![n(1), n(2), n(3)]);
+}
+
+#[tokio::test]
 async fn followers_do_not_manage_voters() {
     let node1 = NodeId::validated(1).unwrap();
     let node2 = NodeId::validated(2).unwrap();

--- a/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/unique.rs
@@ -642,23 +642,23 @@ impl<T: ClusterTransport> NodeController<T> {
 
     /// The unique VOTER set — the denominator for durability and seal quorums. A reservation is
     /// majority-durable and a seal learns it only against these nodes, so a newly-joined node is
-    /// excluded until the leader has carried outstanding reservations to it and promoted it. Filtered
-    /// to current membership so a not-yet-removed departed voter cannot inflate the denominator.
+    /// excluded until the leader has carried outstanding reservations to it and promoted it. The set
+    /// is the leader-managed voter set verbatim: it is NOT filtered to current membership, because a
+    /// departed voter must stay in the denominator until the leader paces it out one node per
+    /// interval. Filtering it out on departure would shrink the denominator by more than one node at
+    /// once under correlated loss, defeating the single-step safety invariant (see
+    /// `ClusterUniqueReconfigV6.tla`: unpaced removal oversells). A departed voter cannot ack a
+    /// reserve or seal (it is absent from `unique_fanout_group`), so keeping it counted only raises
+    /// the quorum bar — a correlated loss fails closed rather than overselling.
     /// Before the leader establishes a voter set (empty), falls back to the full fan-out group —
-    /// pre-founding there are no reservations to protect, and the leader installs the lagged set
-    /// within a tick.
+    /// pre-founding there are no reservations to protect, and the leader installs the set within a tick.
     #[must_use]
     pub(crate) fn unique_voter_group(&self) -> Vec<NodeId> {
         let voters = self.heartbeat.voters();
         if voters.is_empty() {
             return self.unique_fanout_group();
         }
-        let members = self.partition_map.all_nodes();
-        let mut group: Vec<NodeId> = voters
-            .iter()
-            .copied()
-            .filter(|n| *n == self.node_id || members.contains(n))
-            .collect();
+        let mut group: Vec<NodeId> = voters.iter().copied().collect();
         group.sort_unstable_by_key(|n| n.get());
         group
     }

--- a/docs/design/cluster-unique-hardening.md
+++ b/docs/design/cluster-unique-hardening.md
@@ -350,20 +350,33 @@ concurrent reserve/quorum await, and the remote-reserve timeout reservation leak
   re-check and by `project` skipping keys whose record was deleted. Tests:
   `reconcile_apply_skips_record_deleted_after_collection`,
   `project_reconcile_work_skips_key_deleted_after_gather`.
-- **Dynamic reconfiguration — quorum-group source FIXED; membership-change intersection still OPEN.**
-  `unique_quorum_group()` now derives from the **replicated partition map** (`PartitionMap::all_nodes()`
-  ∪ self), not `HeartbeatManager::registered_nodes()`. The map is consensus-agreed, so every node
-  derives the **same** group and it changes only through raft rebalance — closing the silent, divergent
-  heartbeat growth (`receive_heartbeat` inserting a previously-unknown sender) that was the disjoint-
-  majority source. `registered_nodes()` is removed. At a failover the map already holds every other
-  partition's assignment, so `all_nodes()` is the full membership when `become_primary` computes the
-  seal majority (the formation-time small-group seal is benign: no prior reservations to learn, no
-  superseded primary to fence). Tests: `unique_quorum_group_derives_from_map_not_heartbeat_growth`,
-  `PartitionMap::all_nodes` unit test.
-  **Still open:** a membership *change* that alters the majority between a reserve and its seal can in
-  principle disjoin the two majorities. Fully closing it needs joint-consensus / epoch-versioned
-  reconfiguration (overlapping old+new majorities during a transition) — the TLA models use a fixed
-  `Nodes` constant, so this transition case remains unmodeled.
+- **Dynamic reconfiguration — quorum-group source FIXED; membership-change intersection FIXED via raft-gated voters.**
+  The unique quorum was first moved off the heartbeat-discovered node set onto the **replicated partition
+  map** (`PartitionMap::all_nodes()` ∪ self), which is consensus-agreed so every node derives the same
+  group — closing the silent, divergent heartbeat growth that was the disjoint-majority source.
+  **A membership *change* between a reserve and its seal is now also closed** by gating the voter set: the
+  majority/seal denominator is a **leader-authoritative unique-voter set** (`unique_voter_group()`), a
+  subset of the fan-out membership. Writes still fan out to the whole membership (`unique_fanout_group()`),
+  so a newly-joined node stays caught up as a learner, but it does **not** count toward the majority/seal
+  until the leader promotes it. The leader converges the voter set toward the membership **one node per
+  `UNIQUE_VOTER_CHANGE_INTERVAL_MS`** (> the reserve quorum timeout), so any single membership change keeps
+  every outstanding reservation a majority of the voter set (single-step safety). The voter set is stamped
+  `(raft_term, seq)` and gossiped in the heartbeat (wire version 3); receivers adopt a strictly-newer stamp.
+  A departed voter is kept in the denominator until it is paced out (not dropped the instant it leaves the
+  map), so a correlated multi-node loss fails closed rather than collapsing the denominator and overselling.
+  Modeled: `specs/ClusterUniqueReconfigV4.tla` (the hazard survives raft liveness), `V5` (lazy admission is
+  safe, eager re-replication oversells), `V6` (the shipped paced single-step mechanism is safe, unpaced
+  oversells). Tests: the voter-set unit tests in `node_controller/tests.rs`
+  (`manage_unique_voters_*`, `unique_voter_group_*`, `correlated_removal_does_not_collapse_voter_majority`).
+  **Remaining (narrow, documented):** the voter set is in-memory only. During the window where a node's
+  voter set is empty — a fresh cluster, or a node between process restart and adopting the first
+  voter-bearing heartbeat — `unique_voter_group()` falls back to the full fan-out membership (there is
+  nothing yet to protect on a fresh cluster; a restarted node adopts the founded set within a heartbeat,
+  well inside the 3–5 s election timeout). A promoting primary that seals from that fallback while a
+  reservation is held on a smaller established voter set could in principle disjoin — a narrow, unmodeled
+  transient. Committed claims are backstopped by the record-driven reconciler; the residual is the
+  uncommitted window. Hardening options if needed: persist the voter set, or fail a seal closed on an empty
+  voter set instead of falling back. Tracked as future work, not a routine hazard.
 
 - **P2.a — Quorum group + majority helpers.** `unique_quorum_group() -> Vec<NodeId>` and
   `unique_majority(n)`. Land together with their first consumer (P2.b) to avoid dead code.
@@ -412,9 +425,11 @@ partitions) ∪ `local_node` — with `unique_majority()` = `⌊|group|/2⌋ + 1
 so all nodes derive the same group and it changes only through raft rebalance; no new cross-task
 plumbing is needed (`NodeController` already holds `partition_map`). This replaces the earlier
 heartbeat-derived `registered_nodes()`, which grew locally and divergently when `receive_heartbeat` saw
-a previously-unknown sender — the disjoint-majority source. **Residual:** a membership *change* that
-shifts the majority between a reserve and its seal still needs joint-consensus / epoch-versioned
-reconfiguration to guarantee intersection — see "Open follow-ups → Dynamic reconfiguration".
+a previously-unknown sender — the disjoint-majority source. **Membership change (implemented):** a
+membership *change* that shifts the majority between a reserve and its seal is closed by the
+leader-authoritative unique-VOTER set that gates the majority/seal denominator, converged one node per
+interval so single-step changes preserve intersection — see "Open follow-ups → Dynamic reconfiguration"
+for the full mechanism and the narrow in-memory-voter fallback residual.
 
 ## 5. The hard part — abandonment vs record existence, and why B needs prevention
 

--- a/docs/distributed-design.md
+++ b/docs/distributed-design.md
@@ -1051,19 +1051,27 @@ All cluster messages follow this format (`crates/mqdb-cluster/src/cluster/mqtt_t
 | 92 | `FkReverseLookupRequest` | FK reverse lookup (delete) |
 | 93 | `FkReverseLookupResponse` | FK reverse lookup response |
 
-### 2.3 Heartbeat Message (75 bytes)
+### 2.3 Heartbeat Message (75 bytes + voter trailer, version 3)
 
-`crates/mqdb-cluster/src/cluster/protocol.rs` - BeBytes serialization:
+`crates/mqdb-cluster/src/cluster/protocol/heartbeat.rs` - hand-rolled BE serialization:
 
 ```rust
 struct Heartbeat {
-    version: u8,              // 1 byte, = 1
+    version: u8,              // 1 byte, = 3
     node_id: u16,             // 2 bytes, sender BE
     timestamp_ms: u64,        // 8 bytes, current time BE
     primary_bitmap: [u64; 4], // 32 bytes, bit N = primary for partition N (256 bits)
     replica_bitmap: [u64; 4], // 32 bytes, bit N = replica for partition N (256 bits)
+    // --- version 3 voter trailer (unique-constraint voter gossip) ---
+    voter_term: u64,          // 8 bytes, raft term the voter set was stamped at
+    voter_seq: u64,           // 8 bytes, per-term sequence; adopt strictly-newer (term, seq)
+    voter_count: u16,         // 2 bytes, number of voter node ids
+    voters: [u16; voter_count], // 2 bytes each, the leader-authoritative unique-voter set
 }
-// Total: 1 + 2 + 8 + 32 + 32 = 75 bytes
+// Fixed prefix (through the two bitmaps): 1 + 2 + 8 + 32 + 32 = 75 bytes (this is the v2 size and the
+// minimum a v3 reader accepts). A version-2 heartbeat stops here; a version-3 heartbeat appends the
+// 18-byte voter header + 2 bytes per voter. The frame is self-delimited, so a v2 reader ignores the
+// trailer and a v3 reader treats a v2 (75-byte) heartbeat as carrying no voter set.
 ```
 
 ### 2.4 ReplicationWrite Message (variable)
@@ -1218,11 +1226,15 @@ struct SnapshotComplete {
 
 ```rust
 struct Heartbeat {
-    version: u8,              // Protocol version
+    version: u8,              // Protocol version (currently 3)
     node_id: u16,             // Sender node ID
     timestamp_ms: u64,        // Sender timestamp
     primary_bitmap: [u64; 4], // 256 bits, bit N = this node is primary for partition N
     replica_bitmap: [u64; 4], // 256 bits, bit N = this node is replica for partition N
+    // version 3 trailer: leader-authoritative unique-voter gossip (see §2.3)
+    voter_term: u64,          // raft term the voter set was stamped at
+    voter_seq: u64,           // per-term sequence; receivers adopt a strictly-newer (term, seq)
+    voters: Vec<u16>,         // the unique-constraint voter set (length-prefixed u16 node ids)
 }
 ```
 


### PR DESCRIPTION
## Summary
- Follow-up to #103. A quorum review found the raft-gated voter fix did not pace voter REMOVAL: `unique_voter_group` filtered the stored voter set to the current partition-map membership, so a departed voter left the majority/seal denominator instantly instead of one node per interval.
- Under a correlated multi-node loss (e.g. a dual-AZ outage stripping a reservation's holder majority within one window), the denominator could shrink by more than one node at once and a seal could reach a majority that misses the holders and oversell (the V6 unpaced case). Single-node loss was already safe.
- Fix: keep a departed voter in the denominator until the leader paces it out. It cannot ack a reserve or seal, so it only raises the quorum bar — a correlated loss fails closed instead of overselling.
- Documents the remaining narrow residual (voters are in-memory; the empty-voter fallback window on a restarted promoting primary) and notes that the synchronous `NodeController::tick` path skips voter management.

## Verification
- New test `correlated_removal_does_not_collapse_voter_majority` fails on the pre-fix code (majority collapses 3 to 2) and passes after (denominator preserved, paced removal converges). Matches `specs/ClusterUniqueReconfigV6.tla` V6_paced.
- Cluster lib + integration tests green; clippy and fmt clean.
- 5-node dev cluster: paced voter promotion, and unique enforcement survives a correlated 2-node kill (distinct accepted, duplicate rejected, no oversell).
- Ships the CHANGELOG entry and version bumps (mqdb-cluster 0.4.3, mqdb-cli 0.8.18) and the wire-v3 doc updates that #103 omitted.

## Test plan
- [x] cluster lib + integration tests pass
- [x] clippy + fmt clean
- [x] before/after unit test for the removal collapse
- [x] 5-node cluster: enforcement survives correlated 2-node loss
