### PR TITLE
allow non-admin publish to the subscribe request channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 Each entry lists the date and the crate versions that were released.
 
+## 2026-07-31 — mqdb-cli 0.8.24, mqdb-agent 0.8.17
+
+### Fixed
+
+- **`mqdb subscribe` works for non-admin users.** `$DB/_sub/subscribe` (and the `$DB/_sub/{id}/heartbeat` / `unsubscribe` control topics the `mqdb subscribe` command publishes) were treated as internal `$DB/_*` topics, so any non-admin publish was rejected with `internal entity access denied`. The `$DB/_sub/#` channel is now a new **WriteOnly** protection tier: any authenticated user may **publish** subscribe requests (subject to ACL, like a normal topic), but **subscribing** to `$DB/_sub/#` is denied for non-service clients so one user cannot snoop another's requests or response topics. The server (internal service) bypasses topic protection and still consumes the requests.
+
 ## 2026-07-30 — mqdb-cli 0.8.23, mqdb-agent 0.8.16, mqdb-cluster 0.4.7
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-agent"
-version = "0.8.16"
+version = "0.8.17"
 dependencies = [
  "arc-swap",
  "argon2",
@@ -1455,7 +1455,7 @@ dependencies = [
 
 [[package]]
 name = "mqdb-cli"
-version = "0.8.23"
+version = "0.8.24"
 dependencies = [
  "base64",
  "bebytes",

--- a/README.md
+++ b/README.md
@@ -478,9 +478,10 @@ MQDB enforces hardcoded protection on internal topics that cannot be overridden 
 |------|--------|----------|
 | BlockAll | `_mqdb/#`, `$DB/_idx/#`, `$DB/_unique/#`, `$DB/_fk/#`, `$DB/_query/#`, `$DB/p+/#` | All access denied |
 | ReadOnly | `$SYS/#`, `$DB/+/events/#`, `$DB/u/#` | Subscribe allowed, publish denied |
+| WriteOnly | `$DB/_sub/#` | Publish allowed, subscribe denied |
 | AdminRequired | `$DB/_admin/#`, `$DB/_verify/#`, `$DB/_oauth_tokens/#`, `$DB/_identities/#`, `$DB/_identity_links/#` | Requires admin user or explicit ACL grant |
 
-Entities starting with `_` (e.g., `_sessions`, `_mqtt_subs`) require admin access. Exceptions: `$DB/_health`, `$DB/_vault/*`, and `$DB/_auth/*` are accessible to any authenticated user. For `AdminRequired` topics, non-admin users with an explicit ACL grant for the specific topic are also allowed access. This enables operator-provisioned service accounts (e.g., an email verifier with ACL grants for `$DB/_verify/#`) without requiring full admin privileges.
+Entities starting with `_` (e.g., `_sessions`, `_mqtt_subs`) require admin access. Exceptions: `$DB/_health`, `$DB/_vault/*`, and `$DB/_auth/*` are accessible to any authenticated user, and `$DB/_sub/*` is a user-callable request channel (the `mqdb subscribe` command) — any authenticated user may publish subscribe/heartbeat/unsubscribe requests, but only the server consumes them, so subscribing to `$DB/_sub/*` is denied to prevent request snooping. For `AdminRequired` topics, non-admin users with an explicit ACL grant for the specific topic are also allowed access. This enables operator-provisioned service accounts (e.g., an email verifier with ACL grants for `$DB/_verify/#`) without requiring full admin privileges.
 
 `$DB/u/#` is the reserved per-user scoped-events namespace (`--scoped-events`). Publishing is service-only — blocked for all external users regardless of the flag — so only the internal event publisher writes there. Subscribing is allowed by the ReadOnly tier, and when scoped events are enabled a user may only subscribe to their own `$DB/u/{me}/events/#`. Because the top-level `u` segment is reserved, `u` cannot be used as a regular entity name.
 

--- a/crates/mqdb-agent/Cargo.toml
+++ b/crates/mqdb-agent/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-agent"
-version = "0.8.16"
+version = "0.8.17"
 edition.workspace = true
 license = "Apache-2.0"
 authors.workspace = true

--- a/crates/mqdb-agent/src/topic_protection.rs
+++ b/crates/mqdb-agent/src/topic_protection.rs
@@ -630,4 +630,44 @@ mod tests {
                 .await
         );
     }
+
+    #[tokio::test]
+    async fn non_admin_can_publish_sub_channel() {
+        let provider = create_test_provider(HashSet::new());
+        assert!(
+            provider
+                .authorize_publish("c", Some("alice"), "$DB/_sub/subscribe")
+                .await
+        );
+        assert!(
+            provider
+                .authorize_publish("c", Some("alice"), "$DB/_sub/abc123/heartbeat")
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn non_admin_cannot_subscribe_sub_channel() {
+        let provider = create_test_provider(HashSet::new());
+        assert!(
+            !provider
+                .authorize_subscribe("c", Some("alice"), "$DB/_sub/subscribe")
+                .await
+        );
+        assert!(
+            !provider
+                .authorize_subscribe("c", Some("alice"), "$DB/_sub/#")
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_service_can_consume_sub_channel() {
+        let provider = create_test_provider_with_internal("mqdb-internal");
+        assert!(
+            provider
+                .authorize_subscribe("c", Some("mqdb-internal"), "$DB/_sub/subscribe")
+                .await
+        );
+    }
 }

--- a/crates/mqdb-agent/src/topic_rules.rs
+++ b/crates/mqdb-agent/src/topic_rules.rs
@@ -7,6 +7,7 @@ use std::fmt;
 pub enum ProtectionTier {
     BlockAll,
     ReadOnly,
+    WriteOnly,
     AdminRequired,
 }
 
@@ -50,6 +51,10 @@ pub const PROTECTED_TOPICS: &[TopicRule] = &[
         tier: ProtectionTier::ReadOnly,
     },
     TopicRule {
+        pattern: "$DB/_sub/#",
+        tier: ProtectionTier::WriteOnly,
+    },
+    TopicRule {
         pattern: "$SYS/mqdb/cluster/#",
         tier: ProtectionTier::AdminRequired,
     },
@@ -67,6 +72,7 @@ pub const PROTECTED_TOPICS: &[TopicRule] = &[
 pub enum BlockReason {
     InternalTopicBlocked,
     ReadOnlyTopic,
+    WriteOnlyTopic,
     AdminRequired,
     InternalEntityAccess,
 }
@@ -76,6 +82,7 @@ impl fmt::Display for BlockReason {
         match self {
             Self::InternalTopicBlocked => write!(f, "internal topic blocked"),
             Self::ReadOnlyTopic => write!(f, "read-only topic"),
+            Self::WriteOnlyTopic => write!(f, "write-only topic"),
             Self::AdminRequired => write!(f, "admin role required"),
             Self::InternalEntityAccess => write!(f, "internal entity access denied"),
         }
@@ -171,6 +178,13 @@ pub fn check_topic_access(
                     Err(BlockReason::ReadOnlyTopic)
                 } else {
                     Ok(())
+                }
+            }
+            ProtectionTier::WriteOnly => {
+                if is_publish {
+                    Ok(())
+                } else {
+                    Err(BlockReason::WriteOnlyTopic)
                 }
             }
             ProtectionTier::AdminRequired => {
@@ -395,6 +409,30 @@ mod tests {
         assert_eq!(
             check_topic_access("$DB/u/bob/events/created", false, false),
             Ok(())
+        );
+    }
+
+    #[test]
+    fn check_access_sub_channel_write_only() {
+        assert_eq!(
+            check_topic_access("$DB/_sub/subscribe", true, false),
+            Ok(())
+        );
+        assert_eq!(
+            check_topic_access("$DB/_sub/abc123/heartbeat", true, false),
+            Ok(())
+        );
+        assert_eq!(
+            check_topic_access("$DB/_sub/abc123/unsubscribe", true, false),
+            Ok(())
+        );
+        assert_eq!(
+            check_topic_access("$DB/_sub/subscribe", false, false),
+            Err(BlockReason::WriteOnlyTopic)
+        );
+        assert_eq!(
+            check_topic_access("$DB/_sub/subscribe", false, true),
+            Err(BlockReason::WriteOnlyTopic)
         );
     }
 

--- a/crates/mqdb-cli/Cargo.toml
+++ b/crates/mqdb-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mqdb-cli"
-version = "0.8.23"
+version = "0.8.24"
 publish = false
 edition.workspace = true
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Closes #40.

## Summary

- `mqdb subscribe` was blocked for non-admin users: `$DB/_sub/subscribe` (and the `$DB/_sub/{id}/heartbeat`/`unsubscribe` control topics it publishes) were treated as internal `$DB/_*` topics and rejected with `internal entity access denied`
- adds a `WriteOnly` protection tier (the counterpart to `ReadOnly`) and gates `$DB/_sub/#` with it: any authenticated user may **publish** subscribe requests (still subject to ACL, like a normal topic), but **subscribing** to `$DB/_sub/#` is denied for non-service clients so one user cannot snoop another's requests or response topics
- chosen over the issue's suggested "add `_sub` to the internal-entity allowlist" because that would also allow non-admin *subscribe* to the request channel (request snooping / response spoofing); the CLI only ever publishes there
- the server (internal service) bypasses topic protection and still consumes the requests; `handle_subscribe` has no separate admin gate

## Test plan

- [x] `check_access_sub_channel_write_only` — publish allowed, subscribe denied (incl. admin) for `$DB/_sub/*`
- [x] provider tests: non-admin publishes to `$DB/_sub/subscribe`/heartbeat, non-admin cannot subscribe to `$DB/_sub/#`, internal service can consume
- [x] E2E: a non-admin user ran `mqdb subscribe`, got a subscription (no denial), and received a change event on a create
- [x] clippy clean, agent lib suite green