### PR TITLE
guard set_null foreign keys against nulling typed fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-07-25 — mqdb-cli 0.8.20, mqdb-core 0.7.6, mqdb-agent 0.8.13, mqdb-cluster 0.4.5, mqdb-wasm 0.3.5
+
+### Fixed
+
+- **`on_delete=set_null` foreign keys can no longer null a typed field and corrupt the surviving record.** A `SetNull` cascade writes `null` straight into the referencing field during a parent delete, skipping schema and constraint validation. On a typed field (e.g. a `String` `author_id`) that stores a value violating the field's own schema, which then makes the surviving record un-updatable — every later update re-validates the whole record and fails on the lingering `null`. Combined with a `NotNull` constraint on the same field, the delete silently violated the constraint. Because the schema type system has no nullable flag, `set_null` on any typed field is inherently unsafe. This is now closed on every path that writes the null:
+  - **Agent — definition time.** `add_foreign_key` rejects `on_delete=set_null` on a field with a concrete (non-null) schema type or an existing `NotNull` constraint, and `add_not_null` rejects a field that already carries a `set_null` foreign key.
+  - **Agent — delete time.** The ownership-aware cascade converts a cross-owned `Cascade` child into a `set_null` (to avoid deleting another user's record); that path is a legitimate `Cascade` foreign key, so the definition-time guard cannot see it. The delete now fails closed when any `set_null` operation it produces would write `null` into a typed field, mirroring the existing `NotNull` cascade guard.
+  - **Cluster — definition time and delete time.** The cluster constraint API rejects a `set_null` foreign key on a typed field (cluster mode has no `NotNull` constraint, so only the type guard applies), and the cascade side-effect preparation fails the delete closed when a `set_null` (direct or cross-owned) would target a typed field.
+  - **WASM.** `addForeignKey`/`addForeignKeyAsync` reject `set_null` on a schema-declared field or one with a `NotNull` constraint, and `addNotNull`/`addNotNullAsync` reject a field that already carries a `set_null` foreign key.
+
+  `set_null` remains allowed on null-typed and schema-less fields, where writing `null` is valid.
+
 ## 2026-07-22 — mqdb-cli 0.8.19, mqdb-cluster 0.4.4
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.8.12"
+version = "0.8.13"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.19"
+version = "0.8.20"
 dependencies = [
  "base64",
  "bebytes",
@@ -1482,7 +1482,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cluster"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "arc-swap",
  "bebytes",
@@ -1515,7 +1515,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "arc-swap",
  "bebytes",

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.8.12"
+version = "0.8.13"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-agent/src/database/crud.rs
+++ b/crates/mqdb-agent/src/database/crud.rs
@@ -360,11 +360,15 @@ impl Database {
             });
 
         let constraint_manager = self.constraint_manager.read().await;
-        let delete_ops = constraint_manager.validate_delete(
-            &existing_entity,
-            &self.storage,
-            ownership_ctx.as_ref(),
-        )?;
+        let delete_ops = {
+            let schema_registry = self.schema_registry.read().await;
+            constraint_manager.validate_delete(
+                &existing_entity,
+                &self.storage,
+                ownership_ctx.as_ref(),
+                &schema_registry,
+            )?
+        };
 
         let mut batch = self.storage.batch();
 

--- a/crates/mqdb-agent/src/database/schema_ops.rs
+++ b/crates/mqdb-agent/src/database/schema_ops.rs
@@ -166,11 +166,23 @@ impl Database {
     /// Returns an error if field validation or persisting the constraint fails.
     #[tracing::instrument(skip(self), fields(entity = %entity, field = %field))]
     pub async fn add_not_null(&self, entity: String, field: String) -> Result<()> {
-        use mqdb_core::constraint::{Constraint, NotNullConstraint};
+        use mqdb_core::constraint::{Constraint, NotNullConstraint, OnDeleteAction};
+        use mqdb_core::error::Error;
 
         let schema_registry = self.schema_registry.read().await;
         schema_registry.validate_fields_exist(&entity, &[field.as_str()], "not-null constraint")?;
         drop(schema_registry);
+
+        let constraint_manager = self.constraint_manager.read().await;
+        let conflicting_set_null_fk = constraint_manager.get_constraints(&entity).iter().any(
+            |c| matches!(c, Constraint::ForeignKey(fk) if fk.source_field == field && fk.on_delete == OnDeleteAction::SetNull),
+        );
+        drop(constraint_manager);
+        if conflicting_set_null_fk {
+            return Err(Error::ConstraintViolation(format!(
+                "cannot add not-null constraint on {entity}.{field}: a set-null foreign key exists on the field"
+            )));
+        }
 
         let constraint = Constraint::NotNull(NotNullConstraint::new(entity, field));
 
@@ -199,7 +211,9 @@ impl Database {
         target_field: String,
         on_delete: mqdb_core::constraint::OnDeleteAction,
     ) -> Result<()> {
-        use mqdb_core::constraint::{Constraint, ForeignKeyConstraint};
+        use mqdb_core::constraint::{Constraint, ForeignKeyConstraint, OnDeleteAction};
+        use mqdb_core::error::Error;
+        use mqdb_core::schema::FieldType;
 
         let schema_registry = self.schema_registry.read().await;
         schema_registry.validate_fields_exist(
@@ -212,7 +226,37 @@ impl Database {
             &[target_field.as_str()],
             "foreign key",
         )?;
+
+        if on_delete == OnDeleteAction::SetNull
+            && let Some(schema) = schema_registry.get_schema(&source_entity)
+            && let Some(field_def) = schema.fields.get(&source_field)
+            && field_def.field_type != FieldType::Null
+        {
+            let field_type = field_def.field_type.clone();
+            drop(schema_registry);
+            return Err(Error::SchemaViolation {
+                entity: source_entity.clone(),
+                field: source_field.clone(),
+                reason: format!(
+                    "on_delete=set_null requires a nullable (null-typed) field; '{source_field}' is typed {field_type:?}"
+                ),
+            });
+        }
         drop(schema_registry);
+
+        if on_delete == OnDeleteAction::SetNull {
+            let constraint_manager = self.constraint_manager.read().await;
+            let conflicting_not_null = constraint_manager
+                .get_constraints(&source_entity)
+                .iter()
+                .any(|c| matches!(c, Constraint::NotNull(nn) if nn.field == source_field));
+            drop(constraint_manager);
+            if conflicting_not_null {
+                return Err(Error::ConstraintViolation(format!(
+                    "cannot set on_delete=set_null on {source_entity}.{source_field}: a not-null constraint exists on the field"
+                )));
+            }
+        }
 
         let constraint = Constraint::ForeignKey(ForeignKeyConstraint::new(
             source_entity,

--- a/crates/mqdb-agent/tests/constraint_test.rs
+++ b/crates/mqdb-agent/tests/constraint_test.rs
@@ -1809,3 +1809,191 @@ async fn test_owner_aware_cascade_mixed_ownership_multilevel() {
         "alice's subtask should cascade from alice's task"
     );
 }
+
+#[tokio::test]
+async fn set_null_fk_rejected_on_typed_field() {
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open(tmp.path()).await.unwrap();
+
+    let posts_schema = Schema::new("posts")
+        .add_field(FieldDefinition::new("title", FieldType::String))
+        .add_field(FieldDefinition::new("author_id", FieldType::String));
+    db.add_schema(posts_schema).await.unwrap();
+
+    let result = db
+        .add_foreign_key(
+            "posts".into(),
+            "author_id".into(),
+            "users".into(),
+            "id".into(),
+            OnDeleteAction::SetNull,
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(Error::SchemaViolation { .. })),
+        "set_null on a String-typed field must be rejected at definition time; got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn set_null_fk_allowed_on_null_typed_field() {
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open(tmp.path()).await.unwrap();
+
+    let posts_schema = Schema::new("posts")
+        .add_field(FieldDefinition::new("title", FieldType::String))
+        .add_field(FieldDefinition::new("author_id", FieldType::Null));
+    db.add_schema(posts_schema).await.unwrap();
+
+    db.add_foreign_key(
+        "posts".into(),
+        "author_id".into(),
+        "users".into(),
+        "id".into(),
+        OnDeleteAction::SetNull,
+    )
+    .await
+    .expect("set_null is compatible with a null-typed field");
+}
+
+#[tokio::test]
+async fn set_null_fk_allowed_on_schemaless_entity() {
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open(tmp.path()).await.unwrap();
+
+    db.add_foreign_key(
+        "posts".into(),
+        "author_id".into(),
+        "users".into(),
+        "id".into(),
+        OnDeleteAction::SetNull,
+    )
+    .await
+    .expect("set_null is allowed when the source entity has no schema");
+}
+
+#[tokio::test]
+async fn set_null_fk_rejected_when_not_null_exists() {
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open(tmp.path()).await.unwrap();
+
+    db.add_not_null("posts".into(), "author_id".into())
+        .await
+        .unwrap();
+
+    let result = db
+        .add_foreign_key(
+            "posts".into(),
+            "author_id".into(),
+            "users".into(),
+            "id".into(),
+            OnDeleteAction::SetNull,
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(Error::ConstraintViolation(_))),
+        "set_null must be rejected when a not-null constraint exists on the field; got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn not_null_rejected_when_set_null_fk_exists() {
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open(tmp.path()).await.unwrap();
+
+    db.add_foreign_key(
+        "posts".into(),
+        "author_id".into(),
+        "users".into(),
+        "id".into(),
+        OnDeleteAction::SetNull,
+    )
+    .await
+    .unwrap();
+
+    let result = db.add_not_null("posts".into(), "author_id".into()).await;
+
+    assert!(
+        matches!(result, Err(Error::ConstraintViolation(_))),
+        "not-null must be rejected when a set-null foreign key exists on the field; got {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn cross_owned_cascade_setnull_blocked_on_typed_field() {
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open(tmp.path()).await.unwrap();
+
+    let ownership = OwnershipConfig::parse("projects=userId,tasks=userId").unwrap();
+
+    let tasks_schema = Schema::new("tasks")
+        .add_field(FieldDefinition::new("name", FieldType::String))
+        .add_field(FieldDefinition::new("userId", FieldType::String))
+        .add_field(FieldDefinition::new("projectId", FieldType::String));
+    db.add_schema(tasks_schema).await.unwrap();
+
+    let project = json!({"name": "P1", "userId": "alice"});
+    let created_project = db
+        .create(
+            "projects".into(),
+            project,
+            None,
+            None,
+            None,
+            &ScopeConfig::default(),
+        )
+        .await
+        .unwrap();
+    let project_id = created_project["id"].as_str().unwrap().to_string();
+
+    db.add_foreign_key(
+        "tasks".into(),
+        "projectId".into(),
+        "projects".into(),
+        "id".into(),
+        OnDeleteAction::Cascade,
+    )
+    .await
+    .unwrap();
+
+    let task = json!({"name": "T1", "userId": "bob", "projectId": project_id.clone()});
+    let created_task = db
+        .create(
+            "tasks".into(),
+            task,
+            None,
+            None,
+            None,
+            &ScopeConfig::default(),
+        )
+        .await
+        .unwrap();
+    let task_id = created_task["id"].as_str().unwrap().to_string();
+
+    let result = db
+        .delete(
+            "projects".into(),
+            project_id.clone(),
+            Some("alice"),
+            None,
+            &ScopeConfig::default(),
+            &ownership,
+        )
+        .await;
+    assert!(
+        matches!(result, Err(Error::SchemaViolation { .. })),
+        "cross-owned cascade must not null a typed field; delete must be blocked, got {result:?}"
+    );
+
+    let surviving = db
+        .read("tasks".into(), task_id, vec![], None)
+        .await
+        .unwrap();
+    assert_eq!(
+        surviving["projectId"],
+        json!(project_id),
+        "cross-owned task's FK field must be untouched after the blocked delete"
+    );
+}

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.19"
+version = "0.8.20"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/Cargo.toml
+++ b/crates/mqdb-cluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cluster"
-version = "0.4.4"
+version = "0.4.5"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"

--- a/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/db_handler/json_ops.rs
@@ -950,7 +950,10 @@ impl DbRequestHandler {
             Ok(results) => results,
             Err(msg) => return JsonOpResult::Response(Self::json_error(409, &msg)),
         };
-        let effects = controller.prepare_fk_side_effects(&all_results);
+        let effects = match controller.prepare_fk_side_effects(&all_results) {
+            Ok(effects) => effects,
+            Err(msg) => return JsonOpResult::Response(Self::json_error(409, &msg)),
+        };
         let (cascade, ack_receivers) = controller.execute_fk_side_effects(&effects, sender).await;
         let ctx = JsonOpContext {
             entity,
@@ -1484,7 +1487,16 @@ impl DbRequestHandler {
                 response_topic,
                 correlation_data,
             } => {
-                let effects = controller.prepare_fk_side_effects(&side_effects);
+                let effects = match controller.prepare_fk_side_effects(&side_effects) {
+                    Ok(effects) => effects,
+                    Err(msg) => {
+                        return Some(super::DbPublishResponse {
+                            topic: response_topic,
+                            payload: Self::json_error(409, &msg),
+                            correlation_data,
+                        });
+                    }
+                };
                 let (cascade, ack_receivers) = controller
                     .execute_fk_side_effects(&effects, sender.as_deref())
                     .await;

--- a/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/db_ops.rs
@@ -829,7 +829,10 @@ impl<T: ClusterTransport> NodeController<T> {
             Ok(results) => results,
             Err(msg) => return (Self::json_error(409, &msg), None),
         };
-        let effects = self.prepare_fk_side_effects(&all_results);
+        let effects = match self.prepare_fk_side_effects(&all_results) {
+            Ok(effects) => effects,
+            Err(msg) => return (Self::json_error(409, &msg), None),
+        };
         let (cascade, ack_receivers) = self
             .execute_fk_side_effects(&effects, request.sender.as_deref())
             .await;
@@ -886,7 +889,7 @@ impl<T: ClusterTransport> NodeController<T> {
     pub(crate) fn prepare_fk_side_effects(
         &self,
         results: &[super::fk::FkReverseLookupResult],
-    ) -> Vec<CascadeSideEffect> {
+    ) -> Result<Vec<CascadeSideEffect>, String> {
         use crate::cluster::db::{OnDeleteAction, data_partition};
         let mut effects = Vec::new();
         for r in results {
@@ -908,18 +911,42 @@ impl<T: ClusterTransport> NodeController<T> {
                             });
                         }
                     }
+                    if !r.cross_owned_ids.is_empty() {
+                        self.reject_typed_set_null(&r.source_entity, &r.source_field)?;
+                    }
                     for cross_id in &r.cross_owned_ids {
                         self.push_set_null_effect(&mut effects, r, cross_id);
                     }
                 }
                 OnDeleteAction::SetNull => {
+                    if !r.referencing_ids.is_empty() {
+                        self.reject_typed_set_null(&r.source_entity, &r.source_field)?;
+                    }
                     for child_id in &r.referencing_ids {
                         self.push_set_null_effect(&mut effects, r, child_id);
                     }
                 }
             }
         }
-        effects
+        Ok(effects)
+    }
+
+    fn reject_typed_set_null(&self, entity: &str, field: &str) -> Result<(), String> {
+        let Some(cluster_schema) = self.schema_get(entity) else {
+            return Ok(());
+        };
+        let Ok(schema) = serde_json::from_slice::<mqdb_core::schema::Schema>(&cluster_schema.data)
+        else {
+            return Ok(());
+        };
+        if let Some(field_def) = schema.fields.get(field)
+            && field_def.field_type != mqdb_core::schema::FieldType::Null
+        {
+            return Err(format!(
+                "on_delete=set_null would write null into typed field '{field}' of '{entity}'; delete blocked"
+            ));
+        }
+        Ok(())
     }
 
     fn push_set_null_effect(
@@ -1770,7 +1797,24 @@ impl<T: ClusterTransport> NodeController<T> {
             return;
         };
 
-        let effects = self.prepare_fk_side_effects(&side_effects);
+        let effects = match self.prepare_fk_side_effects(&side_effects) {
+            Ok(effects) => effects,
+            Err(msg) => {
+                if !response_topic.is_empty() {
+                    let response = JsonDbResponse::new(
+                        0,
+                        Self::json_error(409, &msg),
+                        response_topic,
+                        correlation_data,
+                    );
+                    let _ = self
+                        .transport
+                        .send(from, ClusterMessage::JsonDbResponse(response))
+                        .await;
+                }
+                return;
+            }
+        };
         let (cascade, ack_receivers) = self
             .execute_fk_side_effects(&effects, sender.as_deref())
             .await;

--- a/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
+++ b/crates/mqdb-cluster/src/cluster/node_controller/tests.rs
@@ -2090,7 +2090,7 @@ async fn cascade_set_nulls_cross_owned_ref_with_no_owned_siblings() {
         "a cross-owned-only cascade result must survive filtering"
     );
 
-    let effects = ctrl.prepare_fk_side_effects(&filtered);
+    let effects = ctrl.prepare_fk_side_effects(&filtered).unwrap();
     assert!(
         effects.iter().any(|e| matches!(
             e,
@@ -2104,6 +2104,43 @@ async fn cascade_set_nulls_cross_owned_ref_with_no_owned_siblings() {
             CascadeSideEffect::LocalDelete { id, .. } if id == "post-bob"
         )),
         "post-bob must never be deleted"
+    );
+}
+
+#[tokio::test]
+async fn cross_owned_set_null_blocked_on_typed_field() {
+    use super::fk::{FkReverseLookupResult, filter_and_extract_cascade};
+    use crate::cluster::db::OnDeleteAction;
+
+    let node1 = NodeId::validated(1).unwrap();
+    let transport = MockTransport::new(node1);
+    let mut ctrl = create_test_controller(node1, transport);
+    setup_owned_posts_referencing_user(&mut ctrl, node1).await;
+
+    let schema = mqdb_core::schema::Schema::new("posts").add_field(
+        mqdb_core::schema::FieldDefinition::new("author_id", mqdb_core::schema::FieldType::String),
+    );
+    ctrl.schema_register("posts", &serde_json::to_vec(&schema).unwrap())
+        .await
+        .unwrap();
+
+    let reply = FkReverseLookupResult {
+        constraint_name: "posts_author_fk".to_string(),
+        source_entity: "posts".to_string(),
+        source_field: "author_id".to_string(),
+        on_delete: OnDeleteAction::Cascade,
+        referencing_ids: Vec::new(),
+        cross_owned_ids: vec!["post-bob".to_string()],
+        target_id: "u1".to_string(),
+    };
+
+    let mut visited = std::collections::HashSet::new();
+    visited.insert(("users".to_string(), "u1".to_string()));
+    let (filtered, _queue) = filter_and_extract_cascade(vec![reply], &mut visited);
+
+    assert!(
+        ctrl.prepare_fk_side_effects(&filtered).is_err(),
+        "cross-owned set-null on a typed field must be blocked"
     );
 }
 
@@ -2175,7 +2212,7 @@ async fn local_cascade_set_nulls_cross_owned_grandchild() {
     let all = ctrl
         .collect_local_cascade("users", "u1", local_results, Some("alice"))
         .unwrap();
-    let effects = ctrl.prepare_fk_side_effects(&all);
+    let effects = ctrl.prepare_fk_side_effects(&all).unwrap();
     let has = |pred: &dyn Fn(&CascadeSideEffect) -> bool| effects.iter().any(pred);
 
     assert!(

--- a/crates/mqdb-cluster/src/cluster_agent/admin.rs
+++ b/crates/mqdb-cluster/src/cluster_agent/admin.rs
@@ -351,6 +351,20 @@ impl ClusteredAgent {
         )
     }
 
+    async fn set_null_schema_conflict(&self, entity: &str, field: &str) -> Option<String> {
+        let cluster_schema = self.controller.read().await.schema_get(entity)?;
+        let schema: mqdb_core::schema::Schema =
+            serde_json::from_slice(&cluster_schema.data).ok()?;
+        let field_def = schema.fields.get(field)?;
+        if field_def.field_type == mqdb_core::schema::FieldType::Null {
+            return None;
+        }
+        Some(format!(
+            "on_delete=set_null requires a nullable (null-typed) field; '{field}' is typed {:?}",
+            field_def.field_type
+        ))
+    }
+
     async fn handle_constraint_add(&self, entity: &str, payload: &[u8]) -> Response {
         let constraint_def: serde_json::Value = match serde_json::from_slice(payload) {
             Ok(v) => v,
@@ -429,6 +443,13 @@ impl ClusteredAgent {
                         format!("invalid on_delete value: {on_delete_str}"),
                     );
                 };
+
+                if on_delete == crate::cluster::db::OnDeleteAction::SetNull
+                    && let Some(msg) = self.set_null_schema_conflict(entity, field).await
+                {
+                    return Response::error(ErrorCode::BadRequest, msg);
+                }
+
                 let constraint = crate::cluster::db::ClusterConstraint::foreign_key(
                     entity,
                     name,

--- a/crates/mqdb-core/Cargo.toml
+++ b/crates/mqdb-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-core"
-version = "0.7.5"
+version = "0.7.6"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-core/src/constraint.rs
+++ b/crates/mqdb-core/src/constraint.rs
@@ -333,6 +333,7 @@ impl ConstraintManager {
         entity: &Entity,
         storage: &Storage,
         ownership_ctx: Option<&OwnershipContext<'_>>,
+        schema_registry: &crate::schema::SchemaRegistry,
     ) -> Result<Vec<DeleteOperation>> {
         use std::collections::HashSet;
         let mut all_operations = Vec::new();
@@ -354,7 +355,33 @@ impl ConstraintManager {
             ownership_ctx,
         )?;
 
+        for operation in &all_operations {
+            if let DeleteOperation::SetNull(op) = operation
+                && Self::set_null_violates_schema(schema_registry, &op.entity, &op.field)
+            {
+                return Err(Error::SchemaViolation {
+                    entity: op.entity.clone(),
+                    field: op.field.clone(),
+                    reason: format!(
+                        "on_delete=set_null would write null into typed field '{}'; delete blocked",
+                        op.field
+                    ),
+                });
+            }
+        }
+
         Ok(all_operations)
+    }
+
+    fn set_null_violates_schema(
+        schema_registry: &crate::schema::SchemaRegistry,
+        entity: &str,
+        field: &str,
+    ) -> bool {
+        schema_registry
+            .get_schema(entity)
+            .and_then(|schema| schema.fields.get(field))
+            .is_some_and(|field_def| field_def.field_type != crate::schema::FieldType::Null)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/mqdb-wasm/Cargo.lock
+++ b/crates/mqdb-wasm/Cargo.lock
@@ -342,7 +342,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-core"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "arc-swap",
  "bebytes",
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-wasm"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "console_error_panic_hook",
  "futures-channel",

--- a/crates/mqdb-wasm/Cargo.toml
+++ b/crates/mqdb-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-wasm"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 license = "Apache-2.0"
 authors = ["LabOverWire"]

--- a/crates/mqdb-wasm/src/constraints.rs
+++ b/crates/mqdb-wasm/src/constraints.rs
@@ -7,6 +7,32 @@ use super::{
 use crate::types::WasmBatch;
 use mqdb_core::keys::{WASM_INDEX_PREFIX, encode_constraint_key, encode_index_definition_key};
 
+fn reject_incompatible_set_null(
+    inner: &crate::types::DatabaseInner,
+    source_entity: &str,
+    source_field: &str,
+) -> Result<(), JsValue> {
+    if inner
+        .schemas
+        .get(source_entity)
+        .is_some_and(|schema| schema.fields.contains_key(source_field))
+    {
+        return Err(JsValue::from_str(&format!(
+            "on_delete=set_null requires a nullable field; '{source_field}' is declared in the '{source_entity}' schema"
+        )));
+    }
+    if inner
+        .not_null_constraints
+        .get(source_entity)
+        .is_some_and(|fields| fields.iter().any(|f| f == source_field))
+    {
+        return Err(JsValue::from_str(&format!(
+            "cannot set on_delete=set_null on {source_entity}.{source_field}: a not-null constraint exists on the field"
+        )));
+    }
+    Ok(())
+}
+
 #[wasm_bindgen(js_class = "Database")]
 impl WasmDatabase {
     /// Adds a unique constraint on the specified fields.
@@ -43,6 +69,15 @@ impl WasmDatabase {
     #[wasm_bindgen(js_name = "addNotNull")]
     pub fn add_not_null(&self, entity: String, field: String) -> Result<(), JsValue> {
         let mut inner = self.borrow_inner_mut()?;
+        if inner.foreign_keys.iter().any(|fk| {
+            fk.source_entity == entity
+                && fk.source_field == field
+                && fk.on_delete == OnDeleteAction::SetNull
+        }) {
+            return Err(JsValue::from_str(&format!(
+                "cannot add not-null constraint on {entity}.{field}: a set-null foreign key exists on the field"
+            )));
+        }
         inner
             .not_null_constraints
             .entry(entity)
@@ -71,6 +106,9 @@ impl WasmDatabase {
         };
 
         let mut inner = self.borrow_inner_mut()?;
+        if on_delete == OnDeleteAction::SetNull {
+            reject_incompatible_set_null(&inner, &source_entity, &source_field)?;
+        }
         inner.foreign_keys.push(ForeignKeyEntry {
             source_entity,
             source_field,
@@ -125,6 +163,15 @@ impl WasmDatabase {
     pub async fn add_not_null_async(&self, entity: String, field: String) -> Result<(), JsValue> {
         {
             let mut inner = self.borrow_inner_mut()?;
+            if inner.foreign_keys.iter().any(|fk| {
+                fk.source_entity == entity
+                    && fk.source_field == field
+                    && fk.on_delete == OnDeleteAction::SetNull
+            }) {
+                return Err(JsValue::from_str(&format!(
+                    "cannot add not-null constraint on {entity}.{field}: a set-null foreign key exists on the field"
+                )));
+            }
             inner
                 .not_null_constraints
                 .entry(entity.clone())
@@ -163,6 +210,9 @@ impl WasmDatabase {
 
         {
             let mut inner = self.borrow_inner_mut()?;
+            if on_delete_action == OnDeleteAction::SetNull {
+                reject_incompatible_set_null(&inner, &source_entity, &source_field)?;
+            }
             inner.foreign_keys.push(ForeignKeyEntry {
                 source_entity: source_entity.clone(),
                 source_field: source_field.clone(),
@@ -488,9 +538,9 @@ impl WasmDatabase {
         entity: &str,
         id: &str,
     ) -> Result<Vec<(String, String)>, JsValue> {
-        let fks: Vec<ForeignKeyEntry> = {
+        let (fks, schemas) = {
             let inner = self.borrow_inner()?;
-            inner.foreign_keys.clone()
+            (inner.foreign_keys.clone(), inner.schemas.clone())
         };
 
         let mut cascade_deletes = Vec::new();
@@ -522,6 +572,15 @@ impl WasmDatabase {
                             }
                         }
                         OnDeleteAction::SetNull => {
+                            if schemas
+                                .get(&fk.source_entity)
+                                .is_some_and(|s| s.fields.contains_key(&fk.source_field))
+                            {
+                                return Err(JsValue::from_str(&format!(
+                                    "on_delete=set_null would write null into typed field '{}' of '{}'; delete blocked",
+                                    fk.source_field, fk.source_entity
+                                )));
+                            }
                             if let Some(source_id) = value.get("id").and_then(|v| v.as_str()) {
                                 let data_key = format!("data/{}/{}", fk.source_entity, source_id);
                                 let existing_raw = self
@@ -658,9 +717,9 @@ impl WasmDatabase {
         entity: &str,
         id: &str,
     ) -> Result<Vec<(String, String)>, JsValue> {
-        let fks: Vec<ForeignKeyEntry> = {
+        let (fks, schemas) = {
             let inner = self.borrow_inner()?;
-            inner.foreign_keys.clone()
+            (inner.foreign_keys.clone(), inner.schemas.clone())
         };
 
         let mut cascade_deletes = Vec::new();
@@ -692,6 +751,15 @@ impl WasmDatabase {
                             }
                         }
                         OnDeleteAction::SetNull => {
+                            if schemas
+                                .get(&fk.source_entity)
+                                .is_some_and(|s| s.fields.contains_key(&fk.source_field))
+                            {
+                                return Err(JsValue::from_str(&format!(
+                                    "on_delete=set_null would write null into typed field '{}' of '{}'; delete blocked",
+                                    fk.source_field, fk.source_entity
+                                )));
+                            }
                             if let Some(source_id) = value.get("id").and_then(|v| v.as_str()) {
                                 let data_key = format!("data/{}/{}", fk.source_entity, source_id);
                                 let existing_raw =

--- a/crates/mqdb-wasm/src/tests.rs
+++ b/crates/mqdb-wasm/src/tests.rs
@@ -611,3 +611,101 @@ fn test_get_schema_preserves_default_values() {
     let status = fields.iter().find(|f| f["name"] == "status").unwrap();
     assert_eq!(status["default"], "pending");
 }
+
+#[wasm_bindgen_test]
+fn test_set_null_rejected_on_typed_field() {
+    let db = WasmDatabase::new();
+    let schema_js = json_to_js(&serde_json::json!({
+        "fields": [
+            {"name": "title", "type": "string"},
+            {"name": "author_id", "type": "string"}
+        ]
+    }));
+    db.add_schema("posts".into(), schema_js).unwrap();
+
+    let result = db.add_foreign_key(
+        "posts".into(),
+        "author_id".into(),
+        "users".into(),
+        "id".into(),
+        "set_null",
+    );
+    assert!(
+        result.is_err(),
+        "set_null on a schema-declared field must be rejected"
+    );
+}
+
+#[wasm_bindgen_test]
+fn test_set_null_rejected_when_not_null_exists() {
+    let db = WasmDatabase::new();
+    db.add_not_null("posts".into(), "author_id".into()).unwrap();
+
+    let result = db.add_foreign_key(
+        "posts".into(),
+        "author_id".into(),
+        "users".into(),
+        "id".into(),
+        "set_null",
+    );
+    assert!(
+        result.is_err(),
+        "set_null must be rejected when a not-null constraint exists on the field"
+    );
+}
+
+#[wasm_bindgen_test]
+fn test_not_null_rejected_when_set_null_fk_exists() {
+    let db = WasmDatabase::new();
+    db.add_foreign_key(
+        "posts".into(),
+        "author_id".into(),
+        "users".into(),
+        "id".into(),
+        "set_null",
+    )
+    .unwrap();
+
+    let result = db.add_not_null("posts".into(), "author_id".into());
+    assert!(
+        result.is_err(),
+        "not-null must be rejected when a set-null foreign key exists on the field"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn test_set_null_delete_blocked_when_field_typed_after_fk() {
+    let db = WasmDatabase::new();
+    db.add_foreign_key(
+        "posts".into(),
+        "author_id".into(),
+        "users".into(),
+        "id".into(),
+        "set_null",
+    )
+    .unwrap();
+    let schema_js = json_to_js(&serde_json::json!({
+        "fields": [{"name": "author_id", "type": "string"}]
+    }));
+    db.add_schema("posts".into(), schema_js).unwrap();
+
+    let user =
+        serde_wasm_bindgen::to_value(&serde_json::json!({"id": "u1", "name": "Alice"})).unwrap();
+    db.create("users".into(), user).await.unwrap();
+    let post =
+        serde_wasm_bindgen::to_value(&serde_json::json!({"id": "p1", "author_id": "u1"})).unwrap();
+    db.create("posts".into(), post).await.unwrap();
+
+    let result = db.delete("users".into(), "u1".into()).await;
+    assert!(
+        result.is_err(),
+        "delete-time guard must block set_null into a typed field even when the FK predates the schema"
+    );
+
+    let stored = db.read("posts".into(), "p1".into()).await.unwrap();
+    let val: serde_json::Value = serde_wasm_bindgen::from_value(stored).unwrap();
+    assert_eq!(
+        val["author_id"], "u1",
+        "field must not be nulled by a blocked delete"
+    );
+}


### PR DESCRIPTION
## Summary

- reject `on_delete=set_null` foreign keys that would write null into a schema-typed field, closing #94 across agent, cluster, and wasm
- guards at definition time (the constraint API rejects the incompatible definition) and at delete time (the cascade fails closed before writing)
- covers the ownership-aware cross-owned cascade, which converts a legitimate `Cascade` into a `set_null` and so cannot be caught at definition time
- `set_null` still works on null-typed and schema-less fields, where writing null is valid
- one transient cluster residual (schema-sync-skew on a joining node) is deferred to #107; steady-state clusters are closed

## Test plan

- [ ] agent constraint tests: typed reject, null-typed/schemaless allow, both not-null orderings, cross-owned block
- [ ] cluster runtime guard test: cross-owned set_null on a typed field blocked
- [ ] wasm guard tests: definition-time plus the FK-before-schema delete-time case
- [ ] cargo make clippy and native tests green (pre-existing flaky CLI connect-timeout test excepted)