### PR TITLE
protect per-user event namespace and notify grantees on share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-07-26 — mqdb-cli 0.8.21, mqdb-agent 0.8.14
+
+### Fixed
+
+- **Per-user event namespace `$DB/u/#` is now publish-protected unconditionally.** The per-user publish/subscribe guards were gated on `--scoped-events`; with the flag off, no rule matched `$DB/u/...` and any authenticated user could publish to (or subscribe to) another user's `$DB/u/{anyone}/events/#`. A static `$DB/u/#` read-only rule now blocks all publishes to the namespace regardless of the flag (the internal service still publishes there); the cross-user subscribe restriction remains flag-gated, since scoped events are the only feature that uses the namespace.
+- **Grantees are notified when a resource is shared or unshared (scoped events).** Under `--scoped-events`, sharing a diagram with a user emitted no event the grantee could see — the `_shares` change event is a Global entity and broadcast to the admin-only `$DB/_shares/events/...` topic. Share grant/revoke events are now scoped to the affected grantee's `$DB/u/{grantee}/events/_shares/{id}` namespace (a `_shares` event's recipient is its grantee), so a client learns of gained or lost access without polling. With scoped events off, `_shares` events stay admin-only as before.
+
 ## 2026-07-25 — mqdb-cli 0.8.20, mqdb-core 0.7.6, mqdb-agent 0.8.13, mqdb-cluster 0.4.5, mqdb-wasm 0.3.5
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.8.13"
+version = "0.8.14"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.20"
+version = "0.8.21"
 dependencies = [
  "base64",
  "bebytes",

--- a/README.md
+++ b/README.md
@@ -477,10 +477,12 @@ MQDB enforces hardcoded protection on internal topics that cannot be overridden 
 | Tier | Topics | Behavior |
 |------|--------|----------|
 | BlockAll | `_mqdb/#`, `$DB/_idx/#`, `$DB/_unique/#`, `$DB/_fk/#`, `$DB/_query/#`, `$DB/p+/#` | All access denied |
-| ReadOnly | `$SYS/#` | Subscribe allowed, publish denied |
+| ReadOnly | `$SYS/#`, `$DB/+/events/#`, `$DB/u/#` | Subscribe allowed, publish denied |
 | AdminRequired | `$DB/_admin/#`, `$DB/_verify/#`, `$DB/_oauth_tokens/#`, `$DB/_identities/#`, `$DB/_identity_links/#` | Requires admin user or explicit ACL grant |
 
 Entities starting with `_` (e.g., `_sessions`, `_mqtt_subs`) require admin access. Exceptions: `$DB/_health`, `$DB/_vault/*`, and `$DB/_auth/*` are accessible to any authenticated user. For `AdminRequired` topics, non-admin users with an explicit ACL grant for the specific topic are also allowed access. This enables operator-provisioned service accounts (e.g., an email verifier with ACL grants for `$DB/_verify/#`) without requiring full admin privileges.
+
+`$DB/u/#` is the reserved per-user scoped-events namespace (`--scoped-events`). Publishing is service-only — blocked for all external users regardless of the flag — so only the internal event publisher writes there. Subscribing is allowed by the ReadOnly tier, and when scoped events are enabled a user may only subscribe to their own `$DB/u/{me}/events/#`. Because the top-level `u` segment is reserved, `u` cannot be used as a regular entity name.
 
 #### Admin User Configuration
 

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.8.13"
+version = "0.8.14"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-agent/src/database/sharing.rs
+++ b/crates/mqdb-agent/src/database/sharing.rs
@@ -369,6 +369,16 @@ impl Database {
         id: &str,
         data: Option<&Value>,
     ) -> Result<Option<Vec<String>>> {
+        if entity == SHARES_ENTITY {
+            let grantee = data
+                .and_then(|d| d.get("grantee"))
+                .and_then(Value::as_str)
+                .filter(|g| !g.is_empty());
+            return Ok(Some(
+                grantee.map(|g| vec![g.to_string()]).unwrap_or_default(),
+            ));
+        }
+
         let (res_entity, res_id, owner) = if let Some(owner_field) = ownership.owner_field(entity) {
             let owner = data
                 .and_then(|d| d.get(owner_field))

--- a/crates/mqdb-agent/src/topic_protection.rs
+++ b/crates/mqdb-agent/src/topic_protection.rs
@@ -605,4 +605,29 @@ mod tests {
                 .await
         );
     }
+
+    #[tokio::test]
+    async fn user_namespace_publish_blocked_even_with_scoped_events_off() {
+        let provider = create_test_provider(HashSet::new());
+        assert!(
+            !provider
+                .authorize_publish("c", Some("alice"), "$DB/u/bob/events/diagrams/1")
+                .await
+        );
+        assert!(
+            !provider
+                .authorize_publish("c", Some("alice"), "$DB/u/alice/events/diagrams/1")
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_service_publishes_user_namespace_with_scoped_events_off() {
+        let provider = create_test_provider_with_internal("mqdb-internal");
+        assert!(
+            provider
+                .authorize_publish("c", Some("mqdb-internal"), "$DB/u/alice/events/diagrams/1")
+                .await
+        );
+    }
 }

--- a/crates/mqdb-agent/src/topic_rules.rs
+++ b/crates/mqdb-agent/src/topic_rules.rs
@@ -46,6 +46,10 @@ pub const PROTECTED_TOPICS: &[TopicRule] = &[
         tier: ProtectionTier::ReadOnly,
     },
     TopicRule {
+        pattern: "$DB/u/#",
+        tier: ProtectionTier::ReadOnly,
+    },
+    TopicRule {
         pattern: "$SYS/mqdb/cluster/#",
         tier: ProtectionTier::AdminRequired,
     },
@@ -371,6 +375,26 @@ mod tests {
         assert_eq!(
             check_topic_access("$DB/users/events/created", true, true),
             Err(BlockReason::ReadOnlyTopic)
+        );
+    }
+
+    #[test]
+    fn check_access_user_namespace_read_only() {
+        assert_eq!(
+            check_topic_access("$DB/u/bob/events/created", true, false),
+            Err(BlockReason::ReadOnlyTopic)
+        );
+        assert_eq!(
+            check_topic_access("$DB/u/bob/events/diagrams/1", true, false),
+            Err(BlockReason::ReadOnlyTopic)
+        );
+        assert_eq!(
+            check_topic_access("$DB/u/bob/events/created", true, true),
+            Err(BlockReason::ReadOnlyTopic)
+        );
+        assert_eq!(
+            check_topic_access("$DB/u/bob/events/created", false, false),
+            Ok(())
         );
     }
 

--- a/crates/mqdb-agent/tests/integration_test.rs
+++ b/crates/mqdb-agent/tests/integration_test.rs
@@ -2724,6 +2724,51 @@ async fn test_event_recipients_owner_grantees_and_global() {
 }
 
 #[tokio::test]
+async fn test_share_events_route_to_grantee_namespace() {
+    let tmp = TempDir::new().unwrap();
+    let db = Database::open_without_background_tasks(tmp.path())
+        .await
+        .unwrap();
+    let ownership = OwnershipConfig::parse("diagrams=userId").unwrap();
+
+    let recipients = db
+        .event_recipients(
+            &ownership,
+            mqdb_core::types::SHARES_ENTITY,
+            "share-1",
+            Some(&json!({
+                "resource_entity": "diagrams",
+                "resource_id": "d1",
+                "grantee": "bob",
+                "permission": "view",
+            })),
+        )
+        .await
+        .unwrap()
+        .expect("a share grant/revoke is scoped to its grantee");
+    assert_eq!(
+        recipients,
+        vec!["bob".to_string()],
+        "share event must reach only the grantee's per-user namespace"
+    );
+
+    let pending = db
+        .event_recipients(
+            &ownership,
+            mqdb_core::types::SHARES_ENTITY,
+            "share-2",
+            Some(&json!({"resource_entity": "diagrams", "resource_id": "d1", "grantee": ""})),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        pending,
+        Some(vec![]),
+        "a share with no resolved grantee has no recipients and is not broadcast"
+    );
+}
+
+#[tokio::test]
 async fn test_cascade_delete_events_carry_recipients() {
     use mqdb_core::{OnDeleteAction, Request, Response};
     use std::collections::HashMap;

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.20"
+version = "0.8.21"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"


### PR DESCRIPTION
## Summary

- add a `$DB/u/#` read-only rule so publishes to the per-user event namespace are blocked unconditionally, not only when `--scoped-events` is on (closes #84); the internal service still publishes there, and the cross-user subscribe restriction stays flag-gated
- route share grant/revoke events to the affected grantee under `--scoped-events` by treating a `_shares` event's recipient as its grantee, so a client learns of gained/lost access without polling (closes #85); with scoped events off, `_shares` events stay admin-only as before
- both changes are agent-mode only (topic protection and sharing are agent-only; cluster sharing parity is tracked in #75)

## Test plan

- [ ] topic-rules unit test: `$DB/u/#` publish blocked, subscribe allowed
- [ ] topic-protection tests: user-namespace publish blocked with scoped events off; internal service still publishes
- [ ] integration test: `event_recipients` returns the grantee for a `_shares` event, and empty (not broadcast) for an unresolved grantee
- [ ] full agent suite + clippy green